### PR TITLE
duckdb fuzzer 4233: better error propagation

### DIFF
--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -179,7 +179,10 @@ void CSVMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &r
 			names = options.name_list;
 			return_types = options.sql_type_list;
 		}
-		D_ASSERT(return_types.size() == names.size());
+		if (return_types.size() != names.size()) {
+			throw BinderException("read_csv: mismatch between the number of column names (%d) and column types (%d)",
+			                      names.size(), return_types.size());
+		}
 		csv_data.options.dialect_options.num_cols = names.size();
 
 		bind_data.multi_file_reader->BindOptions(bind_data.file_options, multi_file_list, return_types, names,

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -779,14 +779,14 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 			parsed_types.push_back(std::move(def_type));
 		}
 
-		// If columns already set sql_type_list, verify they match
+		// If columns already set sql_type_list, verify they match but keep columns' mappings
 		if (columns_set && !sql_type_list.empty()) {
 			VerifyTypeListsMatch(sql_type_list, parsed_types);
 		} else {
 			sql_type_list = std::move(parsed_types);
-		}
-		if (!parsed_types_per_column.empty()) {
-			sql_types_per_column = std::move(parsed_types_per_column);
+			if (!parsed_types_per_column.empty()) {
+				sql_types_per_column = std::move(parsed_types_per_column);
+			}
 		}
 	} else if (loption == "all_varchar") {
 		all_varchar = GetBooleanValue(loption, val);

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -9,6 +9,21 @@
 
 namespace duckdb {
 
+namespace {
+
+void VerifyTypeListsMatch(const vector<LogicalType> &existing, const vector<LogicalType> &incoming) {
+	if (existing.size() != incoming.size()) {
+		throw BinderException("read_csv column types specified by 'columns' and 'types' doesn't match");
+	}
+	for (idx_t i = 0; i < incoming.size(); i++) {
+		if (existing[i] != incoming[i]) {
+			throw BinderException("read_csv column types specified by 'columns' and 'types' doesn't match");
+		}
+	}
+}
+
+} // namespace
+
 CSVReaderOptions::CSVReaderOptions(const CSVOption<char> single_byte_delimiter,
                                    const CSVOption<string> &multi_byte_delimiter) {
 	if (multi_byte_delimiter.GetValue().empty()) {
@@ -638,19 +653,31 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 		}
 		auto &struct_children = StructValue::GetChildren(val);
 		D_ASSERT(StructType::GetChildCount(child_type) == struct_children.size());
+
+		// Parse into temporary lists first
+		vector<string> parsed_names;
+		vector<LogicalType> parsed_types;
+		case_insensitive_map_t<idx_t> parsed_types_per_column;
 		for (idx_t i = 0; i < struct_children.size(); i++) {
 			auto &name = StructType::GetChildName(child_type, i);
 			auto &val = struct_children[i];
-			name_list.push_back(name);
+			parsed_names.push_back(name);
 			if (val.type().id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("read_csv requires a type specification as string");
 			}
-			sql_types_per_column[name] = i;
-			sql_type_list.emplace_back(TransformStringToLogicalType(StringValue::Get(val), context));
+			parsed_types_per_column[name] = i;
+			parsed_types.emplace_back(TransformStringToLogicalType(StringValue::Get(val), context));
 		}
-		if (name_list.empty()) {
+		if (parsed_names.empty()) {
 			throw BinderException("read_csv requires at least a single column as input!");
 		}
+		// If types were already set by 'types'/'dtypes'/'column_types', verify they match
+		if (!sql_type_list.empty()) {
+			VerifyTypeListsMatch(sql_type_list, parsed_types);
+		}
+		name_list = std::move(parsed_names);
+		sql_type_list = std::move(parsed_types);
+		sql_types_per_column = std::move(parsed_types_per_column);
 	} else if (loption == "auto_type_candidates") {
 		auto_type_candidates.clear();
 		map<uint8_t, LogicalType> candidate_types;
@@ -713,10 +740,13 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 		if (child_type.id() != LogicalTypeId::STRUCT && child_type.id() != LogicalTypeId::LIST) {
 			throw BinderException("read_csv %s requires a struct or list as input", key);
 		}
-		if (!sql_type_list.empty()) {
+		if (!columns_set && !sql_type_list.empty()) {
 			throw BinderException("read_csv column_types/types/dtypes can only be supplied once");
 		}
+
+		// Parse into temporary lists first
 		vector<string> sql_type_names;
+		case_insensitive_map_t<idx_t> parsed_types_per_column;
 		if (child_type.id() == LogicalTypeId::STRUCT) {
 			auto &struct_children = StructValue::GetChildren(val);
 			D_ASSERT(StructType::GetChildCount(child_type) == struct_children.size());
@@ -727,7 +757,7 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 					throw BinderException("read_csv %s requires a type specification as string", key);
 				}
 				sql_type_names.push_back(StringValue::Get(val));
-				sql_types_per_column[name] = i;
+				parsed_types_per_column[name] = i;
 			}
 		} else {
 			auto &list_child = ListType::GetChildType(child_type);
@@ -739,13 +769,24 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 				sql_type_names.push_back(StringValue::Get(child));
 			}
 		}
-		sql_type_list.reserve(sql_type_names.size());
+		vector<LogicalType> parsed_types;
+		parsed_types.reserve(sql_type_names.size());
 		for (auto &sql_type : sql_type_names) {
 			auto def_type = TransformStringToLogicalType(sql_type, context);
 			if (def_type.id() == LogicalTypeId::UNBOUND) {
 				throw BinderException("Unrecognized type \"%s\" for read_csv %s definition", sql_type, key);
 			}
-			sql_type_list.push_back(std::move(def_type));
+			parsed_types.push_back(std::move(def_type));
+		}
+
+		// If columns already set sql_type_list, verify they match
+		if (columns_set && !sql_type_list.empty()) {
+			VerifyTypeListsMatch(sql_type_list, parsed_types);
+		} else {
+			sql_type_list = std::move(parsed_types);
+		}
+		if (!parsed_types_per_column.empty()) {
+			sql_types_per_column = std::move(parsed_types_per_column);
 		}
 	} else if (loption == "all_varchar") {
 		all_varchar = GetBooleanValue(loption, val);

--- a/test/sql/copy/csv/csv_dtypes.test
+++ b/test/sql/copy/csv/csv_dtypes.test
@@ -55,3 +55,39 @@ statement error
 select * from read_csv_auto('{DATA_DIR}/csv/auto/int_bol.csv', dtypes=['varchar', 'varchar', 'varchar']) LIMIT 1
 ----
 3 types were provided, but CSV file only has 2 columns
+
+# columns + types conflict (columns already defines types)
+statement error
+select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', auto_detect=false, columns={'a':'varchar'}, types=['BIGINT', 'DATE'])
+----
+column types specified by 'columns' and 'types' doesn't match
+
+# columns + dtypes conflict
+statement error
+select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', auto_detect=false, columns={'a':'varchar'}, dtypes=['BIGINT'])
+----
+column types specified by 'columns' and 'types' doesn't match
+
+# columns + column_types conflict
+statement error
+select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', auto_detect=false, columns={'a':'varchar'}, column_types={'a': 'BIGINT'})
+----
+column types specified by 'columns' and 'types' doesn't match
+
+# columns + types match each other but differ from sniffer (sniffer would detect BIGINT, BOOLEAN)
+query II
+select typeof(i), typeof(b) from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}, types=['VARCHAR', 'VARCHAR']) LIMIT 1
+----
+VARCHAR	VARCHAR
+
+# columns + types mismatch: same count but different types
+statement error
+select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}, types=['VARCHAR', 'INTEGER'])
+----
+column types specified by 'columns' and 'types' doesn't match
+
+# columns types override sniffer auto-detection (sniffer would detect BIGINT, BOOLEAN)
+query II
+select typeof(i), typeof(b) from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}) LIMIT 1
+----
+VARCHAR	VARCHAR

