### PR TITLE
[DRAFT] Block handle API

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -357,13 +357,22 @@ void ColumnReader::PreparePageV2(PageHeader &page_hdr) {
 	auto compressed_bytes = page_hdr.compressed_page_size - uncompressed_bytes;
 
 	if (compressed_bytes > 0) {
-		ResizeableBuffer compressed_buffer;
-		compressed_buffer.resize(GetAllocator(), compressed_bytes);
-
-		ReadData(compressed_buffer.ptr, compressed_bytes, page_hdr.type);
-
-		DecompressInternal(chunk->meta_data.codec, compressed_buffer.ptr, compressed_bytes,
-		                   block->ptr + uncompressed_bytes, page_hdr.uncompressed_page_size - uncompressed_bytes);
+		auto &trans = reinterpret_cast<ThriftFileTransport &>(*protocol->getTransport());
+		const idx_t compressed_start = trans.GetLocation();
+		data_ptr_t compressed_ptr = nullptr;
+		BufferHandle compressed_pin =
+		    trans.GetCachingFileHandle().Read(QueryContext(), compressed_ptr, compressed_bytes, compressed_start);
+		if (compressed_pin.IsValid()) {
+			trans.Skip(compressed_bytes);
+			DecompressInternal(chunk->meta_data.codec, compressed_ptr, compressed_bytes,
+			                   block->ptr + uncompressed_bytes, page_hdr.uncompressed_page_size - uncompressed_bytes);
+		} else {
+			ResizeableBuffer compressed_buffer;
+			compressed_buffer.resize(GetAllocator(), compressed_bytes);
+			ReadData(compressed_buffer.ptr, compressed_bytes, page_hdr.type);
+			DecompressInternal(chunk->meta_data.codec, compressed_buffer.ptr, compressed_bytes,
+			                   block->ptr + uncompressed_bytes, page_hdr.uncompressed_page_size - uncompressed_bytes);
+		}
 	}
 }
 
@@ -398,12 +407,22 @@ void ColumnReader::PreparePage(PageHeader &page_hdr) {
 		return;
 	}
 
-	ResizeableBuffer compressed_buffer;
-	compressed_buffer.resize(GetAllocator(), compressed_page_size + 1);
-	ReadData(compressed_buffer.ptr, compressed_page_size, page_hdr.type);
-
-	DecompressInternal(chunk->meta_data.codec, compressed_buffer.ptr, compressed_page_size, block->ptr,
-	                   page_hdr.uncompressed_page_size);
+	auto &trans = reinterpret_cast<ThriftFileTransport &>(*protocol->getTransport());
+	const idx_t compressed_start = trans.GetLocation();
+	data_ptr_t compressed_ptr = nullptr;
+	BufferHandle compressed_pin =
+	    trans.GetCachingFileHandle().Read(QueryContext(), compressed_ptr, compressed_page_size, compressed_start);
+	if (compressed_pin.IsValid()) {
+		trans.Skip(compressed_page_size);
+		DecompressInternal(chunk->meta_data.codec, compressed_ptr, compressed_page_size, block->ptr,
+		                   page_hdr.uncompressed_page_size);
+	} else {
+		ResizeableBuffer compressed_buffer;
+		compressed_buffer.resize(GetAllocator(), compressed_page_size + 1);
+		ReadData(compressed_buffer.ptr, compressed_page_size, page_hdr.type);
+		DecompressInternal(chunk->meta_data.codec, compressed_buffer.ptr, compressed_page_size, block->ptr,
+		                   page_hdr.uncompressed_page_size);
+	}
 }
 
 void ColumnReader::DecompressInternal(CompressionCodec::type codec, const_data_ptr_t src, idx_t src_size,

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -210,6 +210,10 @@ public:
 		return size;
 	}
 
