### PR TITLE
Use C++17 inline

### DIFF
--- a/src/include/duckdb/common/enums/memory_tag.hpp
+++ b/src/include/duckdb/common/enums/memory_tag.hpp
@@ -33,6 +33,6 @@ enum class MemoryTag : uint8_t {
 	UNKNOWN = 16,
 };
 
-static constexpr const idx_t MEMORY_TAG_COUNT = static_cast<idx_t>(MemoryTag::UNKNOWN);
+inline constexpr const idx_t MEMORY_TAG_COUNT = static_cast<idx_t>(MemoryTag::UNKNOWN);
 
 } // namespace duckdb

--- a/src/include/duckdb/common/file_buffer.hpp
+++ b/src/include/duckdb/common/file_buffer.hpp
@@ -21,7 +21,7 @@ struct FileHandle;
 
 enum class FileBufferType : uint8_t { BLOCK = 1, MANAGED_BUFFER = 2, TINY_BUFFER = 3, EXTERNAL_FILE = 4 };
 
-static constexpr idx_t FILE_BUFFER_TYPE_COUNT = 4;
+inline constexpr idx_t FILE_BUFFER_TYPE_COUNT = 4;
 
 //! The FileBuffer represents a buffer that can be read or written to a Direct IO FileHandle.
 class FileBuffer {

--- a/src/include/duckdb/common/gzip_file_system.hpp
+++ b/src/include/duckdb/common/gzip_file_system.hpp
@@ -36,21 +36,21 @@ public:
 	idx_t OutBufferSize() override;
 };
 
-static constexpr const uint8_t GZIP_COMPRESSION_DEFLATE = 0x08;
+inline constexpr const uint8_t GZIP_COMPRESSION_DEFLATE = 0x08;
 
-static constexpr const uint8_t GZIP_FLAG_ASCII = 0x1;
-static constexpr const uint8_t GZIP_FLAG_MULTIPART = 0x2;
-static constexpr const uint8_t GZIP_FLAG_EXTRA = 0x4;
-static constexpr const uint8_t GZIP_FLAG_NAME = 0x8;
-static constexpr const uint8_t GZIP_FLAG_COMMENT = 0x10;
-static constexpr const uint8_t GZIP_FLAG_ENCRYPT = 0x20;
+inline constexpr const uint8_t GZIP_FLAG_ASCII = 0x1;
+inline constexpr const uint8_t GZIP_FLAG_MULTIPART = 0x2;
+inline constexpr const uint8_t GZIP_FLAG_EXTRA = 0x4;
+inline constexpr const uint8_t GZIP_FLAG_NAME = 0x8;
+inline constexpr const uint8_t GZIP_FLAG_COMMENT = 0x10;
+inline constexpr const uint8_t GZIP_FLAG_ENCRYPT = 0x20;
 
-static constexpr const uint8_t GZIP_HEADER_MINSIZE = 10;
+inline constexpr const uint8_t GZIP_HEADER_MINSIZE = 10;
 // MAXSIZE should be the same as input buffer size
-static constexpr const idx_t GZIP_HEADER_MAXSIZE = 1u << 15;
-static constexpr const uint8_t GZIP_FOOTER_SIZE = 8;
+inline constexpr const idx_t GZIP_HEADER_MAXSIZE = 1u << 15;
+inline constexpr const uint8_t GZIP_FOOTER_SIZE = 8;
 
-static constexpr const unsigned char GZIP_FLAG_UNSUPPORTED =
+inline constexpr const unsigned char GZIP_FLAG_UNSUPPORTED =
     GZIP_FLAG_ASCII | GZIP_FLAG_MULTIPART | GZIP_FLAG_COMMENT | GZIP_FLAG_ENCRYPT;
 
 } // namespace duckdb

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -39,7 +39,7 @@ struct ExtensionFunctionOverloadEntry {
 	char signature[96];
 };
 
-static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
+inline constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"!__postfix", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"&", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"**", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
@@ -820,7 +820,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"~", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
 }; // END_OF_EXTENSION_FUNCTIONS
 
-static constexpr ExtensionFunctionOverloadEntry EXTENSION_FUNCTION_OVERLOADS[] = {
+inline constexpr ExtensionFunctionOverloadEntry EXTENSION_FUNCTION_OVERLOADS[] = {
     {"age", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY, "[TIMESTAMP]>INTERVAL"},
     {"age", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY, "[TIMESTAMP,TIMESTAMP]>INTERVAL"},
     {"age", "icu", CatalogType::SCALAR_FUNCTION_ENTRY, "[TIMESTAMPTZ]>INTERVAL"},
@@ -1038,7 +1038,7 @@ static constexpr ExtensionFunctionOverloadEntry EXTENSION_FUNCTION_OVERLOADS[] =
     {"yearweek", "icu", CatalogType::SCALAR_FUNCTION_ENTRY, "[TIMESTAMPTZ]>BIGINT"},
 }; // END_OF_EXTENSION_FUNCTION_OVERLOADS
 
-static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
+inline constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"allow_asterisks_in_http_paths", "httpfs"},
     {"auto_fallback_to_full_download", "httpfs"},
     {"azure_account_name", "azure"},
