### PR TITLE
[DRAFT] Fix NULL input for is_histogram_other_bin

### DIFF
--- a/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -264,6 +264,17 @@ void IsHistogramOtherBinFunction(DataChunk &args, ExpressionState &state, Vector
 	auto v = OtherBucketValue(input_type);
 	Vector ref(v);
 	VectorOperations::NotDistinctFrom(args.data[0], ref, result, args.size());
+
+	// Set NULL if input is NULL.
+	auto input_validity = args.data[0].Validity(args.size());
+	if (input_validity.CanHaveNull()) {
+		auto &result_validity = FlatVector::Validity(result);
+		for (idx_t idx = 0; idx < args.size(); ++idx) {
+			if (!input_validity.IsValid(idx)) {
+				result_validity.SetInvalid(idx);
+			}
+		}
+	}
 }
 
 template <class OP, class T>

--- a/test/sql/aggregate/aggregates/duckdb_fuzzer_4313.test
+++ b/test/sql/aggregate/aggregates/duckdb_fuzzer_4313.test
@@ -1,4 +1,3 @@
-
 # name: test/sql/aggregate/aggregates/duckdb_fuzzer_4313.test
 # description: Test is_histogram_other_bin with NULL values
 # group: [aggregates]
@@ -8,3 +7,11 @@ create table all_types as select * exclude(small_enum, medium_enum, large_enum) 
 
 statement ok
 SELECT is_histogram_other_bin(c7) FROM all_types AS t52(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51)
+
+# Test with a mix of NULL and non-NULL values
+query I
+SELECT is_histogram_other_bin(x) FROM (SELECT uhugeint as x FROM test_all_types())
+----
+false
+true
+NULL

--- a/test/sql/aggregate/aggregates/duckdb_fuzzer_4313.test
+++ b/test/sql/aggregate/aggregates/duckdb_fuzzer_4313.test
@@ -2,16 +2,8 @@
 # description: Test is_histogram_other_bin with NULL values
 # group: [aggregates]
 
-statement ok
-create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types();
-
-statement ok
-SELECT is_histogram_other_bin(c7) FROM all_types AS t52(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51)
-
-# Test with a mix of NULL and non-NULL values
 query I
-SELECT is_histogram_other_bin(x) FROM (SELECT uhugeint as x FROM test_all_types())
+SELECT is_histogram_other_bin(x::BIGINT) FROM(VALUES(1), (NULL)) t(x);
 ----
 false
-true
 NULL

--- a/test/sql/aggregate/aggregates/duckdb_fuzzer_4313.test
+++ b/test/sql/aggregate/aggregates/duckdb_fuzzer_4313.test
@@ -1,0 +1,10 @@
+
+# name: test/sql/aggregate/aggregates/duckdb_fuzzer_4313.test
+# description: Test is_histogram_other_bin with NULL values
+# group: [aggregates]
+
+statement ok
+create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types();
+
+statement ok
+SELECT is_histogram_other_bin(c7) FROM all_types AS t52(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51)


### PR DESCRIPTION
https://github.com/duckdb/duckdb-fuzzer/issues/4313
https://github.com/duckdb/duckdb-fuzzer/issues/4350

From stacktrace, the assertion failure happens at `ExpressionExecutor::Execute`
- It first execute the function logic: https://github.com/duckdb/duckdb/blob/5c2c9c2f45de1887bd080bcab101b905264dcf74/src/execution/expression_executor/execute_function.cpp#L204
- Then verify null handling: https://github.com/duckdb/duckdb/blob/5c2c9c2f45de1887bd080bcab101b905264dcf74/src/execution/expression_executor/execute_function.cpp#L216


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to `is_histogram_other_bin` NULL/validity handling plus a regression test; minimal impact outside this scalar function.
> 
> **Overview**
> Fixes `is_histogram_other_bin` to **preserve NULL semantics**: after computing `NOT DISTINCT FROM` against the type-specific “other bucket” sentinel, the result validity is now explicitly set to NULL wherever the input is NULL.
> 
> Adds a regression test (`duckdb_fuzzer_4313.test`) asserting `is_histogram_other_bin(NULL)` returns `NULL` (and non-sentinel values return `false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffeb2b9527d9476087e6669f21f7a09581fb9f2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->