+	CachingFileHandle &GetCachingFileHandle() {
+		return file_handle;
+	}
+
 private:
 	QueryContext context;
 

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -745,6 +745,14 @@ FileHandle::FileHandle(FileSystem &file_system, string path_p, FileOpenFlags fla
 FileHandle::~FileHandle() {
 }
 
+BufferHandle FileHandle::TryReadPinned(QueryContext context, idx_t location, idx_t nr_bytes, data_ptr_t &out_ptr) {
+	(void)context;
+	(void)location;
+	(void)nr_bytes;
+	out_ptr = nullptr;
+	return BufferHandle();
+}
+
 int64_t FileHandle::Read(void *buffer, idx_t nr_bytes) {
 	return file_system.Read(*this, buffer, UnsafeNumericCast<int64_t>(nr_bytes));
 }

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/common/file_buffer.hpp"
 #include "duckdb/common/file_open_flags.hpp"
+#include "duckdb/storage/buffer/buffer_handle.hpp"
 #include "duckdb/common/open_file_info.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/optional_ptr.hpp"
@@ -105,6 +106,12 @@ public:
 	DUCKDB_API FileMetadata Stats();
 
 	DUCKDB_API void TryAddLogger(FileOpener &opener);
+
+	//! If this handle can return a cache-backed pinned range without copying into a caller-supplied buffer, returns a
+	//! valid BufferHandle and sets out_ptr to the first byte; otherwise returns an invalid handle and sets out_ptr to
+	//! nullptr. The memory stays valid until the returned BufferHandle is destroyed or moved from.
+	DUCKDB_API virtual BufferHandle TryReadPinned(QueryContext context, idx_t location, idx_t nr_bytes,
+	                                              data_ptr_t &out_ptr);
 
 	//! Closes the file handle.
 	DUCKDB_API virtual void Close() = 0;

--- a/src/include/duckdb/storage/caching_file_system.hpp
+++ b/src/include/duckdb/storage/caching_file_system.hpp
@@ -46,6 +46,9 @@ public:
 	//! Read (seek) nr_bytes from the file (or cache) at location. The pointer will be set to the requested range
 	//! The buffer is guaranteed to stay in memory as long as the returned BufferHandle is in scope
 	DUCKDB_API BufferHandle Read(data_ptr_t &buffer, idx_t nr_bytes, idx_t location);
+	//! Same as Read, but uses read_context for underlying FileHandle::Read (e.g. I/O profiling) instead of the
+	//! handle's construction-time context.
+	DUCKDB_API BufferHandle Read(QueryContext read_context, data_ptr_t &buffer, idx_t nr_bytes, idx_t location);
 	//! Read (non-seeking) nr bytes from the file (or cache), same as above, also sets nr_bytes to actually read bytes
 	DUCKDB_API BufferHandle Read(data_ptr_t &buffer, idx_t &nr_bytes);
 	//! Get some properties of the file
@@ -76,9 +79,9 @@ private:
 	                                shared_ptr<CachedFileRange> &new_file_range);
 	//! Read from file and copy from cached buffers until the requested read is complete
 	//! If actually_read is false, no reading happens, only the number of non-cached reads is counted and returned
-	idx_t ReadAndCopyInterleaved(const vector<shared_ptr<CachedFileRange>> &overlapping_ranges,
-	                             const shared_ptr<CachedFileRange> &new_file_range, data_ptr_t buffer, idx_t nr_bytes,
-	                             idx_t location, bool actually_read);
+	idx_t ReadAndCopyInterleaved(QueryContext read_context, const vector<shared_ptr<CachedFileRange>> &overlapping_ranges,
+	                            const shared_ptr<CachedFileRange> &new_file_range, data_ptr_t buffer, idx_t nr_bytes,
+	                            idx_t location, bool actually_read);
 
 private:
 	QueryContext context;

--- a/src/include/duckdb/storage/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/caching_file_system_wrapper.hpp
@@ -35,6 +35,9 @@ public:
 
 	DUCKDB_API void Close() override;
 
