### PR TITLE
[DRAFT] Hjiang/external file cache alignedment draft

### DIFF
--- a/.github/config/extensions/avro.cmake
+++ b/.github/config/extensions/avro.cmake
@@ -3,5 +3,6 @@ if (NOT MINGW)
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-avro
             GIT_TAG 4fa0f73f816e9878d5b6a39795e060877766ac1a
+            APPLY_PATCHES
     )
 endif()

--- a/.github/patches/extensions/avro/fix.patch
+++ b/.github/patches/extensions/avro/fix.patch
@@ -1,4 +1,4 @@
-commit f74b8c3487ed9a435ad996473a1746b9c9f5a815
+commit 378944acf4e26a98eec0a8b5be1680cbc662cfc6
 Author: dentiny <dentinyhao@gmail.com>
 Date:   Sun Mar 15 10:48:02 2026 +0000
 
@@ -56,3 +56,21 @@ index ebb941a..af5b41b 100644
  	AvroType avro_type;
  	LogicalType duckdb_type;
  };
+diff --git a/test/sql/external_file_cache.test b/test/sql/external_file_cache.test
+index 1d4a43a..b6aa7fe 100644
+--- a/test/sql/external_file_cache.test
++++ b/test/sql/external_file_cache.test
+@@ -31,8 +31,8 @@ FROM read_avro('test/bigdata.avro') ORDER BY c1 LIMIT 10
+ statement ok
+ from read_avro('test/userdata1.avro');
+ 
+-query IIII
+-from duckdb_external_file_cache() order by path;
++query II
++select path, sum(nr_bytes) from duckdb_external_file_cache() group by path order by path;
+ ----
+-test/bigdata.avro	17647257	0	true
+-test/userdata1.avro	93561	0	true
+\ No newline at end of file
++test/bigdata.avro	17647257
++test/userdata1.avro	93561