@@ -1125,7 +1125,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"unsafe_enable_version_guessing", "iceberg"},
 }; // END_OF_EXTENSION_SETTINGS
 
-static constexpr ExtensionEntry EXTENSION_SECRET_TYPES[] = {
+inline constexpr ExtensionEntry EXTENSION_SECRET_TYPES[] = {
     {"aws", "httpfs"},         {"azure", "azure"},     {"ducklake", "ducklake"},   {"gcs", "httpfs"},
     {"huggingface", "httpfs"}, {"iceberg", "iceberg"}, {"mysql", "mysql_scanner"}, {"postgres", "postgres_scanner"},
     {"r2", "httpfs"},          {"s3", "httpfs"},
@@ -1133,19 +1133,19 @@ static constexpr ExtensionEntry EXTENSION_SECRET_TYPES[] = {
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
-static constexpr ExtensionEntry EXTENSION_COPY_FUNCTIONS[] = {
+inline constexpr ExtensionEntry EXTENSION_COPY_FUNCTIONS[] = {
     {"parquet", "parquet"}, {"json", "json"}, {"avro", "avro"}}; // END_OF_EXTENSION_COPY_FUNCTIONS
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
-static constexpr ExtensionEntry EXTENSION_TYPES[] = {
+inline constexpr ExtensionEntry EXTENSION_TYPES[] = {
     {"json", "json"},
     {"inet", "inet"},
 }; // END_OF_EXTENSION_TYPES
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
-static constexpr ExtensionEntry EXTENSION_COLLATIONS[] = {
+inline constexpr ExtensionEntry EXTENSION_COLLATIONS[] = {
     {"af", "icu"},    {"am", "icu"},    {"ar", "icu"},     {"ar_sa", "icu"}, {"as", "icu"},    {"az", "icu"},
     {"be", "icu"},    {"bg", "icu"},    {"bn", "icu"},     {"bo", "icu"},    {"br", "icu"},    {"bs", "icu"},
     {"ca", "icu"},    {"ceb", "icu"},   {"chr", "icu"},    {"cs", "icu"},    {"cy", "icu"},    {"da", "icu"},
@@ -1171,28 +1171,28 @@ static constexpr ExtensionEntry EXTENSION_COLLATIONS[] = {
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
-static constexpr ExtensionEntry EXTENSION_FILE_PREFIXES[] = {
+inline constexpr ExtensionEntry EXTENSION_FILE_PREFIXES[] = {
     {"http://", "httpfs"}, {"https://", "httpfs"}, {"s3://", "httpfs"}, {"s3a://", "httpfs"},  {"s3n://", "httpfs"},
     {"gcs://", "httpfs"},  {"gs://", "httpfs"},    {"r2://", "httpfs"}, {"azure://", "azure"}, {"az://", "azure"},
     {"abfss://", "azure"}, {"hf://", "httpfs"}}; // END_OF_EXTENSION_FILE_PREFIXES
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
-static constexpr ExtensionEntry EXTENSION_FILE_POSTFIXES[] = {
+inline constexpr ExtensionEntry EXTENSION_FILE_POSTFIXES[] = {
     {".parquet", "parquet"}, {".json", "json"},   {".jsonl", "json"}, {".ndjson", "json"}, {".shp", "spatial"},
     {".gpkg", "spatial"},    {".fgb", "spatial"}, {".xlsx", "excel"}, {".avro", "avro"},
 }; // END_OF_EXTENSION_FILE_POSTFIXES
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
-static constexpr ExtensionEntry EXTENSION_FILE_CONTAINS[] = {{".parquet?", "parquet"},
+inline constexpr ExtensionEntry EXTENSION_FILE_CONTAINS[] = {{".parquet?", "parquet"},
                                                              {".json?", "json"},
                                                              {".ndjson?", ".jsonl?"},
                                                              {".jsonl?", ".ndjson?"}}; // EXTENSION_FILE_CONTAINS
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
-static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
+inline constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
     {"s3/config", "httpfs"},
     {"gcs/config", "httpfs"},
     {"r2/config", "httpfs"},
@@ -1210,7 +1210,7 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
     {"mysql/config", "mysql_scanner"},
     {"postgres/config", "postgres_scanner"}}; // EXTENSION_SECRET_PROVIDERS
 
-static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {"avro",
+inline constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {"avro",
                                                           "aws",
                                                           "azure",
                                                           "autocomplete",

--- a/src/include/duckdb/storage/compression/roaring/roaring.hpp
+++ b/src/include/duckdb/storage/compression/roaring/roaring.hpp
@@ -19,26 +19,26 @@ namespace duckdb {
 namespace roaring {
 
 //! Used for compressed runs/arrays
-static constexpr uint16_t COMPRESSED_SEGMENT_SIZE = 256;
+inline constexpr uint16_t COMPRESSED_SEGMENT_SIZE = 256;
 //! compresed segment size is 256, instead of division we can make use of shifting
-static constexpr uint16_t COMPRESSED_SEGMENT_SHIFT_AMOUNT = 8;
+inline constexpr uint16_t COMPRESSED_SEGMENT_SHIFT_AMOUNT = 8;
 //! The amount of values that are encoded per container
-static constexpr idx_t ROARING_CONTAINER_SIZE = 2048;
-static constexpr bool NULLS = true;
-static constexpr bool NON_NULLS = false;
-static constexpr uint16_t UNCOMPRESSED_SIZE = (ROARING_CONTAINER_SIZE / sizeof(validity_t));
-static constexpr uint16_t COMPRESSED_SEGMENT_COUNT = (ROARING_CONTAINER_SIZE / COMPRESSED_SEGMENT_SIZE);
+inline constexpr idx_t ROARING_CONTAINER_SIZE = 2048;
+inline constexpr bool NULLS = true;
+inline constexpr bool NON_NULLS = false;
+inline constexpr uint16_t UNCOMPRESSED_SIZE = (ROARING_CONTAINER_SIZE / sizeof(validity_t));
+inline constexpr uint16_t COMPRESSED_SEGMENT_COUNT = (ROARING_CONTAINER_SIZE / COMPRESSED_SEGMENT_SIZE);
 
-static constexpr uint16_t MAX_RUN_IDX = (UNCOMPRESSED_SIZE - COMPRESSED_SEGMENT_COUNT) / (sizeof(uint8_t) * 2);
-static constexpr uint16_t MAX_ARRAY_IDX = (UNCOMPRESSED_SIZE - COMPRESSED_SEGMENT_COUNT) / (sizeof(uint8_t) * 1);
+inline constexpr uint16_t MAX_RUN_IDX = (UNCOMPRESSED_SIZE - COMPRESSED_SEGMENT_COUNT) / (sizeof(uint8_t) * 2);
+inline constexpr uint16_t MAX_ARRAY_IDX = (UNCOMPRESSED_SIZE - COMPRESSED_SEGMENT_COUNT) / (sizeof(uint8_t) * 1);
 //! The value used to indicate that a container is a bitset container
-static constexpr uint16_t BITSET_CONTAINER_SENTINEL_VALUE = MAX_ARRAY_IDX + 1;
-static constexpr uint16_t COMPRESSED_ARRAY_THRESHOLD = 8;
-static constexpr uint16_t COMPRESSED_RUN_THRESHOLD = 4;
+inline constexpr uint16_t BITSET_CONTAINER_SENTINEL_VALUE = MAX_ARRAY_IDX + 1;
+inline constexpr uint16_t COMPRESSED_ARRAY_THRESHOLD = 8;
+inline constexpr uint16_t COMPRESSED_RUN_THRESHOLD = 4;
 
-static constexpr uint16_t CONTAINER_TYPE_BITWIDTH = 2;
-static constexpr uint16_t RUN_CONTAINER_SIZE_BITWIDTH = 7;
-static constexpr uint16_t ARRAY_CONTAINER_SIZE_BITWIDTH = 8;
+inline constexpr uint16_t CONTAINER_TYPE_BITWIDTH = 2;
+inline constexpr uint16_t RUN_CONTAINER_SIZE_BITWIDTH = 7;
+inline constexpr uint16_t ARRAY_CONTAINER_SIZE_BITWIDTH = 8;
 
 //! This can be increased, but requires additional changes beyond just changing the constant
 static_assert(MAX_RUN_IDX < NumericLimits<uint8_t>::Maximum(), "The run size is encoded in a maximum of 8 bits");

--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -26,7 +26,7 @@ class TemporaryFileManager;
 //===--------------------------------------------------------------------===//
 // TemporaryBufferSize
 //===--------------------------------------------------------------------===//
-static constexpr uint64_t TEMPORARY_BUFFER_SIZE_GRANULARITY = 32ULL * 1024ULL;
+inline constexpr uint64_t TEMPORARY_BUFFER_SIZE_GRANULARITY = 32ULL * 1024ULL;
 
 enum class TemporaryBufferSize : uint64_t {
 	INVALID = 0,


### PR DESCRIPTION
https://github.com/duckdb/duckdb/issues/21108

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a linkage/ODR cleanup in header-defined constants with no behavioral changes expected, but it could affect builds if any TU relied on external definitions.
> 
> **Overview**
> Updates several header-defined `static constexpr` constants/arrays (e.g., memory tags, file buffer types, gzip constants, roaring compression constants, temporary buffer granularity, and generated extension entry tables) to `inline constexpr` so they can be safely defined in headers under C++17 without multiple-definition/ODR issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6e3ed8ab33b4d7842419e26c9003cc2c8c0070b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->