### PR TITLE
[DRAFT] Fix timestamp out of range

### DIFF
--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -30,11 +30,17 @@ bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag,
 		return true; // Assume valid
 	}
 	if (!current_version_tag.empty() || !cached_version_tag.empty()) {
-		return cached_version_tag == current_version_tag; // Validity checked by version tag (httpfs)
+		return cached_version_tag == current_version_tag; // Validity checked by version tag
 	}
 	if (cached_last_modified != current_last_modified) {
 		return false; // The file has certainly been modified
 	}
+
+	// If the modified time is not assigned (i.e., storage backend does not provide it), we can't validate it.
+	if (!Timestamp::IsFinite(current_last_modified) || !Timestamp::IsFinite(cached_last_modified)) {
+		return false;
+	}
+
 	// The last modified time matches. However, we cannot blindly trust this,
 	// because some file systems use a low resolution clock to set the last modified time.
 	// So, we will require that the last modified time is more than 10 seconds ago.

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -157,6 +157,30 @@ public:
 	}
 };
 
+// A filesystem that simulates an HTTP endpoint with no Last-Modified header and no ETag.
+class NoMetadataFileSystem : public LocalFileSystem {
+public:
+	string GetName() const override {
+		return "NoMetadataFileSystem";
+	}
+
+	timestamp_t GetLastModifiedTime(FileHandle &handle) override {
+		return FileMetadata {}.last_modification_time;
+	}
+
+	string GetVersionTag(FileHandle &handle) override {
+		return "";
+	}
+
+	bool CanHandleFile(const string &path) override {
+		return StringUtil::StartsWith(path, TestDirectoryPath());
+	}
+
+	bool CanSeek() override {
+		return true;
+	}
+};
+
 //===----------------------------------------------------------------------===//
 // CachingFileSystemWrapper Tests
 //===----------------------------------------------------------------------===//
@@ -703,6 +727,22 @@ TEST_CASE("CachingFileSystemWrapper zero-byte read", "[file_system][caching]") {
 
 	REQUIRE_NOTHROW(handle->Read(QueryContext(), &buffer[0], /*nr_bytes=*/0, /*location=*/0));
 	REQUIRE_NOTHROW(handle->Read(QueryContext(), &buffer[0], /*nr_bytes=*/0, /*location=*/10));
+}
+
+TEST_CASE("CachingFileSystemWrapper does not overflow on ninfinity last_modified", "[file_system][caching]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto no_meta_fs = make_uniq<NoMetadataFileSystem>();
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*no_meta_fs, db_instance, CachingMode::ALWAYS_CACHE);
+
+	const string test_content = "Test content for ninfinity last_modified overflow reproducer.";
+	TestFileGuard test_file("test_ninfinity_last_modified.txt", test_content);
+
+	auto handle = caching_wrapper->OpenFile(test_file.GetPath(), FileFlags::FILE_FLAGS_READ);
+	string buffer(200, '\0');
+	REQUIRE_NOTHROW(handle->Read(QueryContext(), &buffer[0], test_content.size(), /*location=*/0));
+	REQUIRE(buffer.substr(0, test_content.size()) == test_content);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes cache validation behavior for backends that don’t provide `ETag`/`Last-Modified`, which could increase cache misses or alter refresh behavior. The logic is small and covered by a new regression test, but it affects external file caching correctness.
> 
> **Overview**
> Prevents `ExternalFileCache::IsValid` from doing arithmetic on non-finite `last_modified` values (e.g., `-inf`/`+inf`) by treating such entries as *not valid* when no version tag is available.
> 
> Adds a regression test with a `NoMetadataFileSystem` that returns no `ETag` and an unassigned `Last-Modified`, ensuring `CachingFileSystemWrapper` reads succeed without overflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ace92ee96172fff4c3b1693514f552890f939d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->