### PR TITLE
Initialize encryption util on parquet reader

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -854,6 +854,9 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 		}
 	} else {
 		metadata = std::move(metadata_p);
+		if (parquet_options.encryption_config) {
+			encryption_util = context_p.db->GetEncryptionUtil(true);
+		}
 	}
 	InitializeSchema(context_p);
 }

--- a/test/sql/copy/parquet/issue_21508.test
+++ b/test/sql/copy/parquet/issue_21508.test
@@ -1,0 +1,25 @@
+# name: test/sql/copy/parquet/issue_21508.test
+# description: Issue #21508: crash when read_parquet uses encryption_config with union_by_name=true
+# group: [parquet]
+
+require parquet
+
+require noforcestorage
+
+require httpfs
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA add_parquet_key('key256', '01234567891123450123456789112345')
+
+statement ok
+COPY (SELECT 1 AS id, 'Alice' AS name) TO '__TEST_DIR__/enc_union_by_name.parquet'
+	(FORMAT PARQUET, ENCRYPTION_CONFIG {footer_key: 'key256'})
+
+query II
+SELECT * FROM read_parquet('__TEST_DIR__/enc_union_by_name.parquet',
+	encryption_config={footer_key: 'key256'}, union_by_name=true)
+----
+1	Alice

--- a/test/sql/copy/parquet/parquet_encryption.test
+++ b/test/sql/copy/parquet/parquet_encryption.test
@@ -99,14 +99,3 @@ query I
 SELECT * FROM read_parquet('__TEST_DIR__/encrypted256.parquet', encryption_config={footer_key: 'key256base64'})
 ----
 42
-
-# union_by_name: scan-phase reader reuses bind metadata; encryption_util must still be initialized
-statement ok
-COPY (SELECT 1 AS id, 'Alice' AS name) TO '__TEST_DIR__/enc_union_by_name.parquet'
-	(FORMAT PARQUET, ENCRYPTION_CONFIG {footer_key: 'key256'});
-
-query II
-SELECT * FROM read_parquet('__TEST_DIR__/enc_union_by_name.parquet',
-	encryption_config={footer_key: 'key256'}, union_by_name=true);
-----
-1	Alice

--- a/test/sql/copy/parquet/parquet_encryption.test
+++ b/test/sql/copy/parquet/parquet_encryption.test
@@ -99,3 +99,14 @@ query I
 SELECT * FROM read_parquet('__TEST_DIR__/encrypted256.parquet', encryption_config={footer_key: 'key256base64'})
 ----
 42
+
+# union_by_name: scan-phase reader reuses bind metadata; encryption_util must still be initialized
+statement ok
+COPY (SELECT 1 AS id, 'Alice' AS name) TO '__TEST_DIR__/enc_union_by_name.parquet'
+	(FORMAT PARQUET, ENCRYPTION_CONFIG {footer_key: 'key256'});
+
+query II
+SELECT * FROM read_parquet('__TEST_DIR__/enc_union_by_name.parquet',
+	encryption_config={footer_key: 'key256'}, union_by_name=true);
+----
+1	Alice


### PR DESCRIPTION
https://github.com/duckdb/duckdb/issues/21508

When parquet metadata is not passed to parquet reader on its initialization, `LoadMetadata` is called to (1) initialize encryption utils; (2) load parquet metadata with encryption utils.
https://github.com/duckdb/duckdb/blob/7e7ee2bdd7be363c44e8943c30c25386e0acab1d/extension/parquet/parquet_reader.cpp#L153-L172

But when metadata is passed, we need to make sure encryption util is initialized as well, which will be used to read pages here: https://github.com/duckdb/duckdb/blob/7e7ee2bdd7be363c44e8943c30c25386e0acab1d/extension/parquet/parquet_reader.cpp#L985

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Parquet encryption initialization, which can affect encrypted-file reads and error handling paths. Scope is small and covered by a targeted regression test.
> 
> **Overview**
> Fixes a crash when `read_parquet` is called with `encryption_config` (notably with `union_by_name=true`) by initializing `encryption_util` in `ParquetReader` when metadata is passed in rather than loaded.
> 
> Adds a regression SQL test (`issue_21508.test`) that writes an encrypted Parquet file and validates it can be read back with `encryption_config` and `union_by_name` enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27a5c1d9923566bbd2b789911e49e5ab7777381f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->