### PR TITLE
[DRAFT] Fix column data allocator

### DIFF
--- a/src/common/types/column/column_data_allocator.cpp
+++ b/src/common/types/column/column_data_allocator.cpp
@@ -48,7 +48,7 @@ ColumnDataAllocator::ColumnDataAllocator(ColumnDataAllocator &other) {
 	case ColumnDataAllocatorType::HYBRID:
 		alloc.buffer_manager = other.alloc.buffer_manager;
 		if (other.managed_result_set.IsValid()) {
-			ResultSetManager::Get(alloc.buffer_manager->GetDatabase()).Add(*this);
+			managed_result_set = ResultSetManager::Get(alloc.buffer_manager->GetDatabase()).Add(*this);
 		}
 		break;
 	case ColumnDataAllocatorType::IN_MEMORY_ALLOCATOR:

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library_unity(
   OBJECT
   test_cast.cpp
   test_checksum.cpp
+  test_column_data_allocator.cpp
   test_file_buffer_handle_group.cpp
   test_file_system.cpp
   test_caching_file_system_wrapper.cpp

--- a/test/common/test_column_data_allocator.cpp
+++ b/test/common/test_column_data_allocator.cpp
@@ -1,0 +1,21 @@
+#include "catch.hpp"
+#include "duckdb.hpp"
+#include "duckdb/common/types/column/column_data_allocator.hpp"
+#include "duckdb/storage/buffer_manager.hpp"
+#include "test_helpers.hpp"
+
+namespace duckdb {
+
+TEST_CASE("ColumnDataAllocator copy constructor preserves managed_result_set", "[column_data_allocator]") {
+	DuckDB db(":memory:");
+	auto &buffer_manager = BufferManager::GetBufferManager(*db.instance);
+
+	ColumnDataAllocator original(buffer_manager, ColumnDataCollectionLifetime::THROW_ERROR_AFTER_DATABASE_CLOSES);
+	REQUIRE(original.GetDatabase() != nullptr);
+
+	ColumnDataAllocator copied(original);
+	REQUIRE(copied.GetDatabase() != nullptr);
+	REQUIRE(copied.GetType() == ColumnDataAllocatorType::BUFFER_MANAGER_ALLOCATOR);
+}
+
+} // namespace duckdb


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches buffer-manager-backed allocator lifetime management; incorrect registration/unregistration could lead to leaks or use-after-close, but the change is small and now covered by a regression test.
> 
> **Overview**
> Fixes `ColumnDataAllocator` copy construction so that when the source allocator is registered with `ResultSetManager`, the copy also stores the returned `managed_result_set` handle instead of discarding it.
> 
> Adds a small unit test (`test_column_data_allocator.cpp`) and wires it into `test/common/CMakeLists.txt` to assert copied allocators still report a valid database under `THROW_ERROR_AFTER_DATABASE_CLOSES` lifetime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cbf98c7d131cb4cb434ba377f2929014393888b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->