### PR TITLE
[DRAFT] Fix double evicted data decrement

### DIFF
--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -566,9 +566,6 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(QueryContext c
 	// Delete the file and return the buffer.
 	DeleteTemporaryFile(block.GetMemory());
 
-	// Decrement evicted size.
-	evicted_data_per_tag[uint8_t(tag)] -= buffer->AllocSize();
-
 	return buffer;
 }
 

--- a/test/sql/storage/test_buffer_manager.cpp
+++ b/test/sql/storage/test_buffer_manager.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/storage/buffer/block_handle.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/storage_info.hpp"
+#include "duckdb/common/enums/memory_tag.hpp"
 #include "test_helpers.hpp"
 
 using namespace duckdb;
@@ -256,6 +257,47 @@ TEST_CASE("Test buffer manager buffer re-use", "[storage][.]") {
 	}
 	blocks.clear();
 	CHECK(buffer_manager.GetUsedMemory() == 0);
+}
+
+TEST_CASE("Test evicted_data not double-decremented for variable-sized blocks", "[storage][.]") {
+	auto storage_database = TestCreatePath("storage_test");
+	auto config = GetTestConfig();
+	config->SetOptionByName("default_block_size", Value::UBIGINT(DEFAULT_BLOCK_ALLOC_SIZE));
+	config->options.maximum_threads = 1;
+	DeleteDatabase(storage_database);
+	DuckDB db(storage_database, config.get());
+	Connection con(db);
+	auto &buffer_manager = BufferManager::GetBufferManager(*con.context);
+
+	idx_t variable_block_size = 424242;
+	auto alloc_size = BufferManager::GetAllocSize(variable_block_size + Storage::DEFAULT_BLOCK_HEADER_SIZE);
+	REQUIRE_NO_FAIL(con.Query(StringUtil::Format("PRAGMA memory_limit='%lldB'", alloc_size)));
+	REQUIRE_NO_FAIL(con.Query("PRAGMA temp_directory='" + TestCreatePath("eviction_tracking_temp") + "'"));
+
+	shared_ptr<BlockHandle> block_a = nullptr;
+	shared_ptr<BlockHandle> block_b = nullptr;
+	{
+		auto pin = buffer_manager.Allocate(MemoryTag::EXTENSION, variable_block_size, false);
+		block_a = pin.GetBlockHandle();
+	}
+	{
+		auto pin = buffer_manager.Allocate(MemoryTag::EXTENSION, variable_block_size, false);
+		block_b = pin.GetBlockHandle();
+	}
+
+	// Read block_a back from disk.
+	{ auto pin = buffer_manager.Pin(block_a); }
+
+	// Destroy both handles, so remaining temp files are cleaned up.
+	block_a.reset();
+	block_b.reset();
+
+	// For now there should be no blocks on disk, and evicted_data must be 0.
+	for (auto &entry : buffer_manager.GetMemoryUsageInfo()) {
+		if (entry.tag == MemoryTag::EXTENSION) {
+			CHECK(entry.evicted_data == 0);
+		}
+	}
 }
 
 TEST_CASE("Test buffer allocator", "[storage][.]") {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core buffer-manager swap accounting and temp-file deletion behavior; mistakes could skew memory/eviction metrics or leak swap-space tracking, but the change is small and covered by a regression test.
> 
> **Overview**
> Fixes `StandardBufferManager` eviction accounting so `evicted_data_per_tag` is not decremented twice for variable-sized temporary `.block` files by only updating the counter when the temp file is actually deleted.
> 
> Adds debug assertions to prevent `evicted_data_per_tag` underflow, and switches temp-file deletion to use `FILE_FLAGS_NULL_IF_NOT_EXISTS` to avoid decrementing when the file is already gone. Includes a new storage test that forces eviction of variable-sized blocks and verifies `evicted_data` returns to `0` after cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d52c33daf4b4396b3530f8a69384fba4b212412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->