### PR TITLE
[DRAFT] Fix arena allocation size at reset

### DIFF
--- a/src/storage/arena_allocator.cpp
+++ b/src/storage/arena_allocator.cpp
@@ -148,7 +148,7 @@ void ArenaAllocator::Reset() {
 		head->current_position = 0;
 		head->prev = nullptr;
 	}
-	allocated_size = 0;
+	allocated_size = head ? head->maximum_size : 0;
 }
 
 void ArenaAllocator::Destroy() {

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library_unity(
   test_parse_logical_type.cpp
   test_utf.cpp
   test_allocator_debug_info.cpp
+  test_arena_allocator.cpp
   test_storage_fuzz.cpp
   test_strftime.cpp
   test_string_util.cpp)

--- a/test/common/test_arena_allocator.cpp
+++ b/test/common/test_arena_allocator.cpp
@@ -1,0 +1,27 @@
+#include "catch.hpp"
+#include "duckdb/storage/arena_allocator.hpp"
+#include "duckdb/common/allocator.hpp"
+
+using namespace duckdb; // NOLINT
+
+TEST_CASE("ArenaAllocator Reset preserves head chunk allocation size", "[arena_allocator]") {
+	Allocator &alloc = Allocator::DefaultAllocator();
+
+	ArenaAllocator arena(alloc, 64);
+
+	arena.Allocate(32);
+	auto size_after_first = arena.AllocationSize();
+	for (int i = 0; i < 10; i++) {
+		arena.Allocate(size_after_first);
+	}
+	REQUIRE(arena.AllocationSize() > size_after_first);
+
+	arena.Reset();
+	REQUIRE(arena.SizeInBytes() == 0);
+
+	auto head = arena.GetHead();
+	REQUIRE(head != nullptr);
+	REQUIRE(arena.AllocationSize() == head->maximum_size);
+	REQUIRE(head->next == nullptr);
+	REQUIRE(arena.GetHead() == arena.GetTail());
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small change to allocator bookkeeping during `ArenaAllocator::Reset` plus a focused unit test; behavior change is limited to the cached allocation-size metric after reset.
> 
> **Overview**
> Fixes `ArenaAllocator::Reset` to keep `AllocationSize()` consistent with the remaining head chunk by setting `allocated_size` to `head->maximum_size` (or `0` when empty) instead of clearing it.
> 
> Adds a new `test_arena_allocator.cpp` and wires it into `test/common/CMakeLists.txt` to assert that `Reset()` drops used bytes, frees extra chunks, and preserves the head chunk’s allocation size and head/tail invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7637c32afe217b172b176329870bf371ac4550e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->