### PR TITLE
[DRAFT] Fix buffer pool reservation for move assignment

### DIFF
--- a/src/storage/buffer/buffer_pool_reservation.cpp
+++ b/src/storage/buffer/buffer_pool_reservation.cpp
@@ -13,6 +13,7 @@ BufferPoolReservation::BufferPoolReservation(BufferPoolReservation &&src) noexce
 }
 
 BufferPoolReservation &BufferPoolReservation::operator=(BufferPoolReservation &&src) noexcept {
+	pool.UpdateUsedMemory(tag, -UnsafeNumericCast<int64_t>(size));
 	tag = src.tag;
 	size = src.size;
 	src.size = 0;

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library_unity(
   test_parse_logical_type.cpp
   test_utf.cpp
   test_allocator_debug_info.cpp
+  test_buffer_pool_reservation.cpp
   test_storage_fuzz.cpp
   test_strftime.cpp
   test_string_util.cpp)

--- a/test/common/test_buffer_pool_reservation.cpp
+++ b/test/common/test_buffer_pool_reservation.cpp
@@ -1,0 +1,31 @@
+#include "catch.hpp"
+#include "duckdb/storage/buffer/buffer_pool.hpp"
+#include "duckdb/storage/buffer/buffer_pool_reservation.hpp"
+#include "duckdb/main/database.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb; // NOLINT
+
+TEST_CASE("BufferPoolReservation move assignment releases old reservation", "[storage][buffer_pool]") {
+	DuckDB db;
+	Connection con(db);
+	auto &context = *con.context;
+	auto &pool = DatabaseInstance::GetDatabase(context).GetBufferPool();
+
+	auto baseline = pool.GetUsedMemory();
+
+	BufferPoolReservation r1(MemoryTag::BASE_TABLE, pool);
+	r1.Resize(1000);
+	REQUIRE(pool.GetUsedMemory() == baseline + 1000);
+
+	BufferPoolReservation r2(MemoryTag::BASE_TABLE, pool);
+	r2.Resize(500);
+	REQUIRE(pool.GetUsedMemory() == baseline + 1500);
+
+	r1 = std::move(r2);
+	REQUIRE(r1.size == 500);
+	REQUIRE(r2.size == 0);
+	REQUIRE(pool.GetUsedMemory() == baseline + 500);
+
+	r1.Resize(0);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches buffer pool memory accounting by changing `BufferPoolReservation` move-assignment behavior; incorrect updates could skew `GetUsedMemory()` and affect eviction/limits, but the change is small and covered by a new test.
> 
> **Overview**
> Fixes `BufferPoolReservation` move assignment to **release any existing reservation** before taking ownership from the moved-from instance, preventing buffer pool used-memory from remaining overcounted.
> 
> Adds a focused unit test (`test_buffer_pool_reservation.cpp`) and wires it into the common test build to assert `GetUsedMemory()` drops appropriately after move-assignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578550b4e2334fc2936c4d1d1f6199eb9e89afe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->