### PR TITLE
[CI] Fix a few classes construction order

### DIFF
--- a/extension/parquet/zstd_file_system.cpp
+++ b/extension/parquet/zstd_file_system.cpp
@@ -4,6 +4,8 @@
 
 namespace duckdb {
 
+namespace {
+
 struct ZstdStreamWrapper : public StreamWrapper {
 	~ZstdStreamWrapper() override;
 
@@ -166,7 +168,11 @@ void ZstdStreamWrapper::Close() {
 	zstd_compress_ptr = nullptr;
 }
 
-class ZStdFile : public CompressedFile {
+struct ZStdFileSystemHolder {
+	ZStdFileSystem zstd_fs;
+};
+
+class ZStdFile : private ZStdFileSystemHolder, public CompressedFile {
 public:
 	ZStdFile(QueryContext context, unique_ptr<FileHandle> child_handle_p, const string &path, bool write)
 	    : CompressedFile(zstd_fs, std::move(child_handle_p), path) {
@@ -176,9 +182,9 @@ public:
 	FileCompressionType GetFileCompressionType() override {
 		return FileCompressionType::ZSTD;
 	}
-
-	ZStdFileSystem zstd_fs;
 };
+
+} // namespace
 
 unique_ptr<FileHandle> ZStdFileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
                                                           bool write) {

--- a/src/common/gzip_file_system.cpp
+++ b/src/common/gzip_file_system.cpp
@@ -11,6 +11,8 @@
 
 namespace duckdb {
 
+namespace {
+
 /*
 
   0      2 bytes  magic header  0x1f, 0x8b (\037 \213)
@@ -54,7 +56,7 @@ namespace duckdb {
 
  */
 
-static idx_t GZipConsumeString(QueryContext context, FileHandle &input) {
+idx_t GZipConsumeString(QueryContext context, FileHandle &input) {
 	idx_t size = 1; // terminator
 	char buffer[1];
 	while (input.Read(context, buffer, 1) == 1) {
@@ -307,7 +309,11 @@ void MiniZStreamWrapper::Close() {
 	file = nullptr;
 }
 
-class GZipFile : public CompressedFile {
+struct GZipFileSystemHolder {
+	GZipFileSystem gzip_fs;
+};
+
+class GZipFile : private GZipFileSystemHolder, public CompressedFile {
 public:
 	GZipFile(QueryContext context, unique_ptr<FileHandle> child_handle_p, const string &path, bool write)
 	    : CompressedFile(gzip_fs, std::move(child_handle_p), path) {
@@ -316,8 +322,9 @@ public:
 	FileCompressionType GetFileCompressionType() override {
 		return FileCompressionType::GZIP;
 	}
-	GZipFileSystem gzip_fs;
 };
+
+} // namespace
 
 void GZipFileSystem::VerifyGZIPHeader(uint8_t gzip_hdr[], idx_t read_count, optional_ptr<CompressedFile> source_file) {
 	// include the filename in the error message if known

--- a/src/common/pipe_file_system.cpp
+++ b/src/common/pipe_file_system.cpp
@@ -8,14 +8,18 @@
 
 namespace duckdb {
 
-class PipeFile : public FileHandle {
+namespace {
+struct PipeFileSystemHolder {
+	PipeFileSystem pipe_fs;
+};
+
+class PipeFile : private PipeFileSystemHolder, public FileHandle {
 public:
 	explicit PipeFile(QueryContext context_p, unique_ptr<FileHandle> child_handle_p)
 	    : FileHandle(pipe_fs, child_handle_p->path, child_handle_p->GetFlags()),
 	      child_handle(std::move(child_handle_p)), context(context_p) {
 	}
 
-	PipeFileSystem pipe_fs;
 	unique_ptr<FileHandle> child_handle;
 
 public:
@@ -35,6 +39,7 @@ int64_t PipeFile::ReadChunk(void *buffer, int64_t nr_bytes) {
 int64_t PipeFile::WriteChunk(void *buffer, int64_t nr_bytes) {
 	return child_handle->Write(context, buffer, UnsafeNumericCast<idx_t>(nr_bytes));
 }
+} // namespace
 
 void PipeFileSystem::Reset(FileHandle &handle) {
 	throw InternalException("Cannot reset pipe file system");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes object construction order for `GZipFile`, `ZStdFile`, and `PipeFile` to avoid passing unconstructed `FileSystem` instances into base constructors, which could affect low-level IO behavior if assumptions change.
> 
> **Overview**
> Fixes incorrect construction order in compressed/pipe file handle implementations by ensuring the embedded `*FileSystem` instances are constructed *before* `CompressedFile`/`FileHandle` base classes use them.
> 
> This is done by introducing `*FileSystemHolder` base classes and moving helper types into anonymous namespaces in `gzip_file_system.cpp`, `zstd_file_system.cpp`, and `pipe_file_system.cpp` (including de-`static`ing `GZipConsumeString` since it’s now internally scoped).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ecdc651ba742e86690d473994fbe1d428ff3950. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->