--- a/test/sql/copy/csv/csv_dtypes.test
+++ b/test/sql/copy/csv/csv_dtypes.test
@@ -86,6 +86,18 @@ select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar'
 ----
 column types specified by 'columns' and 'types' doesn't match
 
+# columns + struct-style column_types with different key names but matching types: columns' name mapping must be preserved
+query II
+select typeof(i), typeof(b) from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}, column_types={'x': 'VARCHAR', 'y': 'VARCHAR'}) LIMIT 1
+----
+VARCHAR	VARCHAR
+
+# columns + struct-style column_types with different key names and mismatching types
+statement error
+select * from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}, column_types={'x': 'INTEGER', 'y': 'BOOLEAN'})
+----
+column types specified by 'columns' and 'types' doesn't match
+
 # columns types override sniffer auto-detection (sniffer would detect BIGINT, BOOLEAN)
 query II
 select typeof(i), typeof(b) from read_csv('{DATA_DIR}/csv/auto/int_bol.csv', columns={'i':'varchar', 'b':'varchar'}) LIMIT 1


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb-fuzzer/issues/4223

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CSV binding and option parsing logic that affects many `read_csv*` call paths; risk is mostly user-facing behavior changes (new/clearer errors) and potential edge cases around option precedence/mapping.
> 
> **Overview**
> Improves `read_csv`/`read_csv_auto` error propagation by replacing a debug assertion with a user-facing `BinderException` when the number of column names and types differs during binding.
> 
> Tightens option parsing so `columns` and `types`/`dtypes`/`column_types` must be consistent: the code now parses into temporary lists, validates that pre-specified type lists match exactly, and preserves the `columns` name-to-index mapping when both are provided. Adds regression tests covering mismatched and matching combinations across list- and struct-style type specifications.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3041fbef5fa39d3f45df9852e08e9ad999bb619f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->