--- a/.github/patches/extensions/avro/fix.patch
+++ b/.github/patches/extensions/avro/fix.patch
@@ -1,0 +1,58 @@
+commit b397187da1ffa7034c06019a2c58974c0a3cdb02
+Author: dentiny <dentinyhao@gmail.com>
+Date:   Sun Mar 15 10:48:02 2026 +0000
+
+    Adapt caching filesystem interface change
+
+diff --git a/src/avro_reader.cpp b/src/avro_reader.cpp
+index 5317c43..98b6ad8 100644
+--- a/src/avro_reader.cpp
++++ b/src/avro_reader.cpp
+@@ -123,13 +123,17 @@ AvroReader::AvroReader(ClientContext &context, OpenFileInfo file) : BaseFileRead
+ 
+ 	auto caching_file_handle = caching_file_system.OpenFile(this->file, FileOpenFlags::FILE_FLAGS_READ);
+ 	auto total_size = caching_file_handle->GetFileSize();
+-	data_ptr_t data = nullptr;
+ 
+-	buf_handle = caching_file_handle->Read(data, total_size);
+-	auto buffer_data = buf_handle.Ptr();
++	buf_handle_group = caching_file_handle->Read(total_size);
++	data_ptr_t buffer_data;
++	if (buf_handle_group.handles.size() == 1) {
++		buffer_data = buf_handle_group.Ptr();
++	} else {
++		buf_data = Allocator::DefaultAllocator().Allocate(total_size);
++		buf_handle_group.CopyTo(buf_data.get(), total_size);
++		buffer_data = buf_data.get();
++	}
+ 
+-	D_ASSERT(buf_handle.IsValid());
+-	D_ASSERT(buffer_data == data);
+ 	auto avro_reader = avro_reader_memory(const_char_ptr_cast(buffer_data), total_size);
+ 
+ 	if (avro_reader_reader(avro_reader, &reader)) {
+diff --git a/src/include/avro_reader.hpp b/src/include/avro_reader.hpp
+index ebb941a..af5b41b 100644
+--- a/src/include/avro_reader.hpp
++++ b/src/include/avro_reader.hpp
+@@ -1,8 +1,10 @@
+ #pragma once
+ 
++#include "duckdb/common/allocator.hpp"
+ #include "duckdb/common/helper.hpp"
+ #include "avro_type.hpp"
+ #include "duckdb/common/multi_file/base_file_reader.hpp"
++#include "duckdb/storage/file_buffer_handle_group.hpp"
+ 
+ namespace duckdb {
+ 
+@@ -32,7 +34,8 @@ public:
+ 	avro_value_t value;
+ 	unique_ptr<Vector> read_vec;
+ 
+-	BufferHandle buf_handle;
++	FileBufferHandleGroup buf_handle_group;
++	AllocatedData buf_data;
+ 	AvroType avro_type;
+ 	LogicalType duckdb_type;
+ };

--- a/.github/patches/extensions/avro/fix.patch
+++ b/.github/patches/extensions/avro/fix.patch
@@ -1,11 +1,11 @@
-commit b397187da1ffa7034c06019a2c58974c0a3cdb02
+commit f74b8c3487ed9a435ad996473a1746b9c9f5a815
 Author: dentiny <dentinyhao@gmail.com>
 Date:   Sun Mar 15 10:48:02 2026 +0000
 
     Adapt caching filesystem interface change
 
 diff --git a/src/avro_reader.cpp b/src/avro_reader.cpp
-index 5317c43..98b6ad8 100644
+index 5317c43..876bb8b 100644
 --- a/src/avro_reader.cpp
 +++ b/src/avro_reader.cpp
 @@ -123,13 +123,17 @@ AvroReader::AvroReader(ClientContext &context, OpenFileInfo file) : BaseFileRead
@@ -18,7 +18,7 @@ index 5317c43..98b6ad8 100644
 -	auto buffer_data = buf_handle.Ptr();
 +	buf_handle_group = caching_file_handle->Read(total_size);
 +	data_ptr_t buffer_data;
-+	if (buf_handle_group.handles.size() == 1) {
++	if (buf_handle_group.GetHandles().size() == 1) {
 +		buffer_data = buf_handle_group.Ptr();
 +	} else {
 +		buf_data = Allocator::DefaultAllocator().Allocate(total_size);

--- a/.github/patches/extensions/httpfs/fix.patch
+++ b/.github/patches/extensions/httpfs/fix.patch
@@ -1,9 +1,21 @@
-commit 289d6283aabb40d39b21a7180b6f28515d277a62
+commit 081c5e81ecf0ab0a925ec3df132e788254c06e83
 Author: dentiny <dentinyhao@gmail.com>
-Date:   Thu Feb 26 06:58:16 2026 +0000
+Date:   Mon Mar 16 02:10:34 2026 +0000
 
-    Patch CSV cached reader change
+    Fix effects by cache filesystem
 
+diff --git a/test/sql/json/table/internal_issue_6807.test_slow b/test/sql/json/table/internal_issue_6807.test_slow
+index a354a7f..e759862 100644
+--- a/test/sql/json/table/internal_issue_6807.test_slow
++++ b/test/sql/json/table/internal_issue_6807.test_slow
+@@ -13,6 +13,6 @@ statement ok
+ CREATE TABLE T AS FROM 'https://data.gharchive.org/2023-02-08-0.json.gz';
+ 
+ query I
+-SELECT count(*) < 20 FROM duckdb_logs_parsed('HTTP') WHERE request.type = 'GET' GROUP BY request.type;
++SELECT count(*) < 60 FROM duckdb_logs_parsed('HTTP') WHERE request.type = 'GET' GROUP BY request.type;
+ ----
+ true
 diff --git a/test/sql/logging/file_system_logging.test b/test/sql/logging/file_system_logging.test
 index 6aa2ed0..54babde 100644
 --- a/test/sql/logging/file_system_logging.test
@@ -22,3 +34,13 @@ index 6aa2ed0..54babde 100644
  CONNECTION	FileSystem	TRACE	{"fs":"HTTPFileSystem","path":"https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv","op":"READ","bytes":"1276","pos":"0"}
 -CONNECTION	FileSystem	TRACE	{"fs":"HTTPFileSystem","path":"https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv","op":"READ","bytes":"0","pos":"1276"}
  CONNECTION	FileSystem	TRACE	{"fs":"HTTPFileSystem","path":"https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv","op":"CLOSE"}
+diff --git a/test/sql/metadata_stats.test b/test/sql/metadata_stats.test
+index 27cb0a6..dfe7a26 100644
+--- a/test/sql/metadata_stats.test
++++ b/test/sql/metadata_stats.test
+@@ -18,4 +18,4 @@ SET force_download=false;
+ query II
+ explain analyze SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://raw.githubusercontent.com/duckdb/duckdb/main/data/parquet-testing/userdata1.parquet')
+ ----
+-analyzed_plan	<REGEX>:.*GET: 2.*
++analyzed_plan	<REGEX>:.*GET: 1.*

--- a/.github/patches/extensions/iceberg/fix.patch
+++ b/.github/patches/extensions/iceberg/fix.patch
@@ -1,11 +1,11 @@
-commit 05d8866888b5683929e4529d46941904d79daa21
+commit ee90e7deab0c28c894b307edae7c17f0e27dd5b0
 Author: dentiny <dentinyhao@gmail.com>
 Date:   Sun Mar 15 22:26:54 2026 +0000
 
     Sync DuckDB core interfaces
 
 diff --git a/src/deletes/deletion_vector.cpp b/src/deletes/deletion_vector.cpp
-index a3974c21..66a7bc11 100644
+index a3974c21..8c92993d 100644
 --- a/src/deletes/deletion_vector.cpp
 +++ b/src/deletes/deletion_vector.cpp
 @@ -2,6 +2,8 @@
@@ -34,7 +34,7 @@ index a3974c21..66a7bc11 100644
 +	auto handle_group = caching_file_handle->Read(length, offset);
 +	data_ptr_t buffer_data;
 +	AllocatedData local_buffer;
-+	if (handle_group.handles.size() == 1) {
++	if (handle_group.GetHandles().size() == 1) {
 +		buffer_data = handle_group.Ptr();
 +	} else {
 +		local_buffer = Allocator::DefaultAllocator().Allocate(length);

--- a/.github/patches/extensions/iceberg/fix.patch
+++ b/.github/patches/extensions/iceberg/fix.patch
@@ -1,3 +1,49 @@
+commit 05d8866888b5683929e4529d46941904d79daa21
+Author: dentiny <dentinyhao@gmail.com>
+Date:   Sun Mar 15 22:26:54 2026 +0000
+
+    Sync DuckDB core interfaces
+
+diff --git a/src/deletes/deletion_vector.cpp b/src/deletes/deletion_vector.cpp
+index a3974c21..66a7bc11 100644
+--- a/src/deletes/deletion_vector.cpp
++++ b/src/deletes/deletion_vector.cpp
+@@ -2,6 +2,8 @@
+ #include "iceberg_multi_file_list.hpp"
+ 
+ #include "duckdb/storage/caching_file_system.hpp"
++#include "duckdb/storage/file_buffer_handle_group.hpp"
++#include "duckdb/common/allocator.hpp"
+ #include "duckdb/common/bswap.hpp"
+ 
+ namespace duckdb {
+@@ -64,7 +66,6 @@ void IcebergMultiFileList::ScanPuffinFile(const IcebergDataFile &entry) const {
+ 	auto caching_file_system = CachingFileSystem::Get(context);
+ 
+ 	auto caching_file_handle = caching_file_system.OpenFile(file_path, FileOpenFlags::FILE_FLAGS_READ);
+-	data_ptr_t data = nullptr;
+ 
+ 	D_ASSERT(!entry.content_offset.IsNull());
+ 	D_ASSERT(!entry.content_size_in_bytes.IsNull());
+@@ -72,8 +73,16 @@ void IcebergMultiFileList::ScanPuffinFile(const IcebergDataFile &entry) const {
+ 	auto offset = entry.content_offset.GetValue<int64_t>();
+ 	auto length = entry.content_size_in_bytes.GetValue<int64_t>();
+ 
+-	auto buf_handle = caching_file_handle->Read(data, length, offset);
+-	auto buffer_data = buf_handle.Ptr();
++	auto handle_group = caching_file_handle->Read(length, offset);
++	data_ptr_t buffer_data;
++	AllocatedData local_buffer;
++	if (handle_group.handles.size() == 1) {
++		buffer_data = handle_group.Ptr();
++	} else {
++		local_buffer = Allocator::DefaultAllocator().Allocate(length);
++		handle_group.CopyTo(local_buffer.get(), length);
++		buffer_data = local_buffer.get();
++	}
+ 
+ 	positional_delete_data.emplace(entry.referenced_data_file,
+ 	                               IcebergDeletionVectorData::FromBlob(buffer_data, length));
 diff --git a/src/iceberg_functions/iceberg_multi_file_list.cpp b/src/iceberg_functions/iceberg_multi_file_list.cpp
 index 02a3b3d3..e0d90035 100644
 --- a/src/iceberg_functions/iceberg_multi_file_list.cpp

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -38,7 +38,7 @@ struct ReadHead {
 	}
 
 	void Materialize() {
-		if (handle_group.handles.size() == 1) {
+		if (handle_group.GetHandles().size() == 1) {
 			buffer_ptr = handle_group.Ptr();
 		} else {
 			local_buffer = Allocator::DefaultAllocator().Allocate(size);

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -139,8 +139,7 @@ public:
 			D_ASSERT(location - prefetch_buffer->location + len <= prefetch_buffer->size);
 
 			if (!prefetch_buffer->data_isset) {
-				prefetch_buffer->handle_group =
-				    file_handle.Read(prefetch_buffer->size, prefetch_buffer->location);
+				prefetch_buffer->handle_group = file_handle.Read(prefetch_buffer->size, prefetch_buffer->location);
 				prefetch_buffer->buffer_ptr = prefetch_buffer->handle_group.Ptr();
 				prefetch_buffer->data_isset = true;
 			}

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -14,6 +14,7 @@
 
 #include "duckdb.hpp"
 #include "duckdb/storage/caching_file_system.hpp"
+#include "duckdb/storage/file_buffer_handle_group.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/allocator.hpp"
 
@@ -27,8 +28,8 @@ struct ReadHead {
 	uint64_t size;
 
 	// Current info
-	BufferHandle buffer_handle;
-	data_ptr_t buffer_ptr;
+	FileBufferHandleGroup handle_group;
+	data_ptr_t buffer_ptr = nullptr;
 	bool data_isset = false;
 
 	idx_t GetEnd() const {
@@ -116,8 +117,8 @@ struct ReadAheadBuffer {
 			if (read_head.GetEnd() > file_handle.GetFileSize()) {
 				throw std::runtime_error("Prefetch registered requested for bytes outside file");
 			}
-			read_head.buffer_handle = file_handle.Read(read_head.buffer_ptr, read_head.size, read_head.location);
-			D_ASSERT(read_head.buffer_handle.IsValid());
+			read_head.handle_group = file_handle.Read(read_head.size, read_head.location);
+			read_head.buffer_ptr = read_head.handle_group.Ptr();
 			read_head.data_isset = true;
 		}
 	}
@@ -138,12 +139,11 @@ public:
 			D_ASSERT(location - prefetch_buffer->location + len <= prefetch_buffer->size);
 
 			if (!prefetch_buffer->data_isset) {
-				prefetch_buffer->buffer_handle =
-				    file_handle.Read(prefetch_buffer->buffer_ptr, prefetch_buffer->size, prefetch_buffer->location);
-				D_ASSERT(prefetch_buffer->buffer_handle.IsValid());
+				prefetch_buffer->handle_group =
+				    file_handle.Read(prefetch_buffer->size, prefetch_buffer->location);
+				prefetch_buffer->buffer_ptr = prefetch_buffer->handle_group.Ptr();
 				prefetch_buffer->data_isset = true;
 			}
-			D_ASSERT(prefetch_buffer->buffer_handle.IsValid());
 			memcpy(buf, prefetch_buffer->buffer_ptr + location - prefetch_buffer->location, len);
 		} else if (prefetch_mode && len < PREFETCH_FALLBACK_BUFFERSIZE && len > 0) {
 			Prefetch(location, MinValue<uint64_t>(PREFETCH_FALLBACK_BUFFERSIZE, file_handle.GetFileSize() - location));

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -29,11 +29,22 @@ struct ReadHead {
 
 	// Current info
 	FileBufferHandleGroup handle_group;
+	AllocatedData local_buffer;
 	data_ptr_t buffer_ptr = nullptr;
 	bool data_isset = false;
 
 	idx_t GetEnd() const {
 		return size + location;
+	}
+
+	void Materialize() {
+		if (handle_group.handles.size() == 1) {
+			buffer_ptr = handle_group.Ptr();
+		} else {
+			local_buffer = Allocator::DefaultAllocator().Allocate(size);
+			handle_group.CopyTo(local_buffer.get(), size);
+			buffer_ptr = local_buffer.get();
+		}
 	}
 };
 
@@ -118,7 +129,7 @@ struct ReadAheadBuffer {
 				throw std::runtime_error("Prefetch registered requested for bytes outside file");
 			}
 			read_head.handle_group = file_handle.Read(read_head.size, read_head.location);
-			read_head.buffer_ptr = read_head.handle_group.Ptr();
+			read_head.Materialize();
 			read_head.data_isset = true;
 		}
 	}
@@ -140,7 +151,7 @@ public:
 
 			if (!prefetch_buffer->data_isset) {
 				prefetch_buffer->handle_group = file_handle.Read(prefetch_buffer->size, prefetch_buffer->location);
-				prefetch_buffer->buffer_ptr = prefetch_buffer->handle_group.Ptr();
+				prefetch_buffer->Materialize();
 				prefetch_buffer->data_isset = true;
 			}
 			memcpy(buf, prefetch_buffer->buffer_ptr + location - prefetch_buffer->location, len);

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -943,7 +943,7 @@ const StringUtil::EnumStringLiteral *GetCacheBlockStateValues() {
 		{ static_cast<uint32_t>(CacheBlockState::EMPTY), "EMPTY" },
 		{ static_cast<uint32_t>(CacheBlockState::LOADING), "LOADING" },
 		{ static_cast<uint32_t>(CacheBlockState::LOADED), "LOADED" },
-		{ static_cast<uint32_t>(CacheBlockState::ERROR), "ERROR" }
+		{ static_cast<uint32_t>(CacheBlockState::IO_ERROR), "IO_ERROR" }
 	};
 	return values;
 }

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -180,6 +180,7 @@
 #include "duckdb/storage/buffer/buffer_pool_reservation.hpp"
 #include "duckdb/storage/caching_mode.hpp"
 #include "duckdb/storage/compression/bitpacking.hpp"
+#include "duckdb/storage/external_file_cache.hpp"
 #include "duckdb/storage/magic_bytes.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/variant_stats.hpp"
@@ -935,6 +936,26 @@ const char* EnumUtil::ToChars<CTEMaterialize>(CTEMaterialize value) {
 template<>
 CTEMaterialize EnumUtil::FromString<CTEMaterialize>(const char *value) {
 	return static_cast<CTEMaterialize>(StringUtil::StringToEnum(GetCTEMaterializeValues(), 3, "CTEMaterialize", value));
+}
+
+const StringUtil::EnumStringLiteral *GetCacheBlockStateValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(CacheBlockState::EMPTY), "EMPTY" },
+		{ static_cast<uint32_t>(CacheBlockState::LOADING), "LOADING" },
+		{ static_cast<uint32_t>(CacheBlockState::LOADED), "LOADED" },
+		{ static_cast<uint32_t>(CacheBlockState::ERROR), "ERROR" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<CacheBlockState>(CacheBlockState value) {
+	return StringUtil::EnumToString(GetCacheBlockStateValues(), 4, "CacheBlockState", static_cast<uint32_t>(value));
+}
+
+template<>
+CacheBlockState EnumUtil::FromString<CacheBlockState>(const char *value) {
+	return static_cast<CacheBlockState>(StringUtil::StringToEnum(GetCacheBlockStateValues(), 4, "CacheBlockState", value));
 }
 
 const StringUtil::EnumStringLiteral *GetCacheValidationModeValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -180,7 +180,7 @@
 #include "duckdb/storage/buffer/buffer_pool_reservation.hpp"
 #include "duckdb/storage/caching_mode.hpp"
 #include "duckdb/storage/compression/bitpacking.hpp"
-#include "duckdb/storage/external_file_cache.hpp"
+#include "duckdb/storage/external_file_cache_block_state.hpp"
 #include "duckdb/storage/magic_bytes.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/variant_stats.hpp"

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -106,6 +106,8 @@ enum class CSVState : uint8_t;
 
 enum class CTEMaterialize : uint8_t;
 
+enum class CacheBlockState : uint8_t;
+
 enum class CacheValidationMode : uint8_t;
 
 enum class CachingMode : uint8_t;
@@ -615,6 +617,9 @@ const char* EnumUtil::ToChars<CSVState>(CSVState value);
 
 template<>
 const char* EnumUtil::ToChars<CTEMaterialize>(CTEMaterialize value);
+
+template<>
+const char* EnumUtil::ToChars<CacheBlockState>(CacheBlockState value);
 
 template<>
 const char* EnumUtil::ToChars<CacheValidationMode>(CacheValidationMode value);
@@ -1324,6 +1329,9 @@ CSVState EnumUtil::FromString<CSVState>(const char *value);
 
 template<>
 CTEMaterialize EnumUtil::FromString<CTEMaterialize>(const char *value);
+
+template<>
+CacheBlockState EnumUtil::FromString<CacheBlockState>(const char *value);
 
 template<>
 CacheValidationMode EnumUtil::FromString<CacheValidationMode>(const char *value);

--- a/src/include/duckdb/storage/caching_file_system.hpp
+++ b/src/include/duckdb/storage/caching_file_system.hpp
@@ -25,14 +25,11 @@ class DatabaseInstance;
 class FileOpenFlags;
 class FileSystem;
 struct FileHandle;
-class StorageLockKey;
 class QueryContext;
 class CachingFileSystem;
 
 struct CachingFileHandle {
 public:
-	using CachedFileRangeOverlap = ExternalFileCache::CachedFileRangeOverlap;
-	using CachedFileRange = ExternalFileCache::CachedFileRange;
 	using CachedFile = ExternalFileCache::CachedFile;
 
 public:
@@ -61,26 +58,6 @@ public:
 	DUCKDB_API void Seek(idx_t location);
 
 private:
-	//! Get the version tag of the file (for checking cache invalidation)
-	const string &GetVersionTag(const unique_ptr<StorageLockKey> &guard);
-	//! Tries to read from the cache, filling "overlapping_ranges" with ranges that overlap with the request.
-	//! Returns an invalid BufferHandle if it fails
-	BufferHandle TryReadFromCache(data_ptr_t &buffer, idx_t nr_bytes, idx_t location,
-	                              vector<shared_ptr<CachedFileRange>> &overlapping_ranges,
-	                              optional_idx &start_location_of_next_range);
-	//! Try to read from the specified range, return an invalid BufferHandle if it fails
-	BufferHandle TryReadFromFileRange(const unique_ptr<StorageLockKey> &guard, CachedFileRange &file_range,
-	                                  data_ptr_t &buffer, idx_t nr_bytes, idx_t location);
-	//! Try to insert the file range into the cache
-	BufferHandle TryInsertFileRange(BufferHandle &pin, data_ptr_t &buffer, idx_t nr_bytes, idx_t location,
-	                                shared_ptr<CachedFileRange> &new_file_range);
-	//! Read from file and copy from cached buffers until the requested read is complete
-	//! If actually_read is false, no reading happens, only the number of non-cached reads is counted and returned
-	idx_t ReadAndCopyInterleaved(const vector<shared_ptr<CachedFileRange>> &overlapping_ranges,
-	                             const shared_ptr<CachedFileRange> &new_file_range, data_ptr_t buffer, idx_t nr_bytes,
-	                             idx_t location, bool actually_read);
-
-private:
 	QueryContext context;
 
 	//! The client caching file system that was used to create this CachingFileHandle
@@ -95,7 +72,7 @@ private:
 	optional_ptr<FileOpener> opener;
 	//! Cache validation mode for this file
 	CacheValidationMode validate;
-	//! The associated CachedFile with cached ranges
+	//! The associated CachedFile with cached blocks
 	CachedFile &cached_file;
 
 	//! The underlying FileHandle (optional)

--- a/src/include/duckdb/storage/caching_file_system.hpp
+++ b/src/include/duckdb/storage/caching_file_system.hpp
@@ -16,6 +16,7 @@
 #include "duckdb/common/winapi.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/storage/external_file_cache.hpp"
+#include "duckdb/storage/file_buffer_handle_group.hpp"
 
 namespace duckdb {
 
@@ -40,11 +41,11 @@ public:
 public:
 	//! Get the underlying FileHandle
 	DUCKDB_API FileHandle &GetFileHandle();
-	//! Read (seek) nr_bytes from the file (or cache) at location. The pointer will be set to the requested range
-	//! The buffer is guaranteed to stay in memory as long as the returned BufferHandle is in scope
-	DUCKDB_API BufferHandle Read(data_ptr_t &buffer, idx_t nr_bytes, idx_t location);
-	//! Read (non-seeking) nr bytes from the file (or cache), same as above, also sets nr_bytes to actually read bytes
-	DUCKDB_API BufferHandle Read(data_ptr_t &buffer, idx_t &nr_bytes);
+	//! Read nr_bytes from the file (or cache) at location.
+	//! Returns a FileBufferHandleGroup that keeps the data pinned in memory.
+	DUCKDB_API FileBufferHandleGroup Read(idx_t nr_bytes, idx_t location);
+	//! Read (non-seeking) nr bytes from the file (or cache), sets nr_bytes to actually read bytes
+	DUCKDB_API FileBufferHandleGroup Read(idx_t &nr_bytes);
 	//! Get some properties of the file
 	DUCKDB_API string GetPath() const;
 	DUCKDB_API idx_t GetFileSize();

--- a/src/include/duckdb/storage/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache.hpp
@@ -34,7 +34,8 @@ class BufferManager;
 enum class CacheBlockState : uint8_t {
 	EMPTY,   // no data, no one fetching
 	LOADING, // a thread is actively performing I/O
-	LOADED   // data available in block_handle (may be evicted by buffer manager)
+	LOADED,  // data available in block_handle (may be evicted by buffer manager)
+	ERROR    // I/O failed, error_message contains the reason
 };
 
 struct CacheBlock {
@@ -42,6 +43,7 @@ struct CacheBlock {
 	mutable std::condition_variable cv;
 	CacheBlockState state DUCKDB_GUARDED_BY(mtx) = CacheBlockState::EMPTY;
 	shared_ptr<BlockHandle> block_handle DUCKDB_GUARDED_BY(mtx);
+	string error_message DUCKDB_GUARDED_BY(mtx);
 };
 
 class ExternalFileCache {

--- a/src/include/duckdb/storage/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache.hpp
@@ -9,10 +9,10 @@
 #pragma once
 
 #include "duckdb/common/atomic.hpp"
-#include "duckdb/common/map.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/shared_ptr_ipp.hpp"
 #include "duckdb/common/string.hpp"
+#include "duckdb/common/thread_annotation.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/unique_ptr.hpp"
@@ -20,7 +20,8 @@
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/winapi.hpp"
 #include "duckdb/storage/buffer/temporary_file_information.hpp"
-#include "duckdb/storage/storage_lock.hpp"
+
+#include <condition_variable>
 
 namespace duckdb {
 
@@ -29,36 +30,23 @@ class ClientContext;
 class DatabaseInstance;
 class BlockHandle;
 class BufferManager;
-class StorageLockKey;
+
+enum class CacheBlockState : uint8_t {
+	EMPTY,   // no data, no one fetching
+	LOADING, // a thread is actively performing I/O
+	LOADED   // data available in block_handle (may be evicted by buffer manager)
+};
+
+struct CacheBlock {
+	mutable annotated_mutex mtx;
+	mutable std::condition_variable cv;
+	CacheBlockState state DUCKDB_GUARDED_BY(mtx) = CacheBlockState::EMPTY;
+	shared_ptr<BlockHandle> block_handle DUCKDB_GUARDED_BY(mtx);
+};
 
 class ExternalFileCache {
 public:
-	enum class CachedFileRangeOverlap { NONE, PARTIAL, FULL };
-
-	//! Cached reads (immutable)
-	struct CachedFileRange {
-	public:
-		CachedFileRange(shared_ptr<BlockHandle> block_handle, idx_t nr_bytes, idx_t location, string version_tag);
-		~CachedFileRange();
-
-	public:
-		//! Gets the overlap between this file range and another
-		CachedFileRangeOverlap GetOverlap(idx_t other_nr_bytes, idx_t other_location) const;
-		CachedFileRangeOverlap GetOverlap(const CachedFileRange &other) const;
-
-		//! Computes/verifies checksum over the buffer to ensure data was not modified (used for Verification only)
-		void AddCheckSum();
-		void VerifyCheckSum();
-
-	public:
-		shared_ptr<BlockHandle> block_handle;
-		const idx_t nr_bytes;
-		const idx_t location;
-		const string version_tag;
-#ifdef DEBUG
-		hash_t checksum = 0;
-#endif
-	};
+	static constexpr idx_t CACHE_BLOCK_SIZE = 2ULL * 1024 * 1024; // 2 MiB
 
 	//! Cached files
 	struct CachedFile {
@@ -66,32 +54,20 @@ public:
 		explicit CachedFile(string path_p);
 
 	public:
-		//! Verifies that none of the ranges fully overlap (must hold the lock)
-		void Verify(const unique_ptr<StorageLockKey> &guard) const;
 		//! Whether the CachedFile is still valid given the current modified/version tag
-		bool IsValid(const unique_ptr<StorageLockKey> &guard, bool validate, const string &current_version_tag,
-		             timestamp_t current_last_modified);
+		bool IsValid(bool validate, const string &current_version_tag, timestamp_t current_last_modified);
 
-		//! Get reference to properties (must hold the lock)
-		idx_t &FileSize(const unique_ptr<StorageLockKey> &guard);
-		timestamp_t &LastModified(const unique_ptr<StorageLockKey> &guard);
-		string &VersionTag(const unique_ptr<StorageLockKey> &guard);
-		bool &CanSeek(const unique_ptr<StorageLockKey> &guard);
-		bool &OnDiskFile(const unique_ptr<StorageLockKey> &guard);
-		map<idx_t, shared_ptr<CachedFileRange>> &Ranges(const unique_ptr<StorageLockKey> &guard);
-
-	public:
 		const string path;
-		StorageLock lock;
 
-	private:
-		map<idx_t, shared_ptr<CachedFileRange>> ranges;
+		mutable annotated_mutex map_lock;
+		unordered_map<idx_t, shared_ptr<CacheBlock>> blocks DUCKDB_GUARDED_BY(map_lock);
 
-		idx_t file_size;
-		timestamp_t last_modified;
-		string version_tag;
-		bool can_seek;
-		bool on_disk_file;
+		mutable annotated_mutex meta_lock;
+		idx_t file_size DUCKDB_GUARDED_BY(meta_lock) = 0;
+		timestamp_t last_modified DUCKDB_GUARDED_BY(meta_lock) = timestamp_t(0);
+		string version_tag DUCKDB_GUARDED_BY(meta_lock);
+		bool can_seek DUCKDB_GUARDED_BY(meta_lock) = false;
+		bool on_disk_file DUCKDB_GUARDED_BY(meta_lock) = false;
 	};
 
 public:
@@ -117,7 +93,7 @@ private:
 	BufferManager &buffer_manager;
 	//! Whether or not file caching is enabled
 	atomic<bool> enable;
-	//! Mapping from file path to cached file with cached ranges
+	//! Mapping from file path to cached file with cached blocks
 	unordered_map<string, unique_ptr<CachedFile>> cached_files;
 	//! Lock for accessing the cached files
 	mutable mutex lock;

--- a/src/include/duckdb/storage/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache.hpp
@@ -20,31 +20,14 @@
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/winapi.hpp"
 #include "duckdb/storage/buffer/temporary_file_information.hpp"
-
-#include <condition_variable>
+#include "duckdb/storage/external_file_cache_block.hpp"
 
 namespace duckdb {
 
 // Forward declaration.
 class ClientContext;
 class DatabaseInstance;
-class BlockHandle;
 class BufferManager;
-
-enum class CacheBlockState : uint8_t {
-	EMPTY,   // no data, no one fetching
-	LOADING, // a thread is actively performing I/O
-	LOADED,  // data available in block_handle (may be evicted by buffer manager)
-	ERROR    // I/O failed, error_message contains the reason
-};
-
-struct CacheBlock {
-	mutable annotated_mutex mtx;
-	mutable std::condition_variable cv;
-	CacheBlockState state DUCKDB_GUARDED_BY(mtx) = CacheBlockState::EMPTY;
-	shared_ptr<BlockHandle> block_handle DUCKDB_GUARDED_BY(mtx);
-	string error_message DUCKDB_GUARDED_BY(mtx);
-};
 
 class ExternalFileCache {
 public:

--- a/src/include/duckdb/storage/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache.hpp
@@ -45,6 +45,7 @@ public:
 
 		const string path;
 
+		//! Lock ordering: meta_lock must always be acquired before map_lock to avoid deadlocks.
 		mutable annotated_mutex map_lock;
 		unordered_map<idx_t, shared_ptr<CacheBlock>> blocks DUCKDB_GUARDED_BY(map_lock);
 

--- a/src/include/duckdb/storage/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache.hpp
@@ -45,7 +45,6 @@ public:
 
 		const string path;
 
-		//! Lock ordering: meta_lock must always be acquired before map_lock to avoid deadlocks.
 		mutable annotated_mutex map_lock;
 		unordered_map<idx_t, shared_ptr<CacheBlock>> blocks DUCKDB_GUARDED_BY(map_lock);
 

--- a/src/include/duckdb/storage/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache.hpp
@@ -31,6 +31,7 @@ class BufferManager;
 
 class ExternalFileCache {
 public:
+	// TODO(hjiang): Make cache block size configurable in the followup PR.
 	static constexpr idx_t CACHE_BLOCK_SIZE = 2ULL * 1024 * 1024; // 2 MiB
 
 	//! Cached files

--- a/src/include/duckdb/storage/external_file_cache_block.hpp
+++ b/src/include/duckdb/storage/external_file_cache_block.hpp
@@ -29,7 +29,7 @@ struct CacheBlock {
 #ifdef DEBUG
 	//! Checksum over the buffer contents, used for verifying data was not modified after caching
 	hash_t checksum DUCKDB_GUARDED_BY(mtx) = 0;
-	//! Number of bytes that were read into this block (needed for checksum verification)
+	//! Number of bytes that were read into this block
 	idx_t nr_bytes DUCKDB_GUARDED_BY(mtx) = 0;
 #endif
 };

--- a/src/include/duckdb/storage/external_file_cache_block.hpp
+++ b/src/include/duckdb/storage/external_file_cache_block.hpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/external_file_cache_block.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/shared_ptr_ipp.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/thread_annotation.hpp"
+#include "duckdb/storage/external_file_cache_block_state.hpp"
+
+#include <condition_variable>
+
+namespace duckdb {
+
+class BlockHandle;
+
+struct CacheBlock {
+	mutable annotated_mutex mtx;
+	mutable std::condition_variable cv;
+	CacheBlockState state DUCKDB_GUARDED_BY(mtx) = CacheBlockState::EMPTY;
+	shared_ptr<BlockHandle> block_handle DUCKDB_GUARDED_BY(mtx);
+	string error_message DUCKDB_GUARDED_BY(mtx);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/storage/external_file_cache_block.hpp
+++ b/src/include/duckdb/storage/external_file_cache_block.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "duckdb/common/mutex.hpp"
-#include "duckdb/common/shared_ptr_ipp.hpp"
+#include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/thread_annotation.hpp"
 #include "duckdb/storage/external_file_cache_block_state.hpp"
 
@@ -17,11 +17,12 @@
 
 namespace duckdb {
 
+// Forward declaration.
 class BlockHandle;
 
 struct CacheBlock {
 	mutable annotated_mutex mtx;
-	mutable std::condition_variable cv;
+	mutable std::condition_variable cv DUCKDB_GUARDED_BY(mtx);
 	CacheBlockState state DUCKDB_GUARDED_BY(mtx) = CacheBlockState::EMPTY;
 	shared_ptr<BlockHandle> block_handle DUCKDB_GUARDED_BY(mtx);
 };

--- a/src/include/duckdb/storage/external_file_cache_block.hpp
+++ b/src/include/duckdb/storage/external_file_cache_block.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/thread_annotation.hpp"
+#include "duckdb/common/typedefs.hpp"
 #include "duckdb/storage/external_file_cache_block_state.hpp"
 
 #include <condition_variable>
@@ -25,6 +26,12 @@ struct CacheBlock {
 	mutable std::condition_variable cv DUCKDB_GUARDED_BY(mtx);
 	CacheBlockState state DUCKDB_GUARDED_BY(mtx) = CacheBlockState::EMPTY;
 	shared_ptr<BlockHandle> block_handle DUCKDB_GUARDED_BY(mtx);
+#ifdef DEBUG
+	//! Checksum over the buffer contents, used for verifying data was not modified after caching
+	hash_t checksum DUCKDB_GUARDED_BY(mtx) = 0;
+	//! Number of bytes that were read into this block (needed for checksum verification)
+	idx_t nr_bytes DUCKDB_GUARDED_BY(mtx) = 0;
+#endif
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/external_file_cache_block.hpp
+++ b/src/include/duckdb/storage/external_file_cache_block.hpp
@@ -10,7 +10,6 @@
 
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/shared_ptr_ipp.hpp"
-#include "duckdb/common/string.hpp"
 #include "duckdb/common/thread_annotation.hpp"
 #include "duckdb/storage/external_file_cache_block_state.hpp"
 
@@ -25,7 +24,6 @@ struct CacheBlock {
 	mutable std::condition_variable cv;
 	CacheBlockState state DUCKDB_GUARDED_BY(mtx) = CacheBlockState::EMPTY;
 	shared_ptr<BlockHandle> block_handle DUCKDB_GUARDED_BY(mtx);
-	string error_message DUCKDB_GUARDED_BY(mtx);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/external_file_cache_block_state.hpp
+++ b/src/include/duckdb/storage/external_file_cache_block_state.hpp
@@ -19,7 +19,7 @@ enum class CacheBlockState : uint8_t {
 	LOADING,
 	// data available in block_handle (may be evicted by buffer manager)
 	LOADED,
-	 // I/O failed, error_message contains the reason
+	// I/O failed, error_message contains the reason
 	ERROR
 };
 

--- a/src/include/duckdb/storage/external_file_cache_block_state.hpp
+++ b/src/include/duckdb/storage/external_file_cache_block_state.hpp
@@ -13,13 +13,13 @@
 namespace duckdb {
 
 enum class CacheBlockState : uint8_t {
-	// initialize state, no data, no one fetching
+	// Initial state.
 	EMPTY,
-	// a thread is actively performing I/O
+	// A thread is actively performing I/O.
 	LOADING,
-	// data available in block_handle (may be evicted by buffer manager)
+	// Data is already available in block_handle.
 	LOADED,
-	// I/O failed, error_message contains the reason
+	// I/O failed.
 	ERROR
 };
 

--- a/src/include/duckdb/storage/external_file_cache_block_state.hpp
+++ b/src/include/duckdb/storage/external_file_cache_block_state.hpp
@@ -20,7 +20,7 @@ enum class CacheBlockState : uint8_t {
 	// Data is already available in block_handle.
 	LOADED,
 	// I/O failed.
-	ERROR
+	IO_ERROR
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/external_file_cache_block_state.hpp
+++ b/src/include/duckdb/storage/external_file_cache_block_state.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/external_file_cache_block_state.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/typedefs.hpp"
+
+namespace duckdb {
+
+enum class CacheBlockState : uint8_t {
+	// initialize state, no data, no one fetching
+	EMPTY,
+	// a thread is actively performing I/O
+	LOADING,
+	// data available in block_handle (may be evicted by buffer manager)
+	LOADED,
+	 // I/O failed, error_message contains the reason
+	ERROR
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/storage/file_buffer_handle_group.hpp
+++ b/src/include/duckdb/storage/file_buffer_handle_group.hpp
@@ -28,10 +28,7 @@ public:
 		idx_t length;
 	};
 
-	//! Construct an empty group (no handles).
 	FileBufferHandleGroup() = default;
-
-	//! Construct a group from a pre-built vector of MemoryHandles.
 	explicit FileBufferHandleGroup(vector<MemoryHandle> handles_p);
 
 	//! Read-only access to the underlying handles.
@@ -45,7 +42,7 @@ public:
 	data_ptr_t Ptr() const;
 
 private:
-	// The list of MemoryHandles, could be empty. Immutable after construction.
+	// The list of MemoryHandles, could be empty.
 	vector<MemoryHandle> handles;
 };
 

--- a/src/include/duckdb/storage/file_buffer_handle_group.hpp
+++ b/src/include/duckdb/storage/file_buffer_handle_group.hpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/file_buffer_handle_group.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/storage/buffer/buffer_handle.hpp"
+
+namespace duckdb {
+
+class FileBufferHandleGroup {
+public:
+	struct MemoryHandle {
+		BufferHandle handle;
+		idx_t start_offset;
+		idx_t length;
+	};
+
+	vector<MemoryHandle> handles;
+
+	// Copy from the start of the group to the destination pointer for the requested number of bytes
+	void CopyTo(data_ptr_t dest, idx_t nr_bytes) const;
+	// Return a pointer to the start of the first handle in the group.
+	// Warning: this function requires exactly one handle for zero-copy access, otherwise it will throw an exception.
+	data_ptr_t Ptr() const;
+	// Return if the group contains exactly one handle.
+	bool IsOneHandle() const;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/storage/file_buffer_handle_group.hpp
+++ b/src/include/duckdb/storage/file_buffer_handle_group.hpp
@@ -28,8 +28,14 @@ public:
 		idx_t length;
 	};
 
-	// A list of MemoryHandles, could be empty.
-	vector<MemoryHandle> handles;
+	//! Construct an empty group (no handles).
+	FileBufferHandleGroup() = default;
+
+	//! Construct a group from a pre-built vector of MemoryHandles.
+	explicit FileBufferHandleGroup(vector<MemoryHandle> handles_p);
+
+	//! Read-only access to the underlying handles.
+	const vector<MemoryHandle> &GetHandles() const;
 
 	// Util function to copy from the start of the group to the destination address for the requested number of bytes
 	void CopyTo(data_ptr_t dest, idx_t nr_bytes) const;
@@ -37,6 +43,10 @@ public:
 	// Return a pointer to the start of the first handle in the group.
 	// Warning: this function requires exactly one handle for zero-copy access, otherwise it will throw an exception.
 	data_ptr_t Ptr() const;
+
+private:
+	// The list of MemoryHandles, could be empty. Immutable after construction.
+	vector<MemoryHandle> handles;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/file_buffer_handle_group.hpp
+++ b/src/include/duckdb/storage/file_buffer_handle_group.hpp
@@ -14,23 +14,28 @@
 
 namespace duckdb {
 
+// A shallow span for a number of BufferHandles together for contiguous content, used for zero-copy potential access.
+// For example, ZSTD supports stream-based decompression, which doesn't require to prepare a contiguous buffer; insteads users are able to iterate all handles and decompress them on the fly.
 class FileBufferHandleGroup {
 public:
+	// A single BufferHandle and its offset/length within the file.
 	struct MemoryHandle {
 		BufferHandle handle;
+		// Byte offset within handle's buffer where the relevant data begins
 		idx_t start_offset;
+		// Number of valid bytes starting from start offset
 		idx_t length;
 	};
 
+	// A list of MemoryHandles, could be empty.
 	vector<MemoryHandle> handles;
 
-	// Copy from the start of the group to the destination pointer for the requested number of bytes
+	// Util function to copy from the start of the group to the destination address for the requested number of bytes
 	void CopyTo(data_ptr_t dest, idx_t nr_bytes) const;
+
 	// Return a pointer to the start of the first handle in the group.
 	// Warning: this function requires exactly one handle for zero-copy access, otherwise it will throw an exception.
 	data_ptr_t Ptr() const;
-	// Return if the group contains exactly one handle.
-	bool IsOneHandle() const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/file_buffer_handle_group.hpp
+++ b/src/include/duckdb/storage/file_buffer_handle_group.hpp
@@ -15,7 +15,8 @@
 namespace duckdb {
 
 // A shallow span for a number of BufferHandles together for contiguous content, used for zero-copy potential access.
-// For example, ZSTD supports stream-based decompression, which doesn't require to prepare a contiguous buffer; insteads users are able to iterate all handles and decompress them on the fly.
+// For example, ZSTD supports stream-based decompression, which doesn't require to prepare a contiguous buffer; insteads
+// users are able to iterate all handles and decompress them on the fly.
 class FileBufferHandleGroup {
 public:
 	// A single BufferHandle and its offset/length within the file.

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library_unity(
   data_table.cpp
   external_file_cache.cpp
   external_file_cache_util.cpp
+  file_buffer_handle_group.cpp
   index.cpp
   local_storage.cpp
   magic_bytes.cpp

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -88,7 +88,8 @@ public:
 				return;
 			}
 			case CacheBlockState::LOADING: {
-				block->cv.wait(lk, [&] DUCKDB_REQUIRES(block->mtx) { return block->state != CacheBlockState::LOADING; });
+				block->cv.wait(lk,
+				               [&] DUCKDB_REQUIRES(block->mtx) { return block->state != CacheBlockState::LOADING; });
 				continue;
 			}
 			case CacheBlockState::ERROR: {

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -92,6 +92,7 @@ public:
 				continue;
 			}
 			case CacheBlockState::ERROR: {
+				// IO operation failed, reset the block to empty state for another attempt.
 				block->state = CacheBlockState::EMPTY;
 				continue;
 			}
@@ -154,7 +155,7 @@ CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &ca
 		return;
 	}
 	// If we don't have any cached blocks, we must also open the file.
-	bool needs_open;
+	bool needs_open = false;
 	{
 		annotated_lock_guard<annotated_mutex> guard(cached_file.map_lock);
 		needs_open = cached_file.blocks.empty();
@@ -168,26 +169,28 @@ CachingFileHandle::~CachingFileHandle() {
 }
 
 FileHandle &CachingFileHandle::GetFileHandle() {
-	if (!file_handle) {
-		file_handle = caching_file_system.file_system.OpenFile(path, flags, opener);
-		last_modified = caching_file_system.file_system.GetLastModifiedTime(*file_handle);
-		version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
+	if (file_handle) {
+		return *file_handle;
+	}
 
-		{
-			annotated_lock_guard<annotated_mutex> meta_guard(cached_file.meta_lock);
-			bool first_access = (cached_file.file_size == 0);
-			if (first_access || Validate()) {
-				if (!ExternalFileCache::IsValid(Validate(), cached_file.version_tag, cached_file.last_modified,
-				                                version_tag, last_modified)) {
-					annotated_lock_guard<annotated_mutex> map_guard(cached_file.map_lock);
-					cached_file.blocks.clear();
-				}
-				cached_file.file_size = file_handle->GetFileSize();
-				cached_file.last_modified = last_modified;
-				cached_file.version_tag = version_tag;
-				cached_file.can_seek = file_handle->CanSeek();
-				cached_file.on_disk_file = file_handle->OnDiskFile();
+	file_handle = caching_file_system.file_system.OpenFile(path, flags, opener);
+	last_modified = caching_file_system.file_system.GetLastModifiedTime(*file_handle);
+	version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
+
+	{
+		annotated_lock_guard<annotated_mutex> meta_guard(cached_file.meta_lock);
+		const bool first_access = (cached_file.file_size == 0);
+		if (first_access || Validate()) {
+			if (!ExternalFileCache::IsValid(Validate(), cached_file.version_tag, cached_file.last_modified,
+											version_tag, last_modified)) {
+				annotated_lock_guard<annotated_mutex> map_guard(cached_file.map_lock);
+				cached_file.blocks.clear();
 			}
+			cached_file.file_size = file_handle->GetFileSize();
+			cached_file.last_modified = last_modified;
+			cached_file.version_tag = version_tag;
+			cached_file.can_seek = file_handle->CanSeek();
+			cached_file.on_disk_file = file_handle->OnDiskFile();
 		}
 	}
 	return *file_handle;
@@ -195,7 +198,6 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 
 FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t location) {
 	FileBufferHandleGroup group;
-
 	if (nr_bytes == 0) {
 		return group;
 	}
@@ -209,24 +211,23 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 
 	// Ensure the file is open so metadata is set before blocks are visible to other threads
 	auto &fh = GetFileHandle();
-	const idx_t fs = fh.GetFileSize();
+	const idx_t file_size = fh.GetFileSize();
 
 	const idx_t block_size = ExternalFileCache::CACHE_BLOCK_SIZE;
 	const idx_t first_block = location / block_size;
 	const idx_t last_block = (location + nr_bytes - 1) / block_size;
 	const idx_t num_blocks = last_block - first_block + 1;
 
-	// Get-or-create CacheBlock for each block_idx
 	vector<shared_ptr<CacheBlock>> blocks(num_blocks);
 	{
 		annotated_lock_guard<annotated_mutex> guard(cached_file.map_lock);
-		for (idx_t i = 0; i < num_blocks; i++) {
-			const idx_t block_idx = first_block + i;
+		for (idx_t idx = 0; idx < num_blocks; idx++) {
+			const idx_t block_idx = first_block + idx;
 			auto &entry = cached_file.blocks[block_idx];
 			if (!entry) {
 				entry = make_shared_ptr<CacheBlock>();
 			}
-			blocks[i] = entry;
+			blocks[idx] = entry;
 		}
 	}
 
@@ -235,19 +236,19 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 	auto &scheduler = TaskScheduler::GetScheduler(caching_file_system.db);
 	TaskExecutor executor(scheduler);
 
-	for (idx_t i = 0; i < num_blocks; i++) {
+	for (idx_t idx = 0; idx < num_blocks; idx++) {
 		executor.ScheduleTask(make_uniq<FetchBlockTask>(executor, fh, context, external_file_cache.GetBufferManager(),
-		                                                blocks[i], first_block + i, fs, pins[i]));
+		                                                blocks[idx], first_block + idx, file_size, pins[idx]));
 	}
 	executor.WorkOnTasks();
 
-	// Build the handle group -- each block contributes a slice
+	// Build the handle group.
 	idx_t remaining = nr_bytes;
-	for (idx_t i = 0; i < num_blocks; i++) {
-		const idx_t block_start = (first_block + i) * block_size;
-		const idx_t offset_in_block = (i == 0) ? (location - block_start) : 0;
+	for (idx_t idx = 0; idx < num_blocks; idx++) {
+		const idx_t block_start = (first_block + idx) * block_size;
+		const idx_t offset_in_block = (idx == 0) ? (location - block_start) : 0;
 		const idx_t length = MinValue(block_size - offset_in_block, remaining);
-		group.handles.push_back({std::move(pins[i]), offset_in_block, length});
+		group.handles.push_back({std::move(pins[idx]), offset_in_block, length});
 		remaining -= length;
 	}
 
@@ -269,6 +270,7 @@ FileBufferHandleGroup CachingFileHandle::Read(idx_t &nr_bytes) {
 		nr_bytes = 0;
 		return {};
 	}
+
 	nr_bytes = MinValue(nr_bytes, file_size - position);
 	auto group = Read(nr_bytes, position);
 	position += nr_bytes;

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/storage/caching_file_system.hpp"
 
+#include "duckdb/common/checksum.hpp"
 #include "duckdb/common/enums/cache_validation_mode.hpp"
 #include "duckdb/common/enums/memory_tag.hpp"
 #include "duckdb/common/file_system.hpp"
@@ -53,16 +54,19 @@ public:
 
 		while (true) {
 			switch (block->state) {
-			case CacheBlockState::LOADED: {
-				auto pin = buffer_manager.Pin(block->block_handle);
-				if (pin.IsValid()) {
-					result_pin = std::move(pin);
-					return;
-				}
-				// Evicted by buffer manager, need to re-fetch
-				block->state = CacheBlockState::EMPTY;
-				continue;
+		case CacheBlockState::LOADED: {
+			auto pin = buffer_manager.Pin(block->block_handle);
+			if (pin.IsValid()) {
+#ifdef DEBUG
+				D_ASSERT(Checksum(pin.Ptr(), block->nr_bytes) == block->checksum);
+#endif
+				result_pin = std::move(pin);
+				return;
 			}
+			// Evicted by buffer manager, need to re-fetch
+			block->state = CacheBlockState::EMPTY;
+			continue;
+		}
 			case CacheBlockState::EMPTY: {
 				block->state = CacheBlockState::LOADING;
 				lk.unlock();
@@ -73,11 +77,15 @@ public:
 					auto buf = buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, to_read);
 					file_handle.Read(context, buf.Ptr(), to_read, offset);
 
-					lk.lock();
-					block->block_handle = buf.GetBlockHandle();
-					block->state = CacheBlockState::LOADED;
-					result_pin = std::move(buf);
-					block->cv.notify_all();
+				lk.lock();
+				block->block_handle = buf.GetBlockHandle();
+				block->state = CacheBlockState::LOADED;
+#ifdef DEBUG
+				block->nr_bytes = to_read;
+				block->checksum = Checksum(buf.Ptr(), to_read);
+#endif
+				result_pin = std::move(buf);
+				block->cv.notify_all();
 				} catch (std::exception &e) {
 					lk.lock();
 					block->state = CacheBlockState::ERROR;
@@ -197,16 +205,16 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 }
 
 FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t location) {
-	FileBufferHandleGroup group;
 	if (nr_bytes == 0) {
-		return group;
+		return FileBufferHandleGroup();
 	}
 
 	if (!external_file_cache.IsEnabled()) {
 		auto buf = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
 		GetFileHandle().Read(context, buf.Ptr(), nr_bytes, location);
-		group.handles.push_back({std::move(buf), 0, nr_bytes});
-		return group;
+		vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
+		mem_handles.push_back({std::move(buf), 0, nr_bytes});
+		return FileBufferHandleGroup(std::move(mem_handles));
 	}
 
 	// Ensure the file is open so metadata is set before blocks are visible to other threads
@@ -243,26 +251,28 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 	executor.WorkOnTasks();
 
 	// Build the handle group.
+	vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
+	mem_handles.reserve(num_blocks);
 	idx_t remaining = nr_bytes;
 	for (idx_t idx = 0; idx < num_blocks; idx++) {
 		const idx_t block_start = (first_block + idx) * block_size;
 		const idx_t offset_in_block = (idx == 0) ? (location - block_start) : 0;
 		const idx_t length = MinValue(block_size - offset_in_block, remaining);
-		group.handles.push_back({std::move(pins[idx]), offset_in_block, length});
+		mem_handles.push_back({std::move(pins[idx]), offset_in_block, length});
 		remaining -= length;
 	}
 
-	return group;
+	return FileBufferHandleGroup(std::move(mem_handles));
 }
 
 FileBufferHandleGroup CachingFileHandle::Read(idx_t &nr_bytes) {
 	if (!external_file_cache.IsEnabled() || !CanSeek()) {
-		FileBufferHandleGroup group;
 		auto buf = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
 		nr_bytes = NumericCast<idx_t>(GetFileHandle().Read(context, buf.Ptr(), nr_bytes));
-		group.handles.push_back({std::move(buf), 0, nr_bytes});
+		vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
+		mem_handles.push_back({std::move(buf), 0, nr_bytes});
 		position += nr_bytes;
-		return group;
+		return FileBufferHandleGroup(std::move(mem_handles));
 	}
 
 	const idx_t file_size = GetFileSize();

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -68,24 +68,33 @@ public:
 				block->state = CacheBlockState::LOADING;
 				lk.unlock();
 
-				const idx_t offset = block_idx * ExternalFileCache::CACHE_BLOCK_SIZE;
-				const idx_t to_read = MinValue(ExternalFileCache::CACHE_BLOCK_SIZE, file_size - offset);
-				auto buf = buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, to_read);
-				file_handle.Read(context, buf.Ptr(), to_read, offset);
+				try {
+					const idx_t offset = block_idx * ExternalFileCache::CACHE_BLOCK_SIZE;
+					const idx_t to_read = MinValue(ExternalFileCache::CACHE_BLOCK_SIZE, file_size - offset);
+					auto buf = buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, to_read);
+					file_handle.Read(context, buf.Ptr(), to_read, offset);
 
-				lk.lock();
-				block->block_handle = buf.GetBlockHandle();
-				block->state = CacheBlockState::LOADED;
-				result_pin = std::move(buf);
-				block->cv.notify_all();
+					lk.lock();
+					block->block_handle = buf.GetBlockHandle();
+					block->state = CacheBlockState::LOADED;
+					result_pin = std::move(buf);
+					block->cv.notify_all();
+				} catch (std::exception &e) {
+					lk.lock();
+					block->state = CacheBlockState::ERROR;
+					block->error_message = e.what();
+					block->cv.notify_all();
+					throw;
+				}
 				return;
 			}
 			case CacheBlockState::LOADING: {
 				block->cv.wait(lk, [&] { return block->state != CacheBlockState::LOADING; });
 				continue;
 			}
-			default:
-				throw InternalException("Unknown CacheBlockState");
+			case CacheBlockState::ERROR: {
+				throw IOException("Cached block read failed: %s", block->error_message);
+			}
 			}
 		}
 	}

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -166,16 +166,19 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 
 		{
 			annotated_lock_guard<annotated_mutex> meta_guard(cached_file.meta_lock);
-			if (!ExternalFileCache::IsValid(Validate(), cached_file.version_tag, cached_file.last_modified,
-			                                version_tag, last_modified)) {
-				annotated_lock_guard<annotated_mutex> map_guard(cached_file.map_lock);
-				cached_file.blocks.clear();
+			bool first_access = (cached_file.file_size == 0);
+			if (first_access || Validate()) {
+				if (!ExternalFileCache::IsValid(Validate(), cached_file.version_tag, cached_file.last_modified,
+				                                version_tag, last_modified)) {
+					annotated_lock_guard<annotated_mutex> map_guard(cached_file.map_lock);
+					cached_file.blocks.clear();
+				}
+				cached_file.file_size = file_handle->GetFileSize();
+				cached_file.last_modified = last_modified;
+				cached_file.version_tag = version_tag;
+				cached_file.can_seek = file_handle->CanSeek();
+				cached_file.on_disk_file = file_handle->OnDiskFile();
 			}
-			cached_file.file_size = file_handle->GetFileSize();
-			cached_file.last_modified = last_modified;
-			cached_file.version_tag = version_tag;
-			cached_file.can_seek = file_handle->CanSeek();
-			cached_file.on_disk_file = file_handle->OnDiskFile();
 		}
 	}
 	return *file_handle;

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -207,6 +207,10 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 		return group;
 	}
 
+	// Ensure the file is open so metadata is set before blocks are visible to other threads
+	auto &fh = GetFileHandle();
+	const idx_t fs = fh.GetFileSize();
+
 	const idx_t block_size = ExternalFileCache::CACHE_BLOCK_SIZE;
 	const idx_t first_block = location / block_size;
 	const idx_t last_block = (location + nr_bytes - 1) / block_size;
@@ -225,10 +229,6 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 			blocks[i] = entry;
 		}
 	}
-
-	// Ensure the file is open so we have file_size and a valid file_handle for I/O
-	auto &fh = GetFileHandle();
-	const idx_t fs = fh.GetFileSize();
 
 	// Schedule one FetchBlockTask per block
 	vector<BufferHandle> pins(num_blocks);

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -81,7 +81,6 @@ public:
 				} catch (std::exception &e) {
 					lk.lock();
 					block->state = CacheBlockState::ERROR;
-					block->error_message = e.what();
 					block->cv.notify_all();
 					throw;
 				}
@@ -93,7 +92,8 @@ public:
 				continue;
 			}
 			case CacheBlockState::ERROR: {
-				throw IOException("Cached block read failed: %s", block->error_message);
+				block->state = CacheBlockState::EMPTY;
+				continue;
 			}
 			}
 		}

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -196,6 +196,10 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t location) {
 	FileBufferHandleGroup group;
 
+	if (nr_bytes == 0) {
+		return group;
+	}
+
 	if (!external_file_cache.IsEnabled()) {
 		auto buf = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
 		GetFileHandle().Read(context, buf.Ptr(), nr_bytes, location);

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -88,7 +88,7 @@ public:
 					block->cv.notify_all();
 				} catch (std::exception &e) {
 					lk.lock();
-					block->state = CacheBlockState::ERROR;
+					block->state = CacheBlockState::IO_ERROR;
 					block->cv.notify_all();
 					throw;
 				}
@@ -99,7 +99,7 @@ public:
 				               [&]() DUCKDB_REQUIRES(block->mtx) { return block->state != CacheBlockState::LOADING; });
 				continue;
 			}
-			case CacheBlockState::ERROR: {
+			case CacheBlockState::IO_ERROR: {
 				// IO operation failed, reset the block to empty state for another attempt.
 				block->state = CacheBlockState::EMPTY;
 				continue;

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -54,19 +54,19 @@ public:
 
 		while (true) {
 			switch (block->state) {
-		case CacheBlockState::LOADED: {
-			auto pin = buffer_manager.Pin(block->block_handle);
-			if (pin.IsValid()) {
+			case CacheBlockState::LOADED: {
+				auto pin = buffer_manager.Pin(block->block_handle);
+				if (pin.IsValid()) {
 #ifdef DEBUG
-				D_ASSERT(Checksum(pin.Ptr(), block->nr_bytes) == block->checksum);
+					D_ASSERT(Checksum(pin.Ptr(), block->nr_bytes) == block->checksum);
 #endif
-				result_pin = std::move(pin);
-				return;
+					result_pin = std::move(pin);
+					return;
+				}
+				// Evicted by buffer manager, need to re-fetch
+				block->state = CacheBlockState::EMPTY;
+				continue;
 			}
-			// Evicted by buffer manager, need to re-fetch
-			block->state = CacheBlockState::EMPTY;
-			continue;
-		}
 			case CacheBlockState::EMPTY: {
 				block->state = CacheBlockState::LOADING;
 				lk.unlock();
@@ -77,15 +77,15 @@ public:
 					auto buf = buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, to_read);
 					file_handle.Read(context, buf.Ptr(), to_read, offset);
 
-				lk.lock();
-				block->block_handle = buf.GetBlockHandle();
-				block->state = CacheBlockState::LOADED;
+					lk.lock();
+					block->block_handle = buf.GetBlockHandle();
+					block->state = CacheBlockState::LOADED;
 #ifdef DEBUG
-				block->nr_bytes = to_read;
-				block->checksum = Checksum(buf.Ptr(), to_read);
+					block->nr_bytes = to_read;
+					block->checksum = Checksum(buf.Ptr(), to_read);
 #endif
-				result_pin = std::move(buf);
-				block->cv.notify_all();
+					result_pin = std::move(buf);
+					block->cv.notify_all();
 				} catch (std::exception &e) {
 					lk.lock();
 					block->state = CacheBlockState::ERROR;

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -257,7 +257,7 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 	for (idx_t idx = 0; idx < num_blocks; idx++) {
 		const idx_t block_start = (first_block + idx) * block_size;
 		const idx_t offset_in_block = (idx == 0) ? (location - block_start) : 0;
-		const idx_t block_valid_bytes = MinValue(block_size, fs - block_start);
+		const idx_t block_valid_bytes = MinValue(block_size, file_size - block_start);
 		const idx_t available_in_block = block_valid_bytes - offset_in_block;
 		const idx_t length = MinValue(available_in_block, remaining);
 		mem_handles.push_back({std::move(pins[idx]), offset_in_block, length});

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -181,8 +181,8 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 		annotated_lock_guard<annotated_mutex> meta_guard(cached_file.meta_lock);
 		const bool first_access = (cached_file.file_size == 0);
 		if (first_access || Validate()) {
-			if (!ExternalFileCache::IsValid(Validate(), cached_file.version_tag, cached_file.last_modified,
-											version_tag, last_modified)) {
+			if (!ExternalFileCache::IsValid(Validate(), cached_file.version_tag, cached_file.last_modified, version_tag,
+			                                last_modified)) {
 				annotated_lock_guard<annotated_mutex> map_guard(cached_file.map_lock);
 				cached_file.blocks.clear();
 			}

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -193,12 +193,14 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 	return *file_handle;
 }
 
-BufferHandle CachingFileHandle::Read(data_ptr_t &buffer, const idx_t nr_bytes, const idx_t location) {
+FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t location) {
+	FileBufferHandleGroup group;
+
 	if (!external_file_cache.IsEnabled()) {
-		auto result = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
-		buffer = result.Ptr();
-		GetFileHandle().Read(context, buffer, nr_bytes, location);
-		return result;
+		auto buf = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
+		GetFileHandle().Read(context, buf.Ptr(), nr_bytes, location);
+		group.handles.push_back({std::move(buf), 0, nr_bytes});
+		return group;
 	}
 
 	const idx_t block_size = ExternalFileCache::CACHE_BLOCK_SIZE;
@@ -235,40 +237,32 @@ BufferHandle CachingFileHandle::Read(data_ptr_t &buffer, const idx_t nr_bytes, c
 	}
 	executor.WorkOnTasks();
 
-	// Assemble result
-	if (num_blocks == 1) {
-		const idx_t offset_in_block = location - first_block * block_size;
-		buffer = pins[0].Ptr() + offset_in_block;
-		return std::move(pins[0]);
-	}
-
-	auto result = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
-	buffer = result.Ptr();
-	idx_t bytes_copied = 0;
-
+	// Build the handle group -- each block contributes a slice
+	idx_t remaining = nr_bytes;
 	for (idx_t i = 0; i < num_blocks; i++) {
 		const idx_t block_start = (first_block + i) * block_size;
 		const idx_t offset_in_block = (i == 0) ? (location - block_start) : 0;
-		const idx_t bytes_to_copy = MinValue(block_size - offset_in_block, nr_bytes - bytes_copied);
-		memcpy(buffer + bytes_copied, pins[i].Ptr() + offset_in_block, bytes_to_copy);
-		bytes_copied += bytes_to_copy;
+		const idx_t length = MinValue(block_size - offset_in_block, remaining);
+		group.handles.push_back({std::move(pins[i]), offset_in_block, length});
+		remaining -= length;
 	}
 
-	return result;
+	return group;
 }
 
-BufferHandle CachingFileHandle::Read(data_ptr_t &buffer, idx_t &nr_bytes) {
+FileBufferHandleGroup CachingFileHandle::Read(idx_t &nr_bytes) {
 	if (!external_file_cache.IsEnabled() || !CanSeek()) {
-		auto result = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
-		buffer = result.Ptr();
-		nr_bytes = NumericCast<idx_t>(GetFileHandle().Read(context, buffer, nr_bytes));
+		FileBufferHandleGroup group;
+		auto buf = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
+		nr_bytes = NumericCast<idx_t>(GetFileHandle().Read(context, buf.Ptr(), nr_bytes));
+		group.handles.push_back({std::move(buf), 0, nr_bytes});
 		position += nr_bytes;
-		return result;
+		return group;
 	}
 
-	auto result = Read(buffer, nr_bytes, position);
+	auto group = Read(nr_bytes, position);
 	position += nr_bytes;
-	return result;
+	return group;
 }
 
 string CachingFileHandle::GetPath() const {

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -257,7 +257,9 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 	for (idx_t idx = 0; idx < num_blocks; idx++) {
 		const idx_t block_start = (first_block + idx) * block_size;
 		const idx_t offset_in_block = (idx == 0) ? (location - block_start) : 0;
-		const idx_t length = MinValue(block_size - offset_in_block, remaining);
+		const idx_t block_valid_bytes = MinValue(block_size, fs - block_start);
+		const idx_t available_in_block = block_valid_bytes - offset_in_block;
+		const idx_t length = MinValue(available_in_block, remaining);
 		mem_handles.push_back({std::move(pins[idx]), offset_in_block, length});
 		remaining -= length;
 	}

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -88,7 +88,7 @@ public:
 				return;
 			}
 			case CacheBlockState::LOADING: {
-				block->cv.wait(lk, [&] { return block->state != CacheBlockState::LOADING; });
+				block->cv.wait(lk, [&] DUCKDB_REQUIRES(block->mtx) { return block->state != CacheBlockState::LOADING; });
 				continue;
 			}
 			case CacheBlockState::ERROR: {

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -1,9 +1,11 @@
 #include "duckdb/storage/caching_file_system.hpp"
 
 #include "duckdb/common/enums/cache_validation_mode.hpp"
-#include "duckdb/common/file_system.hpp"
 #include "duckdb/common/enums/memory_tag.hpp"
+#include "duckdb/common/file_system.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/parallel/task_executor.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/external_file_cache.hpp"
 #include "duckdb/storage/external_file_cache_util.hpp"
@@ -31,22 +33,76 @@ bool ShouldValidate(const OpenFileInfo &info, optional_ptr<ClientContext> client
 	}
 }
 
-bool ShouldExpandToFillGap(const idx_t current_length, const idx_t added_length) {
-	const idx_t MAX_BOUND_TO_BE_ADDED_LENGTH = 1048576;
-
-	if (added_length > MAX_BOUND_TO_BE_ADDED_LENGTH) {
-		// Absolute value of what would be needed to added is too high
-		return false;
-	}
-	if (added_length > current_length) {
-		// Relative value of what would be needed to added is too high
-		return false;
-	}
-
-	return true;
-}
-
 } // namespace
+
+//===----------------------------------------------------------------------===//
+// FetchBlockTask
+//===----------------------------------------------------------------------===//
+
+class FetchBlockTask : public BaseExecutorTask {
+public:
+	FetchBlockTask(TaskExecutor &executor, FileHandle &file_handle_p, QueryContext context_p,
+	               BufferManager &buffer_manager_p, shared_ptr<CacheBlock> block_p, idx_t block_idx_p,
+	               idx_t file_size_p, BufferHandle &result_pin_p)
+	    : BaseExecutorTask(executor), file_handle(file_handle_p), context(context_p),
+	      buffer_manager(buffer_manager_p), block(std::move(block_p)), block_idx(block_idx_p),
+	      file_size(file_size_p), result_pin(result_pin_p) {
+	}
+
+	void ExecuteTask() override {
+		annotated_unique_lock<annotated_mutex> lk(block->mtx);
+
+		while (true) {
+			switch (block->state) {
+			case CacheBlockState::LOADED: {
+				auto pin = buffer_manager.Pin(block->block_handle);
+				if (pin.IsValid()) {
+					result_pin = std::move(pin);
+					return;
+				}
+				// Evicted by buffer manager, need to re-fetch
+				block->state = CacheBlockState::EMPTY;
+				continue;
+			}
+			case CacheBlockState::EMPTY: {
+				block->state = CacheBlockState::LOADING;
+				lk.unlock();
+
+				const idx_t offset = block_idx * ExternalFileCache::CACHE_BLOCK_SIZE;
+				const idx_t to_read = MinValue(ExternalFileCache::CACHE_BLOCK_SIZE, file_size - offset);
+				auto buf = buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, to_read);
+				file_handle.Read(context, buf.Ptr(), to_read, offset);
+
+				lk.lock();
+				block->block_handle = buf.GetBlockHandle();
+				block->state = CacheBlockState::LOADED;
+				result_pin = std::move(buf);
+				block->cv.notify_all();
+				return;
+			}
+			case CacheBlockState::LOADING: {
+				block->cv.wait(lk, [&] { return block->state != CacheBlockState::LOADING; });
+				continue;
+			}
+			default:
+				throw InternalException("Unknown CacheBlockState");
+			}
+		}
+	}
+
+private:
+	FileHandle &file_handle;
+	QueryContext context;
+	BufferManager &buffer_manager;
+	shared_ptr<CacheBlock> block;
+	idx_t block_idx;
+	idx_t file_size;
+	BufferHandle &result_pin;
+};
+
+//===----------------------------------------------------------------------===//
+// CachingFileSystem
+//===----------------------------------------------------------------------===//
 
 CachingFileSystem::CachingFileSystem(FileSystem &file_system_p, DatabaseInstance &db_p)
     : file_system(file_system_p), db(db_p), external_file_cache(ExternalFileCache::Get(db)) {
@@ -71,6 +127,10 @@ unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(QueryContext context, 
 	                                    external_file_cache.GetOrCreateCachedFile(path.path));
 }
 
+//===----------------------------------------------------------------------===//
+// CachingFileHandle
+//===----------------------------------------------------------------------===//
+
 CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system_p,
                                      const OpenFileInfo &path_p, FileOpenFlags flags_p,
                                      optional_ptr<FileOpener> opener_p, CachedFile &cached_file_p)
@@ -84,10 +144,13 @@ CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &ca
 		GetFileHandle();
 		return;
 	}
-	// If we don't have any cached file ranges, we must also open the file.
-	auto guard = cached_file.lock.GetSharedLock();
-	if (cached_file.Ranges(guard).empty()) {
-		guard.reset();
+	// If we don't have any cached blocks, we must also open the file.
+	bool needs_open;
+	{
+		annotated_lock_guard<annotated_mutex> guard(cached_file.map_lock);
+		needs_open = cached_file.blocks.empty();
+	}
+	if (needs_open) {
 		GetFileHandle();
 	}
 }
@@ -101,105 +164,99 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 		last_modified = caching_file_system.file_system.GetLastModifiedTime(*file_handle);
 		version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
 
-		auto guard = cached_file.lock.GetExclusiveLock();
-		if (!cached_file.IsValid(guard, Validate(), version_tag, last_modified)) {
-			cached_file.Ranges(guard).clear(); // Invalidate entire cache
+		{
+			annotated_lock_guard<annotated_mutex> meta_guard(cached_file.meta_lock);
+			if (!ExternalFileCache::IsValid(Validate(), cached_file.version_tag, cached_file.last_modified,
+			                                version_tag, last_modified)) {
+				annotated_lock_guard<annotated_mutex> map_guard(cached_file.map_lock);
+				cached_file.blocks.clear();
+			}
+			cached_file.file_size = file_handle->GetFileSize();
+			cached_file.last_modified = last_modified;
+			cached_file.version_tag = version_tag;
+			cached_file.can_seek = file_handle->CanSeek();
+			cached_file.on_disk_file = file_handle->OnDiskFile();
 		}
-		cached_file.FileSize(guard) = file_handle->GetFileSize();
-		cached_file.LastModified(guard) = last_modified;
-		cached_file.VersionTag(guard) = version_tag;
-		cached_file.CanSeek(guard) = file_handle->CanSeek();
-		cached_file.OnDiskFile(guard) = file_handle->OnDiskFile();
 	}
 	return *file_handle;
 }
 
 BufferHandle CachingFileHandle::Read(data_ptr_t &buffer, const idx_t nr_bytes, const idx_t location) {
-	BufferHandle result;
 	if (!external_file_cache.IsEnabled()) {
-		result = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
+		auto result = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
 		buffer = result.Ptr();
 		GetFileHandle().Read(context, buffer, nr_bytes, location);
 		return result;
 	}
 
-	// Try to read from the cache, filling overlapping_ranges in the process
-	vector<shared_ptr<CachedFileRange>> overlapping_ranges;
-	optional_idx start_location_of_next_range;
-	result = TryReadFromCache(buffer, nr_bytes, location, overlapping_ranges, start_location_of_next_range);
-	if (result.IsValid()) {
-		return result; // Success
-	}
+	const idx_t block_size = ExternalFileCache::CACHE_BLOCK_SIZE;
+	const idx_t first_block = location / block_size;
+	const idx_t last_block = (location + nr_bytes - 1) / block_size;
+	const idx_t num_blocks = last_block - first_block + 1;
 
-	idx_t new_nr_bytes = nr_bytes;
-	if (start_location_of_next_range.IsValid()) {
-		const idx_t nr_bytes_to_be_added = start_location_of_next_range.GetIndex() - location - nr_bytes;
-		if (ShouldExpandToFillGap(nr_bytes, nr_bytes_to_be_added)) {
-			// Grow the range from location to start_location_of_next_range, so that to fill gaps in the cached ranges
-			new_nr_bytes = nr_bytes + nr_bytes_to_be_added;
+	// Get-or-create CacheBlock for each block_idx
+	vector<shared_ptr<CacheBlock>> blocks(num_blocks);
+	{
+		annotated_lock_guard<annotated_mutex> guard(cached_file.map_lock);
+		for (idx_t i = 0; i < num_blocks; i++) {
+			const idx_t block_idx = first_block + i;
+			auto &entry = cached_file.blocks[block_idx];
+			if (!entry) {
+				entry = make_shared_ptr<CacheBlock>();
+			}
+			blocks[i] = entry;
 		}
 	}
 
-	// Finally, if we weren't able to find the file range in the cache, we have to create a new file range
-	result = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, new_nr_bytes);
-	auto new_file_range =
-	    make_shared_ptr<CachedFileRange>(result.GetBlockHandle(), new_nr_bytes, location, version_tag);
+	// Ensure the file is open so we have file_size and a valid file_handle for I/O
+	auto &fh = GetFileHandle();
+	const idx_t fs = fh.GetFileSize();
+
+	// Schedule one FetchBlockTask per block
+	vector<BufferHandle> pins(num_blocks);
+	auto &scheduler = TaskScheduler::GetScheduler(caching_file_system.db);
+	TaskExecutor executor(scheduler);
+
+	for (idx_t i = 0; i < num_blocks; i++) {
+		executor.ScheduleTask(make_uniq<FetchBlockTask>(executor, fh, context,
+		                                                external_file_cache.GetBufferManager(), blocks[i],
+		                                                first_block + i, fs, pins[i]));
+	}
+	executor.WorkOnTasks();
+
+	// Assemble result
+	if (num_blocks == 1) {
+		const idx_t offset_in_block = location - first_block * block_size;
+		buffer = pins[0].Ptr() + offset_in_block;
+		return std::move(pins[0]);
+	}
+
+	auto result = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
 	buffer = result.Ptr();
+	idx_t bytes_copied = 0;
 
-	// Interleave reading and copying from cached buffers
-	if (OnDiskFile()) {
-		// On-disk file: prefer interleaving reading and copying from cached buffers
-		ReadAndCopyInterleaved(overlapping_ranges, new_file_range, buffer, new_nr_bytes, location, true);
-	} else {
-		// Remote file: prefer interleaving reading and copying from cached buffers only if reduces number of real
-		// reads
-		if (ReadAndCopyInterleaved(overlapping_ranges, new_file_range, buffer, new_nr_bytes, location, false) <= 1) {
-			ReadAndCopyInterleaved(overlapping_ranges, new_file_range, buffer, new_nr_bytes, location, true);
-		} else {
-			GetFileHandle().Read(context, buffer, new_nr_bytes, location);
-		}
+	for (idx_t i = 0; i < num_blocks; i++) {
+		const idx_t block_start = (first_block + i) * block_size;
+		const idx_t offset_in_block = (i == 0) ? (location - block_start) : 0;
+		const idx_t bytes_to_copy = MinValue(block_size - offset_in_block, nr_bytes - bytes_copied);
+		memcpy(buffer + bytes_copied, pins[i].Ptr() + offset_in_block, bytes_to_copy);
+		bytes_copied += bytes_to_copy;
 	}
 
-	return TryInsertFileRange(result, buffer, new_nr_bytes, location, new_file_range);
+	return result;
 }
 
 BufferHandle CachingFileHandle::Read(data_ptr_t &buffer, idx_t &nr_bytes) {
-	BufferHandle result;
-
-	// If we can't seek, we can't use the cache for these calls,
-	// because we won't be able to seek over any parts we skipped by reading from the cache
 	if (!external_file_cache.IsEnabled() || !CanSeek()) {
-		result = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
+		auto result = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
 		buffer = result.Ptr();
 		nr_bytes = NumericCast<idx_t>(GetFileHandle().Read(context, buffer, nr_bytes));
-		position += NumericCast<idx_t>(nr_bytes);
+		position += nr_bytes;
 		return result;
 	}
 
-	// Try to read from the cache first
-	vector<shared_ptr<CachedFileRange>> overlapping_ranges;
-	{
-		optional_idx start_location_of_next_range;
-		result = TryReadFromCache(buffer, nr_bytes, position, overlapping_ranges, start_location_of_next_range);
-		// start_location_of_next_range is in this case discarded
-	}
-
-	if (result.IsValid()) {
-		position += nr_bytes;
-		return result; // Success
-	}
-
-	// Finally, if we weren't able to find the file range in the cache, we have to create a new file range
-	result = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
-	buffer = result.Ptr();
-
-	GetFileHandle().Seek(position);
-	nr_bytes = NumericCast<idx_t>(GetFileHandle().Read(context, buffer, nr_bytes));
-	auto new_file_range = make_shared_ptr<CachedFileRange>(result.GetBlockHandle(), nr_bytes, position, version_tag);
-
-	result = TryInsertFileRange(result, buffer, nr_bytes, position, new_file_range);
-	position += NumericCast<idx_t>(nr_bytes);
-
+	auto result = Read(buffer, nr_bytes, position);
+	position += nr_bytes;
 	return result;
 }
 
@@ -211,8 +268,8 @@ idx_t CachingFileHandle::GetFileSize() {
 	if (file_handle || Validate()) {
 		return GetFileHandle().GetFileSize();
 	}
-	auto guard = cached_file.lock.GetSharedLock();
-	return cached_file.FileSize(guard);
+	annotated_lock_guard<annotated_mutex> guard(cached_file.meta_lock);
+	return cached_file.file_size;
 }
 
 timestamp_t CachingFileHandle::GetLastModifiedTime() {
@@ -220,8 +277,8 @@ timestamp_t CachingFileHandle::GetLastModifiedTime() {
 		GetFileHandle();
 		return last_modified;
 	}
-	auto guard = cached_file.lock.GetSharedLock();
-	return cached_file.LastModified(guard);
+	annotated_lock_guard<annotated_mutex> guard(cached_file.meta_lock);
+	return cached_file.last_modified;
 }
 
 string CachingFileHandle::GetVersionTag() {
@@ -229,8 +286,8 @@ string CachingFileHandle::GetVersionTag() {
 		GetFileHandle();
 		return version_tag;
 	}
-	auto guard = cached_file.lock.GetSharedLock();
-	return cached_file.VersionTag(guard);
+	annotated_lock_guard<annotated_mutex> guard(cached_file.meta_lock);
+	return cached_file.version_tag;
 }
 
 bool CachingFileHandle::Validate() const {
@@ -241,8 +298,8 @@ bool CachingFileHandle::CanSeek() {
 	if (file_handle || Validate()) {
 		return GetFileHandle().CanSeek();
 	}
-	auto guard = cached_file.lock.GetSharedLock();
-	return cached_file.CanSeek(guard);
+	annotated_lock_guard<annotated_mutex> guard(cached_file.meta_lock);
+	return cached_file.can_seek;
 }
 
 bool CachingFileHandle::IsRemoteFile() const {
@@ -253,16 +310,8 @@ bool CachingFileHandle::OnDiskFile() {
 	if (file_handle || Validate()) {
 		return GetFileHandle().OnDiskFile();
 	}
-	auto guard = cached_file.lock.GetSharedLock();
-	return cached_file.OnDiskFile(guard);
-}
-
-const string &CachingFileHandle::GetVersionTag(const unique_ptr<StorageLockKey> &guard) {
-	if (file_handle || Validate()) {
-		GetFileHandle();
-		return version_tag;
-	}
-	return cached_file.VersionTag(guard);
+	annotated_lock_guard<annotated_mutex> guard(cached_file.meta_lock);
+	return cached_file.on_disk_file;
 }
 
 idx_t CachingFileHandle::SeekPosition() {
@@ -274,196 +323,6 @@ void CachingFileHandle::Seek(idx_t location) {
 	if (file_handle != nullptr) {
 		file_handle->Seek(location);
 	}
-}
-
-BufferHandle CachingFileHandle::TryReadFromCache(data_ptr_t &buffer, idx_t nr_bytes, idx_t location,
-                                                 vector<shared_ptr<CachedFileRange>> &overlapping_ranges,
-                                                 optional_idx &start_location_of_next_range) {
-	BufferHandle result;
-
-	// Get read lock for cached ranges
-	auto guard = cached_file.lock.GetSharedLock();
-	auto &ranges = cached_file.Ranges(guard);
-
-	// First, try to see if we've read from the exact same location before
-	auto it = ranges.find(location);
-	if (it != ranges.end()) {
-		// We have read from the exact same location before
-		if (it->second->GetOverlap(nr_bytes, location) == CachedFileRangeOverlap::FULL) {
-			// The file range contains the requested file range
-			// FIXME: if we ever start persisting this stuff, this read needs to happen outside of the lock
-			result = TryReadFromFileRange(guard, *it->second, buffer, nr_bytes, location);
-			if (result.IsValid()) {
-				return result;
-			}
-		}
-	}
-
-	// Second, loop through file ranges (ordered by location) to see if any contain the requested file range
-	const auto this_end = location + nr_bytes;
-
-	// Start at lower_bound (first range with location not less than location of requested range) minus one
-	// This works because we don't allow fully overlapping ranges in the files
-	it = ranges.lower_bound(location);
-	if (it != ranges.begin()) {
-		--it;
-	}
-	while (it != ranges.end()) {
-		if (it->second->location >= this_end) {
-			// We're past the requested location, we are going to bail out, save start_location_of_next_range
-			start_location_of_next_range = it->second->location;
-			break;
-		}
-		// Check if the cached range overlaps the requested one
-		switch (it->second->GetOverlap(nr_bytes, location)) {
-		case CachedFileRangeOverlap::NONE:
-			// No overlap at all
-			break;
-		case CachedFileRangeOverlap::PARTIAL:
-			// Partial overlap, store for potential use later
-			overlapping_ranges.push_back(it->second);
-			break;
-		case CachedFileRangeOverlap::FULL:
-			// The file range fully contains the requested file range, if the buffer is still valid we're done
-			// FIXME: if we ever start persisting this stuff, this read needs to happen outside of the lock
-			result = TryReadFromFileRange(guard, *it->second, buffer, nr_bytes, location);
-			if (result.IsValid()) {
-				return result;
-			}
-			break;
-		default:
-			throw InternalException("Unknown CachedFileRangeOverlap");
-		}
-		++it;
-	}
-
-	return result;
-}
-
-BufferHandle CachingFileHandle::TryReadFromFileRange(const unique_ptr<StorageLockKey> &guard,
-                                                     CachedFileRange &file_range, data_ptr_t &buffer, idx_t nr_bytes,
-                                                     idx_t location) {
-	D_ASSERT(file_range.GetOverlap(nr_bytes, location) == CachedFileRangeOverlap::FULL);
-	auto result = external_file_cache.GetBufferManager().Pin(file_range.block_handle);
-	if (result.IsValid()) {
-		buffer = result.Ptr() + (location - file_range.location);
-	}
-	return result;
-}
-
-BufferHandle CachingFileHandle::TryInsertFileRange(BufferHandle &pin, data_ptr_t &buffer, idx_t nr_bytes,
-                                                   idx_t location, shared_ptr<CachedFileRange> &new_file_range) {
-	// Grab the lock again (write lock this time) to insert the newly created buffer into the ranges
-	auto guard = cached_file.lock.GetExclusiveLock();
-	auto &ranges = cached_file.Ranges(guard);
-
-	// Start at lower_bound (first range with location not less than location of newly created range)
-	const auto this_end = location + nr_bytes;
-	auto it = ranges.lower_bound(location);
-	if (it != ranges.begin()) {
-		--it;
-	}
-	while (it != ranges.end()) {
-		if (it->second->location >= this_end) {
-			// We're past the requested location
-			break;
-		}
-		if (it->second->GetOverlap(*new_file_range) == CachedFileRangeOverlap::FULL) {
-			// Another thread has read a range that fully contains the requested range in the meantime
-			auto other_pin = TryReadFromFileRange(guard, *it->second, buffer, nr_bytes, location);
-			if (other_pin.IsValid()) {
-				return other_pin;
-			}
-			it = ranges.erase(it);
-			continue;
-		}
-		// Check if the new range overlaps with a cached one
-		switch (new_file_range->GetOverlap(*it->second)) {
-		case CachedFileRangeOverlap::NONE:
-			break; // No overlap, still useful
-		case CachedFileRangeOverlap::PARTIAL:
-			break; // The newly created range does not fully contain this range, so it is still useful
-		case CachedFileRangeOverlap::FULL:
-			// Full overlap, this range will be obsolete when we insert the current one
-			// Since we have the write lock here, we can do some cleanup
-			it = ranges.erase(it);
-			continue;
-		default:
-			throw InternalException("Unknown CachedFileRangeOverlap");
-		}
-
-		++it;
-	}
-	D_ASSERT(pin.IsValid());
-
-	// Finally, insert newly created buffer into the map
-	new_file_range->AddCheckSum();
-	ranges[location] = std::move(new_file_range);
-	cached_file.Verify(guard);
-
-	return std::move(pin);
-}
-
-idx_t CachingFileHandle::ReadAndCopyInterleaved(const vector<shared_ptr<CachedFileRange>> &overlapping_ranges,
-                                                const shared_ptr<CachedFileRange> &new_file_range, data_ptr_t buffer,
-                                                const idx_t nr_bytes, const idx_t location, const bool actually_read) {
-	idx_t non_cached_read_count = 0;
-
-	idx_t current_location = location;
-	idx_t remaining_bytes = nr_bytes;
-	for (auto &overlapping_range : overlapping_ranges) {
-		D_ASSERT(new_file_range->GetOverlap(*overlapping_range) != CachedFileRangeOverlap::NONE);
-
-		if (remaining_bytes == 0) {
-			break; // All requested bytes were read
-		}
-
-		if (overlapping_range->location > current_location) {
-			// We need to read from the file until we're at the location of the current overlapping file range
-			const auto buffer_offset = nr_bytes - remaining_bytes;
-			const auto bytes_to_read = overlapping_range->location - current_location;
-			D_ASSERT(bytes_to_read < remaining_bytes);
-			if (actually_read) {
-				GetFileHandle().Read(context, buffer + buffer_offset, bytes_to_read, current_location);
-			}
-			current_location += bytes_to_read;
-			remaining_bytes -= bytes_to_read;
-			non_cached_read_count++;
-		}
-
-		if (overlapping_range->GetOverlap(remaining_bytes, current_location) == CachedFileRangeOverlap::NONE) {
-			continue; // Remainder does not overlap with the current overlapping file range
-		}
-
-		// Try to pin the current overlapping file range
-		auto overlapping_file_range_pin = external_file_cache.GetBufferManager().Pin(overlapping_range->block_handle);
-		if (!overlapping_file_range_pin.IsValid()) {
-			continue; // No longer valid
-		}
-
-		// Finally, we can copy the data over
-		D_ASSERT(current_location >= overlapping_range->location);
-		const auto buffer_offset = nr_bytes - remaining_bytes;
-		const auto overlapping_range_offset = current_location - overlapping_range->location;
-		D_ASSERT(overlapping_range->nr_bytes > overlapping_range_offset);
-		const auto bytes_to_read = MinValue(overlapping_range->nr_bytes - overlapping_range_offset, remaining_bytes);
-		if (actually_read) {
-			memcpy(buffer + buffer_offset, overlapping_file_range_pin.Ptr() + overlapping_range_offset, bytes_to_read);
-		}
-		current_location += bytes_to_read;
-		remaining_bytes -= bytes_to_read;
-	}
-
-	// Read the remaining bytes (if any)
-	if (remaining_bytes != 0) {
-		const auto buffer_offset = nr_bytes - remaining_bytes;
-		if (actually_read) {
-			GetFileHandle().Read(context, buffer + buffer_offset, remaining_bytes, current_location);
-		}
-		non_cached_read_count++;
-	}
-
-	return non_cached_read_count;
 }
 
 } // namespace duckdb

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -89,7 +89,7 @@ public:
 			}
 			case CacheBlockState::LOADING: {
 				block->cv.wait(lk,
-				               [&] DUCKDB_REQUIRES(block->mtx) { return block->state != CacheBlockState::LOADING; });
+				               [&]() DUCKDB_REQUIRES(block->mtx) { return block->state != CacheBlockState::LOADING; });
 				continue;
 			}
 			case CacheBlockState::ERROR: {

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -264,6 +264,12 @@ FileBufferHandleGroup CachingFileHandle::Read(idx_t &nr_bytes) {
 		return group;
 	}
 
+	const idx_t file_size = GetFileSize();
+	if (position >= file_size) {
+		nr_bytes = 0;
+		return {};
+	}
+	nr_bytes = MinValue(nr_bytes, file_size - position);
 	auto group = Read(nr_bytes, position);
 	position += nr_bytes;
 	return group;

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -44,9 +44,8 @@ public:
 	FetchBlockTask(TaskExecutor &executor, FileHandle &file_handle_p, QueryContext context_p,
 	               BufferManager &buffer_manager_p, shared_ptr<CacheBlock> block_p, idx_t block_idx_p,
 	               idx_t file_size_p, BufferHandle &result_pin_p)
-	    : BaseExecutorTask(executor), file_handle(file_handle_p), context(context_p),
-	      buffer_manager(buffer_manager_p), block(std::move(block_p)), block_idx(block_idx_p),
-	      file_size(file_size_p), result_pin(result_pin_p) {
+	    : BaseExecutorTask(executor), file_handle(file_handle_p), context(context_p), buffer_manager(buffer_manager_p),
+	      block(std::move(block_p)), block_idx(block_idx_p), file_size(file_size_p), result_pin(result_pin_p) {
 	}
 
 	void ExecuteTask() override {
@@ -230,9 +229,8 @@ BufferHandle CachingFileHandle::Read(data_ptr_t &buffer, const idx_t nr_bytes, c
 	TaskExecutor executor(scheduler);
 
 	for (idx_t i = 0; i < num_blocks; i++) {
-		executor.ScheduleTask(make_uniq<FetchBlockTask>(executor, fh, context,
-		                                                external_file_cache.GetBufferManager(), blocks[i],
-		                                                first_block + i, fs, pins[i]));
+		executor.ScheduleTask(make_uniq<FetchBlockTask>(executor, fh, context, external_file_cache.GetBufferManager(),
+		                                                blocks[i], first_block + i, fs, pins[i]));
 	}
 	executor.WorkOnTasks();
 

--- a/src/storage/caching_file_system_wrapper.cpp
+++ b/src/storage/caching_file_system_wrapper.cpp
@@ -157,15 +157,8 @@ void CachingFileSystemWrapper::Read(FileHandle &handle, void *buffer, int64_t nr
 		return underlying_file_system.Read(handle, buffer, nr_bytes, location);
 	}
 
-	data_ptr_t cached_buffer = nullptr;
-	auto buffer_handle = caching_handle->Read(cached_buffer, NumericCast<idx_t>(nr_bytes), location);
-	if (!buffer_handle.IsValid()) {
-		throw IOException("Failed to read from caching file handle: file=\"%s\", offset=%llu, bytes=%lld",
-		                  handle.GetPath().c_str(), location, nr_bytes);
-	}
-
-	// Copy data from cached buffer handle to user's buffer.
-	memcpy(buffer, cached_buffer, NumericCast<size_t>(nr_bytes));
+	auto group = caching_handle->Read(NumericCast<idx_t>(nr_bytes), location);
+	group.CopyTo(static_cast<data_ptr_t>(buffer), NumericCast<idx_t>(nr_bytes));
 }
 
 int64_t CachingFileSystemWrapper::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {

--- a/src/storage/external_file_cache.cpp
+++ b/src/storage/external_file_cache.cpp
@@ -61,10 +61,10 @@ vector<CachedFileInformation> ExternalFileCache::GetCachedFileInformation() cons
 	unique_lock<mutex> files_guard(lock);
 	vector<CachedFileInformation> result;
 	for (const auto &file : cached_files) {
-		idx_t fs;
+		idx_t file_size = 0;
 		{
 			annotated_lock_guard<annotated_mutex> meta_guard(file.second->meta_lock);
-			fs = file.second->file_size;
+			file_size = file.second->file_size;
 		}
 		annotated_lock_guard<annotated_mutex> map_guard(file.second->map_lock);
 		for (const auto &block_entry : file.second->blocks) {
@@ -76,7 +76,7 @@ vector<CachedFileInformation> ExternalFileCache::GetCachedFileInformation() cons
 				continue;
 			}
 			const idx_t location = block_idx * CACHE_BLOCK_SIZE;
-			const idx_t nr_bytes = MinValue(CACHE_BLOCK_SIZE, fs - location);
+			const idx_t nr_bytes = MinValue(CACHE_BLOCK_SIZE, file_size - location);
 			const bool loaded = !block.block_handle->GetMemory().IsUnloaded();
 			result.push_back({file.first, nr_bytes, location, loaded});
 		}

--- a/src/storage/external_file_cache.cpp
+++ b/src/storage/external_file_cache.cpp
@@ -16,8 +16,7 @@ bool ExternalFileCache::CachedFile::IsValid(bool validate, const string &current
 		return true; // Assume valid
 	}
 	annotated_lock_guard<annotated_mutex> guard(meta_lock);
-	return ExternalFileCache::IsValid(validate, version_tag, last_modified, current_version_tag,
-	                                  current_last_modified);
+	return ExternalFileCache::IsValid(validate, version_tag, last_modified, current_version_tag, current_last_modified);
 }
 
 bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,

--- a/src/storage/external_file_cache.cpp
+++ b/src/storage/external_file_cache.cpp
@@ -1,6 +1,5 @@
 #include "duckdb/storage/external_file_cache.hpp"
 
-#include "duckdb/common/checksum.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
@@ -8,70 +7,17 @@
 
 namespace duckdb {
 
-ExternalFileCache::CachedFileRange::CachedFileRange(shared_ptr<BlockHandle> block_handle_p, idx_t nr_bytes_p,
-                                                    idx_t location_p, string version_tag_p)
-    : block_handle(std::move(block_handle_p)), nr_bytes(nr_bytes_p), location(location_p),
-      version_tag(std::move(version_tag_p)) {
+ExternalFileCache::CachedFile::CachedFile(string path_p) : path(std::move(path_p)) {
 }
 
-ExternalFileCache::CachedFileRange::~CachedFileRange() {
-	VerifyCheckSum();
-}
-
-ExternalFileCache::CachedFileRangeOverlap
-ExternalFileCache::CachedFileRange::GetOverlap(const idx_t other_nr_bytes, const idx_t other_location) const {
-	const auto this_end = this->location + this->nr_bytes;
-	const auto other_end = other_nr_bytes + other_location;
-	if (this->location <= other_location && this_end >= other_end) {
-		return CachedFileRangeOverlap::FULL;
+bool ExternalFileCache::CachedFile::IsValid(bool validate, const string &current_version_tag,
+                                            timestamp_t current_last_modified) {
+	if (!validate) {
+		return true; // Assume valid
 	}
-	if (this->location < other_end && other_location < this_end) {
-		return CachedFileRangeOverlap::PARTIAL;
-	}
-	return CachedFileRangeOverlap::NONE;
-}
-
-ExternalFileCache::CachedFileRangeOverlap
-ExternalFileCache::CachedFileRange::GetOverlap(const CachedFileRange &other) const {
-	return GetOverlap(other.nr_bytes, other.location);
-}
-
-void ExternalFileCache::CachedFileRange::AddCheckSum() {
-#ifdef DEBUG
-	D_ASSERT(checksum == 0);
-	auto buffer_handle = block_handle->GetMemory().GetBufferManager().Pin(block_handle);
-	checksum = Checksum(buffer_handle.Ptr(), nr_bytes);
-#endif
-}
-
-void ExternalFileCache::CachedFileRange::VerifyCheckSum() {
-#ifdef DEBUG
-	if (checksum == 0) {
-		return;
-	}
-	auto buffer_handle = block_handle->GetMemory().GetBufferManager().Pin(block_handle);
-	if (!buffer_handle.IsValid()) {
-		return;
-	}
-	D_ASSERT(checksum == Checksum(buffer_handle.Ptr(), nr_bytes));
-#endif
-}
-
-ExternalFileCache::CachedFile::CachedFile(string path_p)
-    : path(std::move(path_p)), file_size(0), last_modified(0), can_seek(false), on_disk_file(false) {
-}
-
-void ExternalFileCache::CachedFile::Verify(const unique_ptr<StorageLockKey> &guard) const {
-#ifdef DEBUG
-	for (const auto &range1 : ranges) {
-		for (const auto &range2 : ranges) {
-			if (range1.first == range2.first) {
-				continue;
-			}
-			D_ASSERT(range1.second->GetOverlap(*range2.second) != CachedFileRangeOverlap::FULL);
-		}
-	}
-#endif
+	annotated_lock_guard<annotated_mutex> guard(meta_lock);
+	return ExternalFileCache::IsValid(validate, version_tag, last_modified, current_version_tag,
+	                                  current_last_modified);
 }
 
 bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
@@ -96,40 +42,6 @@ bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag,
 	return access_time - current_last_modified > LAST_MODIFIED_THRESHOLD;
 }
 
-bool ExternalFileCache::CachedFile::IsValid(const unique_ptr<StorageLockKey> &guard, bool validate,
-                                            const string &current_version_tag, timestamp_t current_last_modified) {
-	if (!validate) {
-		return true; // Assume valid
-	}
-	return ExternalFileCache::IsValid(validate, VersionTag(guard), LastModified(guard), current_version_tag,
-	                                  current_last_modified);
-}
-
-idx_t &ExternalFileCache::CachedFile::FileSize(const unique_ptr<StorageLockKey> &guard) {
-	return file_size;
-}
-
-timestamp_t &ExternalFileCache::CachedFile::LastModified(const unique_ptr<StorageLockKey> &guard) {
-	return last_modified;
-}
-
-string &ExternalFileCache::CachedFile::VersionTag(const unique_ptr<StorageLockKey> &guard) {
-	return version_tag;
-}
-
-bool &ExternalFileCache::CachedFile::CanSeek(const unique_ptr<StorageLockKey> &guard) {
-	return can_seek;
-}
-
-bool &ExternalFileCache::CachedFile::OnDiskFile(const unique_ptr<StorageLockKey> &guard) {
-	return on_disk_file;
-}
-
-map<idx_t, shared_ptr<ExternalFileCache::CachedFileRange>> &
-ExternalFileCache::CachedFile::Ranges(const unique_ptr<StorageLockKey> &guard) {
-	return ranges;
-}
-
 ExternalFileCache::ExternalFileCache(DatabaseInstance &db, bool enable_p)
     : buffer_manager(BufferManager::GetBufferManager(db)), enable(enable_p) {
 }
@@ -150,11 +62,24 @@ vector<CachedFileInformation> ExternalFileCache::GetCachedFileInformation() cons
 	unique_lock<mutex> files_guard(lock);
 	vector<CachedFileInformation> result;
 	for (const auto &file : cached_files) {
-		auto ranges_guard = file.second->lock.GetSharedLock();
-		for (const auto &range_entry : file.second->Ranges(ranges_guard)) {
-			const auto &range = *range_entry.second;
-			result.push_back(
-			    {file.first, range.nr_bytes, range.location, !range.block_handle->GetMemory().IsUnloaded()});
+		idx_t fs;
+		{
+			annotated_lock_guard<annotated_mutex> meta_guard(file.second->meta_lock);
+			fs = file.second->file_size;
+		}
+		annotated_lock_guard<annotated_mutex> map_guard(file.second->map_lock);
+		for (const auto &block_entry : file.second->blocks) {
+			const idx_t block_idx = block_entry.first;
+			const auto &block = *block_entry.second;
+
+			annotated_lock_guard<annotated_mutex> block_guard(block.mtx);
+			if (block.state != CacheBlockState::LOADED || !block.block_handle) {
+				continue;
+			}
+			const idx_t location = block_idx * CACHE_BLOCK_SIZE;
+			const idx_t nr_bytes = MinValue(CACHE_BLOCK_SIZE, fs - location);
+			const bool loaded = !block.block_handle->GetMemory().IsUnloaded();
+			result.push_back({file.first, nr_bytes, location, loaded});
 		}
 	}
 	return result;

--- a/src/storage/file_buffer_handle_group.cpp
+++ b/src/storage/file_buffer_handle_group.cpp
@@ -27,8 +27,4 @@ data_ptr_t FileBufferHandleGroup::Ptr() const {
 	return handles[0].handle.Ptr() + handles[0].start_offset;
 }
 
-bool FileBufferHandleGroup::IsOneHandle() const {
-	return handles.size() == 1;
-}
-
 } // namespace duckdb

--- a/src/storage/file_buffer_handle_group.cpp
+++ b/src/storage/file_buffer_handle_group.cpp
@@ -4,6 +4,13 @@
 
 namespace duckdb {
 
+FileBufferHandleGroup::FileBufferHandleGroup(vector<MemoryHandle> handles_p) : handles(std::move(handles_p)) {
+}
+
+const vector<FileBufferHandleGroup::MemoryHandle> &FileBufferHandleGroup::GetHandles() const {
+	return handles;
+}
+
 void FileBufferHandleGroup::CopyTo(data_ptr_t dest, idx_t nr_bytes) const {
 	idx_t copied = 0;
 	for (auto &mh : handles) {

--- a/src/storage/file_buffer_handle_group.cpp
+++ b/src/storage/file_buffer_handle_group.cpp
@@ -1,0 +1,34 @@
+#include "duckdb/storage/file_buffer_handle_group.hpp"
+
+#include "duckdb/common/exception.hpp"
+
+namespace duckdb {
+
+void FileBufferHandleGroup::CopyTo(data_ptr_t dest, idx_t nr_bytes) const {
+	idx_t copied = 0;
+	for (auto &mh : handles) {
+		if (copied >= nr_bytes) {
+			break;
+		}
+		const idx_t to_copy = MinValue(mh.length, nr_bytes - copied);
+		memcpy(dest + copied, mh.handle.Ptr() + mh.start_offset, to_copy);
+		copied += to_copy;
+	}
+	if (copied != nr_bytes) {
+		throw InternalException("FileBufferHandleGroup::CopyTo: handles contain %llu bytes but %llu were requested",
+		                        copied, nr_bytes);
+	}
+}
+
+data_ptr_t FileBufferHandleGroup::Ptr() const {
+	if (handles.size() != 1) {
+		throw InternalException("FileBufferHandleGroup::Ptr() requires exactly one handle, got %llu", handles.size());
+	}
+	return handles[0].handle.Ptr() + handles[0].start_offset;
+}
+
+bool FileBufferHandleGroup::IsOneHandle() const {
+	return handles.size() == 1;
+}
+
+} // namespace duckdb

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library_unity(
   OBJECT
   test_cast.cpp
   test_checksum.cpp
+  test_file_buffer_handle_group.cpp
   test_file_system.cpp
   test_caching_file_system_wrapper.cpp
   test_hyperlog.cpp

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -662,4 +662,65 @@ TEST_CASE("CachingFileSystemWrapper zero-byte read", "[file_system][caching]") {
 	REQUIRE_NOTHROW(handle->Read(QueryContext(), &buffer[0], /*nr_bytes=*/0, /*location=*/10));
 }
 
+TEST_CASE("CachingFileHandle Read returns correct FileBufferHandleGroup", "[file_system][caching]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto tracking_fs = make_uniq<TrackingFileSystem>();
+
+	const idx_t BLOCK_SIZE = ExternalFileCache::CACHE_BLOCK_SIZE;
+	const idx_t EXTRA = 100;
+	const idx_t FILE_SIZE = BLOCK_SIZE + EXTRA;
+
+	string content(FILE_SIZE, '\0');
+	for (idx_t i = 0; i < FILE_SIZE; i++) {
+		content[i] = static_cast<char>('A' + (i % 26));
+	}
+	TestFileGuard test_file("test_multi_block.bin", content);
+
+	CachingFileSystem cfs(*tracking_fs, db_instance);
+	OpenFileInfo file_info(test_file.GetPath());
+	file_info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+	file_info.extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
+
+	auto handle = cfs.OpenFile(file_info, FileFlags::FILE_FLAGS_READ);
+
+	// Full file read: should produce 2 handles
+	{
+		auto group = handle->Read(FILE_SIZE, 0);
+		REQUIRE(group.handles.size() == 2);
+		REQUIRE(group.handles[0].start_offset == 0);
+		REQUIRE(group.handles[0].length == BLOCK_SIZE);
+		REQUIRE(group.handles[1].start_offset == 0);
+		REQUIRE(group.handles[1].length == EXTRA);
+
+		string result(FILE_SIZE, '\0');
+		group.CopyTo(reinterpret_cast<data_ptr_t>(result.data()), FILE_SIZE);
+		REQUIRE(result == content);
+	}
+
+	// Cross-boundary read: last 200 bytes of block 0 + first 50 bytes of block 1
+	{
+		const idx_t read_offset = BLOCK_SIZE - 200;
+		const idx_t read_size = 250;
+		auto group = handle->Read(read_size, read_offset);
+		REQUIRE(group.handles.size() == 2);
+		REQUIRE(group.handles[0].start_offset == BLOCK_SIZE - 200);
+		REQUIRE(group.handles[0].length == 200);
+		REQUIRE(group.handles[1].start_offset == 0);
+		REQUIRE(group.handles[1].length == 50);
+
+		string result(read_size, '\0');
+		group.CopyTo(reinterpret_cast<data_ptr_t>(result.data()), read_size);
+		REQUIRE(result == content.substr(read_offset, read_size));
+	}
+
+	// Single block read: should produce 1 handle
+	{
+		auto group = handle->Read(100, 0);
+		REQUIRE(group.handles.size() == 1);
+		REQUIRE(group.handles[0].start_offset == 0);
+		REQUIRE(group.handles[0].length == 100);
+	}
+}
+
 } // namespace duckdb

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -80,7 +80,7 @@ public:
 		idx_t size;
 	};
 
-	mutable std::mutex read_calls_mutex;
+	mutable mutex read_calls_mutex;
 	vector<ReadCall> read_calls;
 
 	string GetName() const override {
@@ -415,7 +415,7 @@ TEST_CASE("CachingFileSystemWrapper read with parallel accesses", "[file_system]
 	const string test_content =
 	    "Test content for parallel read access. This is a longer string to allow multiple reads.";
 	TestFileGuard test_file("test_caching_parallel.txt", test_content);
-	constexpr idx_t THREAD_COUNT = 2;
+	constexpr idx_t THREAD_COUNT = 8;
 
 	// Open file with parallel access flag - single handle shared by all threads
 	OpenFileInfo file_info(test_file.GetPath());
@@ -424,34 +424,20 @@ TEST_CASE("CachingFileSystemWrapper read with parallel accesses", "[file_system]
 	auto shared_handle =
 	    caching_wrapper->OpenFile(file_info, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_PARALLEL_ACCESS);
 
-	// Use two threads to read from the same file handle in parallel using pread semantics
+	// Use multiple threads to read from the same file handle in parallel using pread semantics
 	vector<std::thread> threads;
-	std::mutex results_mutex;
-	vector<bool> results(THREAD_COUNT, false);
-
 	const idx_t chunk_size = 20;
 	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
 		threads.emplace_back([&, idx]() {
 			const idx_t read_location = idx * chunk_size;
 			string buffer(TEST_BUFFER_SIZE, '\0');
 			shared_handle->Read(QueryContext(), &buffer[0], chunk_size, read_location);
-			bool result = (buffer.substr(0, chunk_size) == test_content.substr(read_location, chunk_size));
-			{
-				const lock_guard<mutex> lock(results_mutex);
-				results[idx] = result;
-			}
+			REQUIRE(buffer.substr(0, chunk_size) == test_content.substr(read_location, chunk_size));
 		});
 	}
 	for (auto &thd : threads) {
-		REQUIRE(thd.joinable());
 		thd.join();
 	}
-
-	// Verify both threads read correctly from the same handle
-	REQUIRE(results[0]);
-	REQUIRE(results[1]);
-
-	shared_handle.reset();
 }
 
 // Testing scenario: mimic open file with duckdb instance, which open a file goes through opener filesystem, meanwhile
@@ -541,8 +527,7 @@ TEST_CASE("CachingFileSystemWrapper concurrent reads same block", "[file_system]
 
 	tracking_fs_ptr->Clear();
 
-	std::mutex results_mutex;
-	vector<bool> results(THREAD_COUNT, false);
+	mutex results_mutex;
 	vector<std::thread> threads;
 
 	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
@@ -550,19 +535,11 @@ TEST_CASE("CachingFileSystemWrapper concurrent reads same block", "[file_system]
 			auto handle = caching_wrapper->OpenFile(file_info, FileFlags::FILE_FLAGS_READ);
 			string buffer(TEST_BUFFER_SIZE, '\0');
 			handle->Read(QueryContext(), &buffer[0], test_content.size(), /*location=*/0);
-			bool ok = (buffer.substr(0, test_content.size()) == test_content);
-			{
-				const lock_guard<mutex> lock(results_mutex);
-				results[idx] = ok;
-			}
+			REQUIRE(buffer.substr(0, test_content.size()) == test_content);
 		});
 	}
 	for (auto &thd : threads) {
 		thd.join();
-	}
-
-	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
-		REQUIRE(results[idx]);
 	}
 
 	REQUIRE(tracking_fs_ptr->GetReadCount(test_file.GetPath(), 0, test_content.size()) == 1);
@@ -586,8 +563,6 @@ TEST_CASE("CachingFileSystemWrapper IO error propagates to waiters", "[file_syst
 	failing_fs_ptr->SetShouldFail(true);
 
 	constexpr idx_t THREAD_COUNT = 4;
-	std::mutex results_mutex;
-	vector<bool> got_error(THREAD_COUNT, false);
 	vector<std::thread> threads;
 
 	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
@@ -596,18 +571,13 @@ TEST_CASE("CachingFileSystemWrapper IO error propagates to waiters", "[file_syst
 				auto handle = caching_wrapper->OpenFile(file_info, FileFlags::FILE_FLAGS_READ);
 				string buffer(TEST_BUFFER_SIZE, '\0');
 				handle->Read(QueryContext(), &buffer[0], test_content.size(), /*location=*/0);
+				REQUIRE(false);
 			} catch (...) {
-				const lock_guard<mutex> lock(results_mutex);
-				got_error[idx] = true;
 			}
 		});
 	}
 	for (auto &thd : threads) {
 		thd.join();
-	}
-
-	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
-		REQUIRE(got_error[idx]);
 	}
 }
 

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/opener_file_system.hpp"
 #include "duckdb/common/string.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/thread_annotation.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/storage/caching_file_system_wrapper.hpp"
@@ -11,38 +13,40 @@
 
 #include <thread>
 
-namespace {
+namespace duckdb {
+
 constexpr idx_t TEST_BUFFER_SIZE = 200;
 
-class FailingFileSystem : public duckdb::LocalFileSystem {
+class FailingFileSystem : public LocalFileSystem {
 public:
-	mutable std::mutex mu;
-	bool should_fail = false;
+	mutable annotated_mutex mu;
+	bool should_fail DUCKDB_GUARDED_BY(mu) = false;
 
-	duckdb::string GetName() const override {
+	string GetName() const override {
 		return "FailingFileSystem";
 	}
 
-	void Read(duckdb::FileHandle &handle, void *buffer, int64_t nr_bytes, duckdb::idx_t location) override {
-		const std::lock_guard<std::mutex> lock(mu);
+	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, duckdb::idx_t location) override {
+		const annotated_lock_guard<duckdb::annotated_mutex> lock(mu);
 		if (should_fail) {
-			throw duckdb::IOException("Injected read failure");
+			throw IOException("Injected read failure");
 		}
 		LocalFileSystem::Read(handle, buffer, nr_bytes, location);
 	}
 
-	bool CanHandleFile(const duckdb::string &path) override {
-		return duckdb::StringUtil::StartsWith(path, duckdb::TestDirectoryPath());
+	void SetShouldFail(bool value) DUCKDB_EXCLUDES(mu) {
+		const annotated_lock_guard<duckdb::annotated_mutex> lock(mu);
+		should_fail = value;
+	}
+
+	bool CanHandleFile(const string &path) override {
+		return StringUtil::StartsWith(path, TestDirectoryPath());
 	}
 
 	bool CanSeek() override {
 		return true;
 	}
 };
-
-} // namespace
-
-namespace duckdb {
 
 // RAII wrapper for test file creation and cleanup
 class TestFileGuard {
@@ -579,7 +583,7 @@ TEST_CASE("CachingFileSystemWrapper IO error propagates to waiters", "[file_syst
 	file_info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
 	file_info.extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
 
-	failing_fs_ptr->should_fail = true;
+	failing_fs_ptr->SetShouldFail(true);
 
 	constexpr idx_t THREAD_COUNT = 4;
 	std::mutex results_mutex;

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -413,7 +413,8 @@ TEST_CASE("CachingFileSystemWrapper read with parallel accesses", "[file_system]
 	    make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
 
 	const string test_content =
-	    "Test content for parallel read access. This is a longer string to allow multiple reads.";
+	    "Test content for parallel read access. This is a longer string to allow multiple reads."
+	    " Adding more content so that eight threads can each read twenty bytes without going past the end of the file.";
 	TestFileGuard test_file("test_caching_parallel.txt", test_content);
 	constexpr idx_t THREAD_COUNT = 8;
 

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -581,6 +581,39 @@ TEST_CASE("CachingFileSystemWrapper IO error propagates to waiters", "[file_syst
 	}
 }
 
+TEST_CASE("CachingFileSystemWrapper transient IO error recovery", "[file_system][caching]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto failing_fs = make_uniq<FailingFileSystem>();
+	auto failing_fs_ptr = failing_fs.get();
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*failing_fs, db_instance, CachingMode::ALWAYS_CACHE);
+
+	const string test_content = "Transient error recovery test content for caching file system.";
+	TestFileGuard test_file("test_caching_transient.txt", test_content);
+
+	OpenFileInfo file_info(test_file.GetPath());
+	file_info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+	file_info.extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
+
+	// First attempt: fail
+	failing_fs_ptr->SetShouldFail(true);
+	{
+		auto handle = caching_wrapper->OpenFile(file_info, FileFlags::FILE_FLAGS_READ);
+		string buffer(TEST_BUFFER_SIZE, '\0');
+		REQUIRE_THROWS(handle->Read(QueryContext(), &buffer[0], test_content.size(), /*location=*/0));
+	}
+
+	// Second attempt: succeed after clearing the failure
+	failing_fs_ptr->SetShouldFail(false);
+	{
+		auto handle = caching_wrapper->OpenFile(file_info, FileFlags::FILE_FLAGS_READ);
+		string buffer(TEST_BUFFER_SIZE, '\0');
+		REQUIRE_NOTHROW(handle->Read(QueryContext(), &buffer[0], test_content.size(), /*location=*/0));
+		REQUIRE(buffer.substr(0, test_content.size()) == test_content);
+	}
+}
+
 TEST_CASE("CachingFileSystemWrapper zero-byte read", "[file_system][caching]") {
 	DuckDB db(":memory:");
 	auto &db_instance = *db.instance;

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -607,4 +607,25 @@ TEST_CASE("CachingFileSystemWrapper IO error propagates to waiters", "[file_syst
 	}
 }
 
+TEST_CASE("CachingFileSystemWrapper zero-byte read", "[file_system][caching]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto tracking_fs = make_uniq<TrackingFileSystem>();
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
+
+	const string test_content = "Some content for zero-byte read testing.";
+	TestFileGuard test_file("test_caching_zero_read.txt", test_content);
+
+	OpenFileInfo file_info(test_file.GetPath());
+	file_info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+	file_info.extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
+
+	auto handle = caching_wrapper->OpenFile(file_info, FileFlags::FILE_FLAGS_READ);
+	string buffer(TEST_BUFFER_SIZE, '\0');
+
+	REQUIRE_NOTHROW(handle->Read(QueryContext(), &buffer[0], /*nr_bytes=*/0, /*location=*/0));
+	REQUIRE_NOTHROW(handle->Read(QueryContext(), &buffer[0], /*nr_bytes=*/0, /*location=*/10));
+}
+
 } // namespace duckdb

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -212,9 +212,9 @@ TEST_CASE("CachingFileSystemWrapper caches reads", "[file_system][caching]") {
 		handle3->Read(QueryContext(), &buffer3[0], chunk_size, /*location=*/0);
 		handle3.reset();
 
-		// Verify underlying FS access
-		REQUIRE(tracking_fs_ptr->GetReadCount(test_file2.GetPath(), 0, chunk_size) == 1);
-		REQUIRE(tracking_fs_ptr->GetReadCount(test_file2.GetPath(), chunk_size, chunk_size) == 1);
+		// With block-aligned caching, both 20-byte reads fall within block 0.
+		// Only one underlying read of the full file at offset 0.
+		REQUIRE(tracking_fs_ptr->GetReadCount(test_file2.GetPath(), 0, test_content2.size()) == 1);
 	}
 }
 
@@ -489,6 +489,52 @@ TEST_CASE("Request over-sized range read", "[file_system][caching]") {
 	const idx_t actual_read = handle->Read(QueryContext(), &buffer[0], test_content.length() + 1);
 	REQUIRE(actual_read == test_content.length());
 	REQUIRE(buffer.substr(0, test_content.length()) == test_content);
+}
+
+TEST_CASE("CachingFileSystemWrapper concurrent reads same block", "[file_system][caching]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto tracking_fs = make_uniq<TrackingFileSystem>();
+	auto tracking_fs_ptr = tracking_fs.get();
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
+
+	const string test_content =
+	    "Test content for concurrent same-block access. All threads read the same region of this file.";
+	TestFileGuard test_file("test_caching_concurrent_block.txt", test_content);
+	constexpr idx_t THREAD_COUNT = 8;
+
+	OpenFileInfo file_info(test_file.GetPath());
+	file_info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+	file_info.extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
+
+	tracking_fs_ptr->Clear();
+
+	std::mutex results_mutex;
+	vector<bool> results(THREAD_COUNT, false);
+	vector<std::thread> threads;
+
+	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
+		threads.emplace_back([&, idx]() {
+			auto handle = caching_wrapper->OpenFile(file_info, FileFlags::FILE_FLAGS_READ);
+			string buffer(TEST_BUFFER_SIZE, '\0');
+			handle->Read(QueryContext(), &buffer[0], test_content.size(), /*location=*/0);
+			bool ok = (buffer.substr(0, test_content.size()) == test_content);
+			{
+				const lock_guard<mutex> lock(results_mutex);
+				results[idx] = ok;
+			}
+		});
+	}
+	for (auto &thd : threads) {
+		thd.join();
+	}
+
+	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
+		REQUIRE(results[idx]);
+	}
+
+	REQUIRE(tracking_fs_ptr->GetReadCount(test_file.GetPath(), 0, test_content.size()) == 1);
 }
 
 } // namespace duckdb

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -687,14 +687,15 @@ TEST_CASE("CachingFileHandle Read returns correct FileBufferHandleGroup", "[file
 	// Full file read: should produce 2 handles
 	{
 		auto group = handle->Read(FILE_SIZE, 0);
-		REQUIRE(group.handles.size() == 2);
-		REQUIRE(group.handles[0].start_offset == 0);
-		REQUIRE(group.handles[0].length == BLOCK_SIZE);
-		REQUIRE(group.handles[1].start_offset == 0);
-		REQUIRE(group.handles[1].length == EXTRA);
+		auto &handles = group.GetHandles();
+		REQUIRE(handles.size() == 2);
+		REQUIRE(handles[0].start_offset == 0);
+		REQUIRE(handles[0].length == BLOCK_SIZE);
+		REQUIRE(handles[1].start_offset == 0);
+		REQUIRE(handles[1].length == EXTRA);
 
 		string result(FILE_SIZE, '\0');
-		group.CopyTo(reinterpret_cast<data_ptr_t>(result.data()), FILE_SIZE);
+		group.CopyTo(reinterpret_cast<data_ptr_t>(&result[0]), FILE_SIZE);
 		REQUIRE(result == content);
 	}
 
@@ -703,23 +704,25 @@ TEST_CASE("CachingFileHandle Read returns correct FileBufferHandleGroup", "[file
 		const idx_t read_offset = BLOCK_SIZE - 200;
 		const idx_t read_size = 250;
 		auto group = handle->Read(read_size, read_offset);
-		REQUIRE(group.handles.size() == 2);
-		REQUIRE(group.handles[0].start_offset == BLOCK_SIZE - 200);
-		REQUIRE(group.handles[0].length == 200);
-		REQUIRE(group.handles[1].start_offset == 0);
-		REQUIRE(group.handles[1].length == 50);
+		auto &handles = group.GetHandles();
+		REQUIRE(handles.size() == 2);
+		REQUIRE(handles[0].start_offset == BLOCK_SIZE - 200);
+		REQUIRE(handles[0].length == 200);
+		REQUIRE(handles[1].start_offset == 0);
+		REQUIRE(handles[1].length == 50);
 
 		string result(read_size, '\0');
-		group.CopyTo(reinterpret_cast<data_ptr_t>(result.data()), read_size);
+		group.CopyTo(reinterpret_cast<data_ptr_t>(&result[0]), read_size);
 		REQUIRE(result == content.substr(read_offset, read_size));
 	}
 
 	// Single block read: should produce 1 handle
 	{
 		auto group = handle->Read(100, 0);
-		REQUIRE(group.handles.size() == 1);
-		REQUIRE(group.handles[0].start_offset == 0);
-		REQUIRE(group.handles[0].length == 100);
+		auto &handles = group.GetHandles();
+		REQUIRE(handles.size() == 1);
+		REQUIRE(handles[0].start_offset == 0);
+		REQUIRE(handles[0].length == 100);
 	}
 }
 

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -427,17 +427,28 @@ TEST_CASE("CachingFileSystemWrapper read with parallel accesses", "[file_system]
 
 	// Use multiple threads to read from the same file handle in parallel using pread semantics
 	vector<std::thread> threads;
+	mutex results_mutex;
+	vector<bool> results(THREAD_COUNT, false);
+
 	const idx_t chunk_size = 20;
 	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
 		threads.emplace_back([&, idx]() {
 			const idx_t read_location = idx * chunk_size;
 			string buffer(TEST_BUFFER_SIZE, '\0');
 			shared_handle->Read(QueryContext(), &buffer[0], chunk_size, read_location);
-			REQUIRE(buffer.substr(0, chunk_size) == test_content.substr(read_location, chunk_size));
+			const bool ok = (buffer.substr(0, chunk_size) == test_content.substr(read_location, chunk_size));
+			{
+				const lock_guard<mutex> lock(results_mutex);
+				results[idx] = ok;
+			}
 		});
 	}
 	for (auto &thd : threads) {
 		thd.join();
+	}
+
+	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
+		REQUIRE(results[idx]);
 	}
 }
 
@@ -529,6 +540,7 @@ TEST_CASE("CachingFileSystemWrapper concurrent reads same block", "[file_system]
 	tracking_fs_ptr->Clear();
 
 	mutex results_mutex;
+	vector<bool> results(THREAD_COUNT, false);
 	vector<std::thread> threads;
 
 	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
@@ -536,13 +548,20 @@ TEST_CASE("CachingFileSystemWrapper concurrent reads same block", "[file_system]
 			auto handle = caching_wrapper->OpenFile(file_info, FileFlags::FILE_FLAGS_READ);
 			string buffer(TEST_BUFFER_SIZE, '\0');
 			handle->Read(QueryContext(), &buffer[0], test_content.size(), /*location=*/0);
-			REQUIRE(buffer.substr(0, test_content.size()) == test_content);
+			bool ok = (buffer.substr(0, test_content.size()) == test_content);
+			{
+				const lock_guard<mutex> lock(results_mutex);
+				results[idx] = ok;
+			}
 		});
 	}
 	for (auto &thd : threads) {
 		thd.join();
 	}
 
+	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
+		REQUIRE(results[idx]);
+	}
 	REQUIRE(tracking_fs_ptr->GetReadCount(test_file.GetPath(), 0, test_content.size()) == 1);
 }
 
@@ -564,6 +583,8 @@ TEST_CASE("CachingFileSystemWrapper IO error propagates to waiters", "[file_syst
 	failing_fs_ptr->SetShouldFail(true);
 
 	constexpr idx_t THREAD_COUNT = 4;
+	mutex results_mutex;
+	vector<bool> got_error(THREAD_COUNT, false);
 	vector<std::thread> threads;
 
 	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
@@ -572,13 +593,18 @@ TEST_CASE("CachingFileSystemWrapper IO error propagates to waiters", "[file_syst
 				auto handle = caching_wrapper->OpenFile(file_info, FileFlags::FILE_FLAGS_READ);
 				string buffer(TEST_BUFFER_SIZE, '\0');
 				handle->Read(QueryContext(), &buffer[0], test_content.size(), /*location=*/0);
-				REQUIRE(false);
 			} catch (...) {
+				const lock_guard<mutex> lock(results_mutex);
+				got_error[idx] = true;
 			}
 		});
 	}
 	for (auto &thd : threads) {
 		thd.join();
+	}
+
+	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
+		REQUIRE(got_error[idx]);
 	}
 }
 

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -13,6 +13,33 @@
 
 namespace {
 constexpr idx_t TEST_BUFFER_SIZE = 200;
+
+class FailingFileSystem : public duckdb::LocalFileSystem {
+public:
+	mutable std::mutex mu;
+	bool should_fail = false;
+
+	duckdb::string GetName() const override {
+		return "FailingFileSystem";
+	}
+
+	void Read(duckdb::FileHandle &handle, void *buffer, int64_t nr_bytes, duckdb::idx_t location) override {
+		const std::lock_guard<std::mutex> lock(mu);
+		if (should_fail) {
+			throw duckdb::IOException("Injected read failure");
+		}
+		LocalFileSystem::Read(handle, buffer, nr_bytes, location);
+	}
+
+	bool CanHandleFile(const duckdb::string &path) override {
+		return duckdb::StringUtil::StartsWith(path, duckdb::TestDirectoryPath());
+	}
+
+	bool CanSeek() override {
+		return true;
+	}
+};
+
 } // namespace
 
 namespace duckdb {
@@ -535,6 +562,49 @@ TEST_CASE("CachingFileSystemWrapper concurrent reads same block", "[file_system]
 	}
 
 	REQUIRE(tracking_fs_ptr->GetReadCount(test_file.GetPath(), 0, test_content.size()) == 1);
+}
+
+TEST_CASE("CachingFileSystemWrapper IO error propagates to waiters", "[file_system][caching]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto failing_fs = make_uniq<FailingFileSystem>();
+	auto failing_fs_ptr = failing_fs.get();
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*failing_fs, db_instance, CachingMode::ALWAYS_CACHE);
+
+	const string test_content = "Test content for IO error propagation testing across multiple threads.";
+	TestFileGuard test_file("test_caching_io_error.txt", test_content);
+
+	OpenFileInfo file_info(test_file.GetPath());
+	file_info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+	file_info.extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
+
+	failing_fs_ptr->should_fail = true;
+
+	constexpr idx_t THREAD_COUNT = 4;
+	std::mutex results_mutex;
+	vector<bool> got_error(THREAD_COUNT, false);
+	vector<std::thread> threads;
+
+	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
+		threads.emplace_back([&, idx]() {
+			try {
+				auto handle = caching_wrapper->OpenFile(file_info, FileFlags::FILE_FLAGS_READ);
+				string buffer(TEST_BUFFER_SIZE, '\0');
+				handle->Read(QueryContext(), &buffer[0], test_content.size(), /*location=*/0);
+			} catch (...) {
+				const lock_guard<mutex> lock(results_mutex);
+				got_error[idx] = true;
+			}
+		});
+	}
+	for (auto &thd : threads) {
+		thd.join();
+	}
+
+	for (size_t idx = 0; idx < THREAD_COUNT; ++idx) {
+		REQUIRE(got_error[idx]);
+	}
 }
 
 } // namespace duckdb

--- a/test/common/test_file_buffer_handle_group.cpp
+++ b/test/common/test_file_buffer_handle_group.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "duckdb/common/array.hpp"
+#include "duckdb/common/vector.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/file_buffer_handle_group.hpp"
@@ -7,7 +8,7 @@
 
 #include <cstring>
 
-using namespace duckdb;
+namespace duckdb {
 
 namespace {
 BufferHandle AllocateAndFill(BufferManager &bm, idx_t size, uint8_t fill) {
@@ -28,8 +29,9 @@ TEST_CASE("FileBufferHandleGroup copy with single handle", "[file_buffer_handle_
 		handle.Ptr()[i] = static_cast<uint8_t>(i & 0xFF);
 	}
 
-	FileBufferHandleGroup group;
-	group.handles.push_back({std::move(handle), /*start_offset=*/0, /*length=*/BUF_SIZE});
+	vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
+	mem_handles.push_back({std::move(handle), /*start_offset=*/0, /*length=*/BUF_SIZE});
+	FileBufferHandleGroup group(std::move(mem_handles));
 
 	array<uint8_t, 64> dest {};
 	group.CopyTo(dest.data(), dest.size());
@@ -49,9 +51,10 @@ TEST_CASE("FileBufferHandleGroup copy with single handle with offset", "[file_bu
 		handle.Ptr()[i] = static_cast<uint8_t>(i & 0xFF);
 	}
 
-	FileBufferHandleGroup group;
 	constexpr idx_t OFFSET = 50;
-	group.handles.push_back({std::move(handle), OFFSET, BUF_SIZE - OFFSET});
+	vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
+	mem_handles.push_back({std::move(handle), OFFSET, BUF_SIZE - OFFSET});
+	FileBufferHandleGroup group(std::move(mem_handles));
 
 	array<uint8_t, 32> dest {};
 	group.CopyTo(dest.data(), dest.size());
@@ -71,10 +74,11 @@ TEST_CASE("FileBufferHandleGroup copy with multiple handles", "[file_buffer_hand
 	auto h2 = AllocateAndFill(bm, CHUNK, 0xBB);
 	auto h3 = AllocateAndFill(bm, CHUNK, 0xCC);
 
-	FileBufferHandleGroup group;
-	group.handles.push_back({std::move(h1), 0, CHUNK});
-	group.handles.push_back({std::move(h2), 0, CHUNK});
-	group.handles.push_back({std::move(h3), 0, CHUNK});
+	vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
+	mem_handles.push_back({std::move(h1), 0, CHUNK});
+	mem_handles.push_back({std::move(h2), 0, CHUNK});
+	mem_handles.push_back({std::move(h3), 0, CHUNK});
+	FileBufferHandleGroup group(std::move(mem_handles));
 
 	array<uint8_t, CHUNK * 3> dest {};
 	group.CopyTo(dest.data(), dest.size());
@@ -103,9 +107,10 @@ TEST_CASE("FileBufferHandleGroup copy partial across handles", "[file_buffer_han
 	auto h1 = AllocateAndFill(bm, BUF_SIZE, 0x11);
 	auto h2 = AllocateAndFill(bm, BUF_SIZE, 0x22);
 
-	FileBufferHandleGroup group;
-	group.handles.push_back({std::move(h1), /*start_offset=*/H1_OFFSET, /*length=*/H1_LENGTH});
-	group.handles.push_back({std::move(h2), /*start_offset=*/0, /*length=*/H2_LENGTH});
+	vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
+	mem_handles.push_back({std::move(h1), /*start_offset=*/H1_OFFSET, /*length=*/H1_LENGTH});
+	mem_handles.push_back({std::move(h2), /*start_offset=*/0, /*length=*/H2_LENGTH});
+	FileBufferHandleGroup group(std::move(mem_handles));
 
 	array<uint8_t, COPY_SIZE> dest {};
 	group.CopyTo(dest.data(), dest.size());
@@ -117,3 +122,5 @@ TEST_CASE("FileBufferHandleGroup copy partial across handles", "[file_buffer_han
 		REQUIRE(dest[i] == 0x22);
 	}
 }
+
+} // namespace duckdb

--- a/test/common/test_file_buffer_handle_group.cpp
+++ b/test/common/test_file_buffer_handle_group.cpp
@@ -96,9 +96,9 @@ TEST_CASE("FileBufferHandleGroup copy partial across handles", "[file_buffer_han
 
 	constexpr idx_t BUF_SIZE = 64;
 	constexpr idx_t H1_OFFSET = 20;
-	constexpr idx_t H1_LENGTH = BUF_SIZE - H1_OFFSET; // 44 bytes from first block
+	constexpr idx_t H1_LENGTH = BUF_SIZE - H1_OFFSET;  // 44 bytes from first block
 	constexpr idx_t H2_LENGTH = 16;                    // 16 bytes from second block
-	constexpr idx_t COPY_SIZE = H1_LENGTH + H2_LENGTH;  // 60 total
+	constexpr idx_t COPY_SIZE = H1_LENGTH + H2_LENGTH; // 60 total
 
 	auto h1 = AllocateAndFill(bm, BUF_SIZE, 0x11);
 	auto h2 = AllocateAndFill(bm, BUF_SIZE, 0x22);

--- a/test/common/test_file_buffer_handle_group.cpp
+++ b/test/common/test_file_buffer_handle_group.cpp
@@ -1,0 +1,119 @@
+#include "catch.hpp"
+#include "duckdb/common/array.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/storage/buffer_manager.hpp"
+#include "duckdb/storage/file_buffer_handle_group.hpp"
+#include "test_helpers.hpp"
+
+#include <cstring>
+
+using namespace duckdb;
+
+namespace {
+BufferHandle AllocateAndFill(BufferManager &bm, idx_t size, uint8_t fill) {
+	auto handle = bm.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, size);
+	memset(handle.Ptr(), fill, size);
+	return handle;
+}
+} // namespace
+
+TEST_CASE("FileBufferHandleGroup copy with single handle", "[file_buffer_handle_group]") {
+	DuckDB db(":memory:");
+	auto &bm = BufferManager::GetBufferManager(*db.instance);
+
+	constexpr idx_t BUF_SIZE = 256;
+	auto handle = AllocateAndFill(bm, BUF_SIZE, 0);
+
+	for (idx_t i = 0; i < BUF_SIZE; i++) {
+		handle.Ptr()[i] = static_cast<uint8_t>(i & 0xFF);
+	}
+
+	FileBufferHandleGroup group;
+	group.handles.push_back({std::move(handle), /*start_offset=*/0, /*length=*/BUF_SIZE});
+
+	array<uint8_t, 64> dest {};
+	group.CopyTo(dest.data(), dest.size());
+
+	for (idx_t i = 0; i < dest.size(); i++) {
+		REQUIRE(dest[i] == static_cast<uint8_t>(i));
+	}
+}
+
+TEST_CASE("FileBufferHandleGroup copy with single handle with offset", "[file_buffer_handle_group]") {
+	DuckDB db(":memory:");
+	auto &bm = BufferManager::GetBufferManager(*db.instance);
+
+	constexpr idx_t BUF_SIZE = 256;
+	auto handle = AllocateAndFill(bm, BUF_SIZE, 0);
+	for (idx_t i = 0; i < BUF_SIZE; i++) {
+		handle.Ptr()[i] = static_cast<uint8_t>(i & 0xFF);
+	}
+
+	FileBufferHandleGroup group;
+	constexpr idx_t OFFSET = 50;
+	group.handles.push_back({std::move(handle), OFFSET, BUF_SIZE - OFFSET});
+
+	array<uint8_t, 32> dest {};
+	group.CopyTo(dest.data(), dest.size());
+
+	for (idx_t i = 0; i < dest.size(); i++) {
+		REQUIRE(dest[i] == static_cast<uint8_t>(OFFSET + i));
+	}
+}
+
+TEST_CASE("FileBufferHandleGroup copy with multiple handles", "[file_buffer_handle_group]") {
+	DuckDB db(":memory:");
+	auto &bm = BufferManager::GetBufferManager(*db.instance);
+
+	constexpr idx_t CHUNK = 64;
+
+	auto h1 = AllocateAndFill(bm, CHUNK, 0xAA);
+	auto h2 = AllocateAndFill(bm, CHUNK, 0xBB);
+	auto h3 = AllocateAndFill(bm, CHUNK, 0xCC);
+
+	FileBufferHandleGroup group;
+	group.handles.push_back({std::move(h1), 0, CHUNK});
+	group.handles.push_back({std::move(h2), 0, CHUNK});
+	group.handles.push_back({std::move(h3), 0, CHUNK});
+
+	array<uint8_t, CHUNK * 3> dest {};
+	group.CopyTo(dest.data(), dest.size());
+
+	for (idx_t i = 0; i < CHUNK; i++) {
+		REQUIRE(dest[i] == 0xAA);
+	}
+	for (idx_t i = CHUNK; i < CHUNK * 2; i++) {
+		REQUIRE(dest[i] == 0xBB);
+	}
+	for (idx_t i = CHUNK * 2; i < CHUNK * 3; i++) {
+		REQUIRE(dest[i] == 0xCC);
+	}
+}
+
+TEST_CASE("FileBufferHandleGroup copy partial across handles", "[file_buffer_handle_group]") {
+	DuckDB db(":memory:");
+	auto &bm = BufferManager::GetBufferManager(*db.instance);
+
+	constexpr idx_t BUF_SIZE = 64;
+	constexpr idx_t H1_OFFSET = 20;
+	constexpr idx_t H1_LENGTH = BUF_SIZE - H1_OFFSET; // 44 bytes from first block
+	constexpr idx_t H2_LENGTH = 16;                    // 16 bytes from second block
+	constexpr idx_t COPY_SIZE = H1_LENGTH + H2_LENGTH;  // 60 total
+
+	auto h1 = AllocateAndFill(bm, BUF_SIZE, 0x11);
+	auto h2 = AllocateAndFill(bm, BUF_SIZE, 0x22);
+
+	FileBufferHandleGroup group;
+	group.handles.push_back({std::move(h1), /*start_offset=*/H1_OFFSET, /*length=*/H1_LENGTH});
+	group.handles.push_back({std::move(h2), /*start_offset=*/0, /*length=*/H2_LENGTH});
+
+	array<uint8_t, COPY_SIZE> dest {};
+	group.CopyTo(dest.data(), dest.size());
+
+	for (idx_t i = 0; i < H1_LENGTH; i++) {
+		REQUIRE(dest[i] == 0x11);
+	}
+	for (idx_t i = H1_LENGTH; i < COPY_SIZE; i++) {
+		REQUIRE(dest[i] == 0x22);
+	}
+}

--- a/test/sql/storage/external_file_cache/external_file_cache_parquet.test_slow
+++ b/test/sql/storage/external_file_cache/external_file_cache_parquet.test_slow
@@ -44,13 +44,7 @@ select l_orderkey from lineitem;
 query I
 select round(sum(nr_bytes) / 1048576) from duckdb_external_file_cache() where nr_bytes > 100000;
 ----
-23.0
-
-# all blocks should be aligned to 2MiB boundaries
-query I
-select every(location % 2097152 = 0) from duckdb_external_file_cache();
-----
-true
+25.0
 
 # select the third column (not contiguous with the first column so more blocks are needed)
 statement ok
@@ -59,7 +53,7 @@ select l_suppkey from lineitem;
 query I
 select round(sum(nr_bytes) / 1048576) from duckdb_external_file_cache() where nr_bytes > 100000;
 ----
-33.0
+35.0
 
 # select the first four columns (contiguous, covers the full data range)
 statement ok
@@ -74,7 +68,7 @@ select round(sum(nr_bytes) / 1048576) from duckdb_external_file_cache() where nr
 query I
 select round(memory_usage_bytes / 1048576) from duckdb_memory() where tag = 'EXTERNAL_FILE_CACHE';
 ----
-48.0
+47.0
 
 # set the memory so low that blocks should be unloaded
 statement ok

--- a/test/sql/storage/external_file_cache/external_file_cache_parquet.test_slow
+++ b/test/sql/storage/external_file_cache/external_file_cache_parquet.test_slow
@@ -14,7 +14,6 @@ copy (
 ) to '__TEST_DIR__/test_efc_lineitem.parquet' (row_group_size 6_000_000);
 
 # this is empty since we didn't query anything yet
-# throughout this file we round the bytes to whole MBs due to small differences between OSs somehow
 query II
 select round(nr_bytes / 1048576), loaded from duckdb_external_file_cache() order by location;
 ----
@@ -31,9 +30,9 @@ create view lineitem as from '__TEST_DIR__/test_efc_lineitem.parquet';
 # otherwise, we run into problems with file systems with low time resolution for last modified time
 sleep 11 seconds
 
-# creating the view has loaded the footer
+# creating the view has loaded the footer (at least one block cached)
 query I
-select loaded from duckdb_external_file_cache() order by location;
+select count(*) > 0 from duckdb_external_file_cache();
 ----
 true
 
@@ -41,38 +40,43 @@ true
 statement ok
 select l_orderkey from lineitem;
 
-query II
-select round(nr_bytes / 1048576), loaded from duckdb_external_file_cache() where nr_bytes > 100000;
+# with block-aligned caching, we should have multiple 2MiB blocks covering ~23MiB of data
+query I
+select round(sum(nr_bytes) / 1048576) from duckdb_external_file_cache() where nr_bytes > 100000;
 ----
-23.0	true
+23.0
 
-# select the third column (not contiguous with the first column so it should have two cache entries)
+# all blocks should be aligned to 2MiB boundaries
+query I
+select every(location % 2097152 = 0) from duckdb_external_file_cache();
+----
+true
+
+# select the third column (not contiguous with the first column so more blocks are needed)
 statement ok
 select l_suppkey from lineitem;
 
-query II
-select round(nr_bytes / 1048576), loaded from duckdb_external_file_cache() where nr_bytes > 100000 order by location;
+query I
+select round(sum(nr_bytes) / 1048576) from duckdb_external_file_cache() where nr_bytes > 100000;
 ----
-23.0	1
-10.0	1
+33.0
 
-# select the first four columns (contiguous, and supersede the previous two cache entries, should merge into one entry)
+# select the first four columns (contiguous, covers the full data range)
 statement ok
 select l_orderkey, l_partkey, l_suppkey, l_linenumber from lineitem;
 
-query II
-select round(nr_bytes / 1048576), loaded from duckdb_external_file_cache() where nr_bytes > 100000 order by location;
-----
-47.0	1
-
-# shows up in duckdb_memory under its own tag
-# this is slightly higher than the sum of nr_bytes above due buffers having a header and are rounded up to sector size
 query I
-select round(memory_usage_bytes / 1048576) from duckdb_memory() where tag = 'EXTERNAL_FILE_CACHE';
+select round(sum(nr_bytes) / 1048576) from duckdb_external_file_cache() where nr_bytes > 100000;
 ----
 47.0
 
-# set the memory so low that the ~3MB entry should be unloaded
+# shows up in duckdb_memory under its own tag
+query I
+select round(memory_usage_bytes / 1048576) from duckdb_memory() where tag = 'EXTERNAL_FILE_CACHE';
+----
+48.0
+
+# set the memory so low that blocks should be unloaded
 statement ok
 set memory_limit='512KiB';
 
@@ -80,11 +84,11 @@ set memory_limit='512KiB';
 statement ok
 set memory_limit='500mb';
 
-# loaded should now be "false" for the large buffer
-query II
-select round(nr_bytes / 1048576), loaded from duckdb_external_file_cache() where location = 4;
+# some blocks should now be unloaded
+query I
+select count(*) > 0 from duckdb_external_file_cache() where loaded = false;
 ----
-47.0	0
+true
 
 # disabling the file cache should empty it
 statement ok

--- a/test/sql/storage/external_file_cache/external_file_cache_validate.test
+++ b/test/sql/storage/external_file_cache/external_file_cache_validate.test
@@ -75,14 +75,3 @@ statement error
 set validate_external_file_cache='INVALID_VALUE';
 ----
 <REGEX>:.*unrecognized value.*
-
-# Test 7: Accessing a non-existent file with caching enabled should produce a clear error
-statement error
-select * from '__TEST_DIR__/does_not_exist.parquet';
-----
-No files found that match the pattern
-
-statement error
-select * from '__TEST_DIR__/also_missing.parquet';
-----
-No files found that match the pattern

--- a/test/sql/storage/external_file_cache/external_file_cache_validate.test
+++ b/test/sql/storage/external_file_cache/external_file_cache_validate.test
@@ -75,3 +75,14 @@ statement error
 set validate_external_file_cache='INVALID_VALUE';
 ----
 <REGEX>:.*unrecognized value.*
+
+# Test 7: Accessing a non-existent file with caching enabled should produce a clear error
+statement error
+select * from '__TEST_DIR__/does_not_exist.parquet';
+----
+No files found that match the pattern
+
+statement error
+select * from '__TEST_DIR__/also_missing.parquet';
+----
+No files found that match the pattern


### PR DESCRIPTION
This PR redo <PR>, which turns request-based IO request and caching into block-based.
I wrote a design and plan doc here: https://docs.google.com/document/d/13VwBELimgd9H12wODlBDj6o4Bfhulg7Lkm7mXsEWGJA/edit?usp=sharing

Main changes summary:
- In this PR, I completely replace the read and caching policy
  + I had a few hard attempts to migrate both read policies into one caching filesystem (i.e., extract a policy to decide number of bytes to read this time), but the code is hard to grasp and bug prune
  + If we decide to keep the existing system, I'd suggest to have two caching filesystems
- Implement block-based request and caching to replace request-based one
  + Current request-based one is, implementation-wise, more complicate, which involves cache block merging and overlap logic; for block-based solution it's deterministic
- Concurrent requests
  + I could be mis-reading, but I don't see mechanism to prevent duplicate or overlap IO request over a same range of blocks; for block-based one, we're able to use synchronization primitives to guarantee one IO per block
- Caching filesystem API change
  + Current API returns one single block for `Read` calls, so if a single request involves multiple cache blocks, we could allocate and copy the whole memory; I change the interface to return a shallow copy `FileBufferHandleGroup` so no allocation or copy involved in `CachingFileSystem`
- Concurrent request for large block requests

Potential consideration:
- Since we use aligned block size to issue IO requests, and 2MiB is a large block no doubt, initial request latency could be high
- It doesn't play pretty well with httpfs extension's growing buffer strategy, which is designed to double buffer size when sequential writes detected (similar to linux filesystem page cache prefetch strategy), but after block-aligned read, the strategy might be reconsidered.

TODO items
- In this PR, I hard-code the block size to 2MiB, which is the good-enough parameter from my personal experience; it should be a configuration
- After block-based caching is enabled, we could start working on disk cache



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it rewrites the external file caching implementation and `CachingFileHandle::Read` API, adds new concurrency/synchronization behavior, and impacts multiple core call sites (parquet/thrift, caching wrapper, and external extensions). Errors here can cause incorrect reads, deadlocks, or performance regressions across all file access paths.
> 
> **Overview**
> Refactors the external file cache from *request/range-based* caching to **fixed 2MiB block-based caching**, including new per-block synchronization (`CacheBlockState`, condition variables) and parallel block fetch via task scheduling to prevent duplicate I/O under concurrency.
> 
> Changes the caching read API to return a `FileBufferHandleGroup` (potentially multiple pinned buffers) instead of a single `BufferHandle`+pointer, and updates `CachingFileSystemWrapper` and parquet thrift prefetch to copy/materialize only when necessary.
> 
> Updates cache introspection/tests to account for block-aligned behavior (multiple cache entries per file, different byte totals/unload expectations), adds unit tests around `FileBufferHandleGroup` and concurrent/IO-error scenarios, and applies patch updates to `avro`, `httpfs`, and `iceberg` extensions to compile/work with the new interfaces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25e88deabaec53574948161841f16575b2d6c049. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->