### PR TITLE
Use C++17 hashmap extract

### DIFF
--- a/extension/json/json_reader.cpp
+++ b/extension/json/json_reader.cpp
@@ -269,11 +269,10 @@ optional_ptr<JSONBufferHandle> JSONReader::GetBuffer(idx_t buffer_idx) {
 
 AllocatedData JSONReader::RemoveBuffer(JSONBufferHandle &handle) {
 	lock_guard<mutex> guard(lock);
-	auto it = buffer_map.find(handle.buffer_index);
-	D_ASSERT(it != buffer_map.end());
-	D_ASSERT(RefersToSameObject(handle, *it->second));
-	auto result = std::move(it->second->buffer);
-	buffer_map.erase(it);
+	auto nh = buffer_map.extract(handle.buffer_index);
+	D_ASSERT(!nh.empty());
+	D_ASSERT(RefersToSameObject(handle, *nh.mapped()));
+	auto result = std::move(nh.mapped()->buffer);
 	return result;
 }
 

--- a/src/include/duckdb/common/owning_string_map.hpp
+++ b/src/include/duckdb/common/owning_string_map.hpp
@@ -55,13 +55,11 @@ public:
 		return insert(std::move(entry));
 	}
 	size_type erase(const key_type &k) { // NOLINT: match std style
-		auto entry = map.find(k);
-		if (entry == map.end()) {
+		auto nh = map.extract(k);
+		if (nh.empty()) {
 			return 0;
 		}
-		string_t erase_string = entry->first;
-		map.erase(entry);
-		DestroyString(erase_string);
+		DestroyString(nh.key());
 		return 1;
 	}
 

--- a/src/main/relation/table_function_relation.cpp
+++ b/src/main/relation/table_function_relation.cpp
@@ -18,9 +18,7 @@ void TableFunctionRelation::AddNamedParameter(const string &name, Value argument
 }
 
 void TableFunctionRelation::RemoveNamedParameterIfExists(const string &name) {
-	if (named_parameters.find(name) != named_parameters.end()) {
-		named_parameters.erase(name);
-	}
+	named_parameters.extract(name);
 }
 
 void TableFunctionRelation::SetNamedParameters(named_parameter_map_t &&options) {

--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -211,9 +211,8 @@ void CompressedMaterialization::CreateCompressProjection(unique_ptr<LogicalOpera
 		}
 
 		if (it->first == replacement_binding.old_binding) {
-			auto binding_info_local = std::move(binding_info);
-			binding_map.erase(it);
-			binding_map.emplace(replacement_binding.new_binding, std::move(binding_info_local));
+			auto nh = binding_map.extract(it);
+			binding_map.emplace(replacement_binding.new_binding, std::move(nh.mapped()));
 		}
 	}
 

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -138,9 +138,7 @@ void BindContext::RemoveUsingBinding(const string &column_name, UsingColumnSet &
 		throw InternalException("Attempting to remove using binding that is not there");
 	}
 	auto &bindings = entry->second;
-	if (bindings.find(set) != bindings.end()) {
-		bindings.erase(set);
-	}
+	bindings.extract(set);
 	if (bindings.empty()) {
 		using_columns.erase(column_name);
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk mechanical refactor replacing `find`+`erase` patterns with C++17 `extract()` in a few map/set mutation paths; behavior should be equivalent but touches buffer lifecycle and planner/optimizer bookkeeping.
> 
> **Overview**
> **Switches several container mutations to C++17 node-handle `extract()`** to avoid separate `find`/`erase` and enable move-friendly key replacement.
> 
> This updates buffer removal in the JSON reader, string-key destruction in `OwningStringMap::erase`, named-parameter removal for table functions, binding-key replacement in compressed materialization, and USING-binding removal in the binder to use `extract()`-based logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38d689aa949081fd0d9e7ec52015a0a9c41f6145. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->