+	DUCKDB_API BufferHandle TryReadPinned(QueryContext context, idx_t location, idx_t nr_bytes,
+	                                      data_ptr_t &out_ptr) override;
+
 private:
 	// CachingFileSystem is not kept within VFS as other filesystems, so sometimes it's necessary to pin it inside of
 	// file handle and ensure it's valid.

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -115,11 +115,16 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 }
 
 BufferHandle CachingFileHandle::Read(data_ptr_t &buffer, const idx_t nr_bytes, const idx_t location) {
+	return Read(context, buffer, nr_bytes, location);
+}
+
+BufferHandle CachingFileHandle::Read(QueryContext read_context, data_ptr_t &buffer, const idx_t nr_bytes,
+                                     const idx_t location) {
 	BufferHandle result;
 	if (!external_file_cache.IsEnabled()) {
 		result = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
 		buffer = result.Ptr();
-		GetFileHandle().Read(context, buffer, nr_bytes, location);
+		GetFileHandle().Read(read_context, buffer, nr_bytes, location);
 		return result;
 	}
 
@@ -149,14 +154,16 @@ BufferHandle CachingFileHandle::Read(data_ptr_t &buffer, const idx_t nr_bytes, c
 	// Interleave reading and copying from cached buffers
 	if (OnDiskFile()) {
 		// On-disk file: prefer interleaving reading and copying from cached buffers
-		ReadAndCopyInterleaved(overlapping_ranges, new_file_range, buffer, new_nr_bytes, location, true);
+		ReadAndCopyInterleaved(read_context, overlapping_ranges, new_file_range, buffer, new_nr_bytes, location, true);
 	} else {
 		// Remote file: prefer interleaving reading and copying from cached buffers only if reduces number of real
 		// reads
-		if (ReadAndCopyInterleaved(overlapping_ranges, new_file_range, buffer, new_nr_bytes, location, false) <= 1) {
-			ReadAndCopyInterleaved(overlapping_ranges, new_file_range, buffer, new_nr_bytes, location, true);
+		if (ReadAndCopyInterleaved(read_context, overlapping_ranges, new_file_range, buffer, new_nr_bytes, location,
+		                           false) <= 1) {
+			ReadAndCopyInterleaved(read_context, overlapping_ranges, new_file_range, buffer, new_nr_bytes, location,
+			                       true);
 		} else {
-			GetFileHandle().Read(context, buffer, new_nr_bytes, location);
+			GetFileHandle().Read(read_context, buffer, new_nr_bytes, location);
 		}
 	}
 
@@ -404,7 +411,8 @@ BufferHandle CachingFileHandle::TryInsertFileRange(BufferHandle &pin, data_ptr_t
 	return std::move(pin);
 }
 
-idx_t CachingFileHandle::ReadAndCopyInterleaved(const vector<shared_ptr<CachedFileRange>> &overlapping_ranges,
+idx_t CachingFileHandle::ReadAndCopyInterleaved(QueryContext read_context,
+                                                const vector<shared_ptr<CachedFileRange>> &overlapping_ranges,
                                                 const shared_ptr<CachedFileRange> &new_file_range, data_ptr_t buffer,
                                                 const idx_t nr_bytes, const idx_t location, const bool actually_read) {
 	idx_t non_cached_read_count = 0;
@@ -424,7 +432,7 @@ idx_t CachingFileHandle::ReadAndCopyInterleaved(const vector<shared_ptr<CachedFi
 			const auto bytes_to_read = overlapping_range->location - current_location;
 			D_ASSERT(bytes_to_read < remaining_bytes);
 			if (actually_read) {
-				GetFileHandle().Read(context, buffer + buffer_offset, bytes_to_read, current_location);
+				GetFileHandle().Read(read_context, buffer + buffer_offset, bytes_to_read, current_location);
 			}
 			current_location += bytes_to_read;
 			remaining_bytes -= bytes_to_read;
@@ -458,7 +466,7 @@ idx_t CachingFileHandle::ReadAndCopyInterleaved(const vector<shared_ptr<CachedFi
 	if (remaining_bytes != 0) {
 		const auto buffer_offset = nr_bytes - remaining_bytes;
 		if (actually_read) {
-			GetFileHandle().Read(context, buffer + buffer_offset, remaining_bytes, current_location);
+			GetFileHandle().Read(read_context, buffer + buffer_offset, remaining_bytes, current_location);
 		}
 		non_cached_read_count++;
 	}

--- a/src/storage/caching_file_system_wrapper.cpp
+++ b/src/storage/caching_file_system_wrapper.cpp
@@ -41,6 +41,15 @@ void CachingFileHandleWrapper::Close() {
 	}
 }
 
+BufferHandle CachingFileHandleWrapper::TryReadPinned(QueryContext query_context, idx_t location, idx_t nr_bytes,
+                                                     data_ptr_t &out_ptr) {
+	if (!caching_handle) {
+		out_ptr = nullptr;
+		return BufferHandle();
+	}
+	return caching_handle->Read(query_context, out_ptr, nr_bytes, location);
+}
+
 //===----------------------------------------------------------------------===//
 // CachingFileSystemWrapper implementation
 //===----------------------------------------------------------------------===//

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -134,6 +134,58 @@ TEST_CASE("CachingFileSystemWrapper write operations not allowed", "[file_system
 	    NotImplementedException);
 }
 
+TEST_CASE("FileHandle TryReadPinned through CachingFileSystemWrapper", "[file_system][caching]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto tracking_fs = make_uniq<TrackingFileSystem>();
+	auto tracking_fs_ptr = tracking_fs.get();
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
+
+	const string test_content = "Pinned read test payload for zero-copy path.";
+	TestFileGuard test_file("test_try_read_pinned.txt", test_content);
+
+	OpenFileInfo file_info(test_file.GetPath());
+	file_info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+	file_info.extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
+
+	tracking_fs_ptr->Clear();
+	auto handle = caching_wrapper->OpenFile(file_info, FileFlags::FILE_FLAGS_READ);
+
+	data_ptr_t pinned_ptr = nullptr;
+	auto pin = handle->TryReadPinned(QueryContext(), 0, test_content.size(), pinned_ptr);
+	REQUIRE(pin.IsValid());
+	REQUIRE(pinned_ptr != nullptr);
+	REQUIRE(string(const_char_ptr_cast(pinned_ptr), test_content.size()) == test_content);
+
+	// Second pinned read of the same range should be satisfied from cache (no extra underlying read).
+	auto read_count_after_first = tracking_fs_ptr->GetReadCount(test_file.GetPath(), 0, test_content.size());
+	data_ptr_t pinned_ptr2 = nullptr;
+	auto pin2 = handle->TryReadPinned(QueryContext(), 0, test_content.size(), pinned_ptr2);
+	REQUIRE(pin2.IsValid());
+	REQUIRE(pinned_ptr2 != nullptr);
+	REQUIRE(string(const_char_ptr_cast(pinned_ptr2), test_content.size()) == test_content);
+	auto read_count_after_second = tracking_fs_ptr->GetReadCount(test_file.GetPath(), 0, test_content.size());
+	REQUIRE(read_count_after_second == read_count_after_first);
+}
+
+TEST_CASE("FileHandle TryReadPinned unavailable when caching bypassed", "[file_system][caching]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto tracking_fs = make_uniq<TrackingFileSystem>();
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::CACHE_REMOTE_ONLY);
+
+	const string test_content = "Local file should bypass cache wrapper.";
+	TestFileGuard test_file("test_try_read_pinned_bypass.txt", test_content);
+
+	auto handle = caching_wrapper->OpenFile(test_file.GetPath(), FileFlags::FILE_FLAGS_READ);
+	data_ptr_t pinned_ptr = nullptr;
+	auto pin = handle->TryReadPinned(QueryContext(), 0, test_content.size(), pinned_ptr);
+	REQUIRE_FALSE(pin.IsValid());
+	REQUIRE(pinned_ptr == nullptr);
+}
+
 TEST_CASE("CachingFileSystemWrapper caches reads", "[file_system][caching]") {
 	DuckDB db(":memory:");
 	auto &db_instance = *db.instance;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches low-level I/O and Parquet page decompression paths by introducing a pinned, cache-backed read API and using it during Parquet reads; regressions could impact correctness/perf of file reads and cache behavior.
> 
> **Overview**
> Parquet page reading now attempts a **zero-copy** path for compressed data by pinning ranges from the `CachingFileHandle` and decompressing directly from the pinned pointer, with a fallback to the existing allocate+read buffering path.
> 
> This introduces a `FileHandle::TryReadPinned` API (default no-op), wires it through `CachingFileSystemWrapper`, and extends `CachingFileHandle::Read` to accept a per-call `QueryContext` (propagated through interleaved cache reads) so pinned/uncopied reads can still be profiled. New tests validate pinned reads are cached and that the API is unavailable when the wrapper bypasses caching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57e63434dd7db8a01a145144719de41944ccdfb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->