### PR TITLE
[DRAFT] consider file search path

### DIFF
--- a/src/common/opener_file_system.cpp
+++ b/src/common/opener_file_system.cpp
@@ -10,28 +10,29 @@ void OpenerFileSystem::VerifyNoOpener(optional_ptr<FileOpener> opener) {
 		throw InternalException("OpenerFileSystem cannot take an opener - the opener is pushed automatically");
 	}
 }
-void OpenerFileSystem::VerifyCanAccessFileInternal(const string &path, FileType type) {
+string OpenerFileSystem::VerifyAndFindAllowedInternal(const string &path, FileType type) {
 	auto opener = GetOpener();
 	if (!opener) {
-		return;
+		return path;
 	}
 	auto db = opener->TryGetDatabase();
 	if (!db) {
-		return;
+		return path;
 	}
 	auto &config = db->config;
-	if (!config.CanAccessFile(path, type, opener)) {
+	auto allowed_path = config.FindAllowedPath(path, type, opener);
+	 {
 		throw PermissionException("Cannot access %s \"%s\" - file system operations are disabled by configuration",
 		                          type == FileType::FILE_TYPE_DIR ? "directory" : "file", path);
 	}
 }
 
-void OpenerFileSystem::VerifyCanAccessFile(const string &path) {
-	VerifyCanAccessFileInternal(path, FileType::FILE_TYPE_REGULAR);
+string OpenerFileSystem::VerifyAndFindAllowedFile(const string &path) {
+	return VerifyAndFindAllowedInternal(path, FileType::FILE_TYPE_REGULAR);
 }
 
-void OpenerFileSystem::VerifyCanAccessDirectory(const string &path) {
-	VerifyCanAccessFileInternal(path, FileType::FILE_TYPE_DIR);
+string OpenerFileSystem::VerifyAndFindAllowedDirectory(const string &path) {
+	return VerifyAndFindAllowedInternal(path, FileType::FILE_TYPE_DIR);
 }
 
 } // namespace duckdb

--- a/src/common/opener_file_system.cpp
+++ b/src/common/opener_file_system.cpp
@@ -20,7 +20,7 @@ void OpenerFileSystem::VerifyCanAccessFileInternal(const string &path, FileType 
 		return;
 	}
 	auto &config = db->config;
-	if (!config.CanAccessFile(path, type)) {
+	if (!config.CanAccessFile(path, type, opener)) {
 		throw PermissionException("Cannot access %s \"%s\" - file system operations are disabled by configuration",
 		                          type == FileType::FILE_TYPE_DIR ? "directory" : "file", path);
 	}

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -301,7 +301,9 @@ public:
 	//! Returns the default value of an option
 	static SettingLookupResult TryGetDefaultValue(optional_ptr<const ConfigurationOption> option, Value &result);
 
-	bool CanAccessFile(const string &path, FileType type, optional_ptr<FileOpener> opener = nullptr);
+	//! Return the first allowed for the given [path].
+	//! If there's no allowed path, throw PermissionException.
+	string VerifyAndFindAllowedPath(const string &path, FileType type, optional_ptr<FileOpener> opener);
 	void AddAllowedDirectory(const string &path);
 	void AddAllowedPath(const string &path);
 	string SanitizeAllowedPath(const string &path) const;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -301,7 +301,7 @@ public:
 	//! Returns the default value of an option
 	static SettingLookupResult TryGetDefaultValue(optional_ptr<const ConfigurationOption> option, Value &result);
 
-	bool CanAccessFile(const string &path, FileType type);
+	bool CanAccessFile(const string &path, FileType type, optional_ptr<FileOpener> opener = nullptr);
 	void AddAllowedDirectory(const string &path);
 	void AddAllowedPath(const string &path);
 	string SanitizeAllowedPath(const string &path) const;
@@ -309,6 +309,10 @@ public:
 	const ExtensionCallbackManager &GetCallbackManager() const;
 
 private:
+	// Get all possible sanitized path for the given [input_path], in the order of current directory and file search paths.
+	// If [opener] provided, it's used to extract the local-scoped file search path.
+	vector<string> GetPossibleSanitizedPaths(const string &input_path, optional_ptr<FileOpener> opener = nullptr);
+
 	mutable mutex config_lock;
 	unique_ptr<CompressionFunctionSet> compression_functions;
 	unique_ptr<EncodingFunctionSet> encoding_functions;

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/main/config.hpp"
 
 #include "duckdb/common/cgroups.hpp"
+#include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/operator/multiply.hpp"
@@ -812,43 +813,61 @@ void DBConfig::AddAllowedPath(const string &path) {
 	options.allowed_paths.insert(allowed_path);
 }
 
-bool DBConfig::CanAccessFile(const string &input_path, FileType type) {
+vector<string> DBConfig::GetPossibleSanitizedPaths(const string &input_path, optional_ptr<FileOpener> opener) {
+	vector<string> result;
+	if (file_system->IsPathAbsolute(input_path)) {
+		result.push_back(SanitizeAllowedPath(input_path));
+		return result;
+	}
+
+	// First check current directory.
+	auto cwd_joined = file_system->JoinPath(FileSystem::GetWorkingDirectory(), input_path);
+	result.push_back(SanitizeAllowedPath(cwd_joined));
+
+	// Also check file search path if opener provided and set.
+	Value value;
+	const bool found = opener ? FileOpener::TryGetCurrentSetting(opener, "file_search_path", value)
+	                     : TryGetCurrentSetting("file_search_path", value);
+	if (found && !value.ToString().empty()) {
+		auto search_paths_str = value.ToString();
+		auto search_paths = StringUtil::Split(search_paths_str, ',');
+		for (const auto &search_path : search_paths) {
+			const auto joined_path = file_system->JoinPath(search_path, input_path);
+			result.push_back(SanitizeAllowedPath(joined_path));
+		}
+	}
+	return result;
+}
+
+bool DBConfig::CanAccessFile(const string &input_path, FileType type, optional_ptr<FileOpener> opener) {
 	if (Settings::Get<EnableExternalAccessSetting>(*this)) {
 		// all external access is allowed
 		return true;
 	}
-	string path = SanitizeAllowedPath(input_path);
 
-	if (options.allowed_paths.count(path) > 0) {
-		// path is explicitly allowed
-		return true;
-	}
+	auto possible_paths = GetPossibleSanitizedPaths(input_path, opener);
+	for (auto &path : possible_paths) {
+		if (options.allowed_paths.count(path) > 0) {
+			return true;
+		}
+		if (options.allowed_directories.empty()) {
+			continue;
+		}
+		if (type == FileType::FILE_TYPE_DIR) {
+			// make sure directories end with a /
+			if (!StringUtil::EndsWith(path, "/")) {
+				path += "/";
+			}
+		}
 
-	if (options.allowed_directories.empty()) {
-		// no prefix directories specified
-		return false;
-	}
-	if (type == FileType::FILE_TYPE_DIR) {
-		// make sure directories end with a /
-		if (!StringUtil::EndsWith(path, "/")) {
-			path += "/";
+		for (const auto &allowed_directory : options.allowed_directories) {
+			if (StringUtil::StartsWith(path, allowed_directory)) {
+				D_ASSERT(StringUtil::EndsWith(allowed_directory, "/"));
+				return true;
+			}
 		}
 	}
-
-	string prefix;
-	for (const auto &allowed_directory : options.allowed_directories) {
-		if (StringUtil::StartsWith(path, allowed_directory)) {
-			prefix = allowed_directory;
-			break;
-		}
-	}
-
-	if (prefix.empty()) {
-		// no common prefix found - path is not inside an allowed directory
-		return false;
-	}
-	D_ASSERT(StringUtil::EndsWith(prefix, "/"));
-	return true;
+	return false;
 }
 
 SerializationOptions::SerializationOptions(AttachedDatabase &db) {


### PR DESCRIPTION
```sql
[~/duckdb] (main) 
vscode@9a5948bd4884$ ./build/reldebug/duckdb
DuckDB v1.5.0-dev8096 (Development Version, 0ae55359dd)
Enter ".help" for usage hints.
memory D SET file_search_path = '/home/vscode/duck-read-cache-fs';
memory D SET allowed_directories = ['/home/vscode/duck-read-cache-fs'];
memory D SET enable_external_access = false;
memory D SELECT * FROM read_blob('extension-helloworld') LIMIT 1;
┌──────────────────────────────────────────┬────────────────┬───────┬──────────────────────────┐
│                 filename                 │    content     │ size  │      last_modified       │
│                 varchar                  │      blob      │ int64 │ timestamp with time zone │
├──────────────────────────────────────────┼────────────────┼───────┼──────────────────────────┤
│ /home/vscode/duck-read-cache-fs/extensio │ helloworld\x0A │    11 │ 2026-02-27 07:19:53+00   │
│ n-helloworld                             │                │       │                          │
└──────────────────────────────────────────┴────────────────┴───────┴──────────────────────────┘
```