### PR TITLE
[WIP] introduce checked integer

### DIFF
--- a/src/include/duckdb/common/checked_integer.hpp
+++ b/src/include/duckdb/common/checked_integer.hpp
@@ -1,0 +1,426 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/checked_integer.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/limits.hpp"
+#include "duckdb/common/operator/add.hpp"
+#include "duckdb/common/operator/multiply.hpp"
+#include "duckdb/common/operator/subtract.hpp"
+
+#include <type_traits>
+
+namespace duckdb {
+
+//! CheckedInteger is a templated wrapper around integer types (signed or unsigned) that throws an InternalException on overflow or underflow for arithmetic operations.
+template <class T>
+class CheckedInteger {
+	static_assert(std::is_integral<T>::value, "CheckedInteger only supports integral types");
+
+private:
+	T value;
+
+public:
+	using value_type = T;
+
+	CheckedInteger() : value(0) {}
+	CheckedInteger(T v) : value(v) {} // NOLINT
+
+	template <class U, typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
+	CheckedInteger(U v) : value(ValidateAndCast<U>(v)) {} // NOLINT
+
+	explicit operator T() const {
+		return value;
+	}
+
+	T GetValue() const {
+		return value;
+	}
+
+	CheckedInteger &operator++() {
+		T result;
+		if (!TryAddOperator::Operation(value, T(1), result)) {
+			throw InternalException("Overflow in increment of CheckedInteger");
+		}
+		value = result;
+		return *this;
+	}
+
+	CheckedInteger operator++(int) {
+		CheckedInteger tmp(*this);
+		++(*this);
+		return tmp;
+	}
+
+	CheckedInteger &operator--() {
+		T result;
+		if (!TrySubtractOperator::Operation(value, T(1), result)) {
+			throw InternalException("Underflow in decrement of CheckedInteger");
+		}
+		value = result;
+		return *this;
+	}
+
+	CheckedInteger operator--(int) {
+		CheckedInteger tmp(*this);
+		--(*this);
+		return tmp;
+	}
+
+	CheckedInteger &operator+=(CheckedInteger rhs) {
+		return operator+=(rhs.value);
+	}
+	CheckedInteger &operator+=(T rhs) {
+		T result;
+		if (!TryAddOperator::Operation(value, rhs, result)) {
+			throw InternalException("Overflow in addition for CheckedInteger");
+		}
+		value = result;
+		return *this;
+	}
+	template <class U, typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
+	CheckedInteger &operator+=(U rhs) {
+		using Promoted = typename std::common_type<T, U>::type;
+		if constexpr (std::is_floating_point<U>::value) {
+			ValidateAssignment(rhs);
+			return operator+=(static_cast<T>(rhs));
+		} else if constexpr (std::is_same<Promoted, T>::value) {
+			if constexpr (std::is_unsigned<T>::value && std::is_signed<U>::value) {
+				if (rhs < 0) {
+					return operator-=(ToAbsoluteT(rhs));
+				}
+			}
+			return operator+=(static_cast<T>(rhs));
+		} else {
+			Promoted result = static_cast<Promoted>(value) + static_cast<Promoted>(rhs);
+			if (static_cast<Promoted>(static_cast<T>(result)) != result) {
+				throw InternalException("Overflow in addition for CheckedInteger");
+			}
+			value = static_cast<T>(result);
+			return *this;
+		}
+	}
+
+	CheckedInteger &operator-=(CheckedInteger rhs) {
+		return operator-=(rhs.value);
+	}
+	CheckedInteger &operator-=(T rhs) {
+		T result;
+		if (!TrySubtractOperator::Operation(value, rhs, result)) {
+			throw InternalException("Underflow in subtraction for CheckedInteger");
+		}
+		value = result;
+		return *this;
+	}
+	template <class U, typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
+	CheckedInteger &operator-=(U rhs) {
+		using Promoted = typename std::common_type<T, U>::type;
+		if constexpr (std::is_floating_point<U>::value) {
+			ValidateAssignment(rhs);
+			return operator-=(static_cast<T>(rhs));
+		} else if constexpr (std::is_same<Promoted, T>::value) {
+			if constexpr (std::is_unsigned<T>::value && std::is_signed<U>::value) {
+				if (rhs < 0) {
+					return operator+=(ToAbsoluteT(rhs));
+				}
+			}
+			return operator-=(static_cast<T>(rhs));
+		} else {
+			Promoted result = static_cast<Promoted>(value) - static_cast<Promoted>(rhs);
+			if (static_cast<Promoted>(static_cast<T>(result)) != result) {
+				throw InternalException("Underflow in subtraction for CheckedInteger");
+			}
+			value = static_cast<T>(result);
+			return *this;
+		}
+	}
+
+	CheckedInteger &operator*=(CheckedInteger rhs) {
+		return operator*=(rhs.value);
+	}
+	CheckedInteger &operator*=(T rhs) {
+		T result;
+		if (!TryMultiplyOperator::Operation(value, rhs, result)) {
+			throw InternalException("Overflow in multiplication for CheckedInteger");
+		}
+		value = result;
+		return *this;
+	}
+	template <class U, typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
+	CheckedInteger &operator*=(U rhs) {
+		using Promoted = typename std::common_type<T, U>::type;
+		if constexpr (std::is_floating_point<U>::value) {
+			ValidateAssignment(rhs);
+			return operator*=(static_cast<T>(rhs));
+		} else if constexpr (std::is_same<Promoted, T>::value) {
+			if constexpr (std::is_unsigned<T>::value && std::is_signed<U>::value) {
+				if (rhs < 0) {
+					throw InternalException("Cannot multiply unsigned CheckedInteger by negative value");
+				}
+			}
+			return operator*=(static_cast<T>(rhs));
+		} else {
+			Promoted result = static_cast<Promoted>(value) * static_cast<Promoted>(rhs);
+			if (static_cast<Promoted>(static_cast<T>(result)) != result) {
+				throw InternalException("Overflow in multiplication for CheckedInteger");
+			}
+			value = static_cast<T>(result);
+			return *this;
+		}
+	}
+
+	CheckedInteger &operator/=(CheckedInteger rhs) {
+		return operator/=(rhs.value);
+	}
+	CheckedInteger &operator/=(T rhs) {
+		if (rhs == 0) {
+			throw InternalException("Division by zero in CheckedInteger");
+		}
+		if (NumericLimits<T>::IsSigned() && value == NumericLimits<T>::Minimum() && rhs == T(-1)) {
+			throw InternalException("Overflow in division for CheckedInteger");
+		}
+		value /= rhs;
+		return *this;
+	}
+	template <class U, typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
+	CheckedInteger &operator/=(U rhs) {
+		using Promoted = typename std::common_type<T, U>::type;
+		if constexpr (std::is_floating_point<U>::value) {
+			ValidateAssignment(rhs);
+			return operator/=(static_cast<T>(rhs));
+		} else if constexpr (std::is_same<Promoted, T>::value) {
+			if constexpr (std::is_unsigned<T>::value && std::is_signed<U>::value) {
+				if (rhs < 0) {
+					throw InternalException("Cannot divide unsigned CheckedInteger by negative value");
+				}
+			}
+			return operator/=(static_cast<T>(rhs));
+		} else {
+			if (rhs == 0) {
+				throw InternalException("Division by zero in CheckedInteger");
+			}
+			Promoted result = static_cast<Promoted>(value) / static_cast<Promoted>(rhs);
+			if (static_cast<Promoted>(static_cast<T>(result)) != result) {
+				throw InternalException("Overflow in division for CheckedInteger");
+			}
+			value = static_cast<T>(result);
+			return *this;
+		}
+	}
+
+	CheckedInteger operator+(CheckedInteger rhs) const {
+		return operator+(rhs.value);
+	}
+	CheckedInteger operator+(T rhs) const {
+		T result;
+		if (!TryAddOperator::Operation(value, rhs, result)) {
+			throw InternalException("Overflow in addition for CheckedInteger");
+		}
+		return CheckedInteger(result);
+	}
+	template <class U, typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
+	CheckedInteger operator+(U rhs) const {
+		using Promoted = typename std::common_type<T, U>::type;
+		if constexpr (std::is_floating_point<U>::value) {
+			ValidateAssignment(rhs);
+			return operator+(static_cast<T>(rhs));
+		} else if constexpr (std::is_same<Promoted, T>::value) {
+			if constexpr (std::is_unsigned<T>::value && std::is_signed<U>::value) {
+				if (rhs < 0) {
+					return operator-(ToAbsoluteT(rhs));
+				}
+			}
+			return operator+(static_cast<T>(rhs));
+		} else {
+			Promoted result = static_cast<Promoted>(value) + static_cast<Promoted>(rhs);
+			if (static_cast<Promoted>(static_cast<T>(result)) != result) {
+				throw InternalException("Overflow in addition for CheckedInteger");
+			}
+			return CheckedInteger(static_cast<T>(result));
+		}
+	}
+
+	CheckedInteger operator-(CheckedInteger rhs) const {
+		return operator-(rhs.value);
+	}
+	CheckedInteger operator-(T rhs) const {
+		T result;
+		if (!TrySubtractOperator::Operation(value, rhs, result)) {
+			throw InternalException("Underflow in subtraction for CheckedInteger");
+		}
+		return CheckedInteger(result);
+	}
+	template <class U, typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
+	CheckedInteger operator-(U rhs) const {
+		using Promoted = typename std::common_type<T, U>::type;
+		if constexpr (std::is_floating_point<U>::value) {
+			ValidateAssignment(rhs);
+			return operator-(static_cast<T>(rhs));
+		} else if constexpr (std::is_same<Promoted, T>::value) {
+			if constexpr (std::is_unsigned<T>::value && std::is_signed<U>::value) {
+				if (rhs < 0) {
+					return operator+(ToAbsoluteT(rhs));
+				}
+			}
+			return operator-(static_cast<T>(rhs));
+		} else {
+			Promoted result = static_cast<Promoted>(value) - static_cast<Promoted>(rhs);
+			if (static_cast<Promoted>(static_cast<T>(result)) != result) {
+				throw InternalException("Underflow in subtraction for CheckedInteger");
+			}
+			return CheckedInteger(static_cast<T>(result));
+		}
+	}
+
+	CheckedInteger operator*(CheckedInteger rhs) const {
+		return operator*(rhs.value);
+	}
+	CheckedInteger operator*(T rhs) const {
+		T result;
+		if (!TryMultiplyOperator::Operation(value, rhs, result)) {
+			throw InternalException("Overflow in multiplication for CheckedInteger");
+		}
+		return CheckedInteger(result);
+	}
+	template <class U, typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
+	CheckedInteger operator*(U rhs) const {
+		using Promoted = typename std::common_type<T, U>::type;
+		if constexpr (std::is_floating_point<U>::value) {
+			ValidateAssignment(rhs);
+			return operator*(static_cast<T>(rhs));
+		} else if constexpr (std::is_same<Promoted, T>::value) {
+			if constexpr (std::is_unsigned<T>::value && std::is_signed<U>::value) {
+				if (rhs < 0) {
+					throw InternalException("Cannot multiply unsigned CheckedInteger by negative value");
+				}
+			}
+			return operator*(static_cast<T>(rhs));
+		} else {
+			Promoted result = static_cast<Promoted>(value) * static_cast<Promoted>(rhs);
+			if (static_cast<Promoted>(static_cast<T>(result)) != result) {
+				throw InternalException("Overflow in multiplication for CheckedInteger");
+			}
+			return CheckedInteger(static_cast<T>(result));
+		}
+	}
+
+	CheckedInteger operator/(CheckedInteger rhs) const {
+		return operator/(rhs.value);
+	}
+	CheckedInteger operator/(T rhs) const {
+		if (rhs == 0) {
+			throw InternalException("Division by zero in CheckedInteger");
+		}
+		if (NumericLimits<T>::IsSigned() && value == NumericLimits<T>::Minimum() && rhs == T(-1)) {
+			throw InternalException("Overflow in division for CheckedInteger");
+		}
+		return CheckedInteger(value / rhs);
+	}
+	template <class U, typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
+	CheckedInteger operator/(U rhs) const {
+		using Promoted = typename std::common_type<T, U>::type;
+		if constexpr (std::is_floating_point<U>::value) {
+			ValidateAssignment(rhs);
+			return operator/(static_cast<T>(rhs));
+		} else if constexpr (std::is_same<Promoted, T>::value) {
+			if constexpr (std::is_unsigned<T>::value && std::is_signed<U>::value) {
+				if (rhs < 0) {
+					throw InternalException("Cannot divide unsigned CheckedInteger by negative value");
+				}
+			}
+			return operator/(static_cast<T>(rhs));
+		} else {
+			if (rhs == 0) {
+				throw InternalException("Division by zero in CheckedInteger");
+			}
+			Promoted result = static_cast<Promoted>(value) / static_cast<Promoted>(rhs);
+			if (static_cast<Promoted>(static_cast<T>(result)) != result) {
+				throw InternalException("Overflow in division for CheckedInteger");
+			}
+			return CheckedInteger(static_cast<T>(result));
+		}
+	}
+
+	bool operator==(const CheckedInteger &other) const {
+		return value == other.value;
+	}
+	bool operator!=(const CheckedInteger &other) const {
+		return value != other.value;
+	}
+	bool operator<(const CheckedInteger &other) const {
+		return value < other.value;
+	}
+	bool operator>(const CheckedInteger &other) const {
+		return value > other.value;
+	}
+	bool operator<=(const CheckedInteger &other) const {
+		return value <= other.value;
+	}
+	bool operator>=(const CheckedInteger &other) const {
+		return value >= other.value;
+	}
+
+private:
+	// Validate negative values cannot be assigned to unsigned types
+	template <class U>
+	static T ValidateAndCast(U v) {
+		if (std::is_unsigned<T>::value && std::is_signed<U>::value) {
+			if (v < 0) {
+				throw InternalException("Cannot assign negative value to unsigned CheckedInteger");
+			}
+		}
+		return static_cast<T>(v);
+	}
+
+	template <class U>
+	static void ValidateAssignment(U v) {
+		if (std::is_unsigned<T>::value && std::is_signed<U>::value && v < 0) {
+			throw InternalException("Cannot assign negative value to unsigned CheckedInteger");
+		}
+	}
+
+	//! Compute |rhs| as type T without signed-overflow UB.
+	//! Only valid when T is unsigned and sizeof(T) >= sizeof(U).
+	template <class U>
+	static T ToAbsoluteT(U rhs) {
+		using UnsignedU = typename std::make_unsigned<U>::type;
+		return static_cast<T>(static_cast<UnsignedU>(-static_cast<UnsignedU>(rhs)));
+	}
+};
+
+template <class TL, class TR>
+CheckedInteger<TR> operator+(TL lhs, const CheckedInteger<TR> &rhs) {
+	return CheckedInteger<TR>(lhs) + rhs.GetValue();
+}
+
+template <class TL, class TR>
+CheckedInteger<TR> operator-(TL lhs, const CheckedInteger<TR> &rhs) {
+	return CheckedInteger<TR>(lhs) - rhs.GetValue();
+}
+
+template <class TL, class TR>
+CheckedInteger<TR> operator*(TL lhs, const CheckedInteger<TR> &rhs) {
+	return CheckedInteger<TR>(lhs) * rhs.GetValue();
+}
+
+template <class TL, class TR>
+CheckedInteger<TR> operator/(TL lhs, const CheckedInteger<TR> &rhs) {
+	return CheckedInteger<TR>(lhs) / rhs.GetValue();
+}
+
+using i8_t = CheckedInteger<int8_t>;
+using i16_t = CheckedInteger<int16_t>;
+using i32_t = CheckedInteger<int32_t>;
+using i64_t = CheckedInteger<int64_t>;
+using u8_t = CheckedInteger<uint8_t>;
+using u16_t = CheckedInteger<uint16_t>;
+using u32_t = CheckedInteger<uint32_t>;
+using u64_t = CheckedInteger<uint64_t>;
+
+} // namespace duckdb

--- a/test/common/test_checked_integer.cpp
+++ b/test/common/test_checked_integer.cpp
@@ -1,0 +1,314 @@
+#include "catch.hpp"
+#include "duckdb/common/checked_integer.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("Checked integer increment/decrement overflow", "[checked_integer]") {
+	// signed i64_t overflow on ++
+	i64_t max_val(NumericLimits<int64_t>::Maximum());
+	REQUIRE_THROWS_AS(++max_val, InternalException);
+	REQUIRE_THROWS_AS(max_val++, InternalException);
+
+	// signed i64_t underflow on --
+	i64_t min_val(NumericLimits<int64_t>::Minimum());
+	REQUIRE_THROWS_AS(--min_val, InternalException);
+	REQUIRE_THROWS_AS(min_val--, InternalException);
+
+	// unsigned u8_t overflow on ++
+	u8_t u8_max(NumericLimits<uint8_t>::Maximum());
+	REQUIRE_THROWS_AS(++u8_max, InternalException);
+	REQUIRE_THROWS_AS(u8_max++, InternalException);
+
+	// unsigned u8_t underflow on --
+	u8_t u8_min(NumericLimits<uint8_t>::Minimum());
+	REQUIRE_THROWS_AS(--u8_min, InternalException);
+	REQUIRE_THROWS_AS(u8_min--, InternalException);
+
+	// valid increment/decrement should work
+	i32_t val(100);
+	++val;
+	REQUIRE(val == 101);
+	val--;
+	REQUIRE(val == 100);
+}
+
+TEST_CASE("Checked integer compound assignment overflow", "[checked_integer]") {
+	// += overflow
+	i64_t a(NumericLimits<int64_t>::Maximum() - 10);
+	REQUIRE_THROWS_AS(a += 20, InternalException);
+
+	// -= underflow
+	i64_t b(NumericLimits<int64_t>::Minimum() + 10);
+	REQUIRE_THROWS_AS(b -= 20, InternalException);
+
+	// *= overflow
+	i32_t c(100000);
+	REQUIRE_THROWS_AS(c *= 100000, InternalException);
+
+	// /= division by zero
+	i64_t d(100);
+	REQUIRE_THROWS_AS(d /= 0, InternalException);
+
+	// /= INT_MIN / -1 overflow
+	i64_t e(NumericLimits<int64_t>::Minimum());
+	REQUIRE_THROWS_AS(e /= -1, InternalException);
+
+	// valid operations
+	u32_t u(100);
+	u += 50;
+	REQUIRE(u == 150u);
+	u -= 25;
+	REQUIRE(u == 125u);
+	u *= 2;
+	REQUIRE(u == 250u);
+	u /= 5;
+	REQUIRE(u == 50u);
+}
+
+TEST_CASE("Checked integer binary arithmetic overflow", "[checked_integer]") {
+	// + overflow
+	i16_t x(NumericLimits<int16_t>::Maximum() - 5);
+	REQUIRE_THROWS_AS(x + 10, InternalException);
+
+	// - underflow
+	i16_t y(NumericLimits<int16_t>::Minimum() + 5);
+	REQUIRE_THROWS_AS(y - 10, InternalException);
+
+	// * overflow
+	i8_t z(100);
+	REQUIRE_THROWS_AS(z * 2, InternalException);
+
+	// / division by zero
+	i32_t w(42);
+	REQUIRE_THROWS_AS(w / 0, InternalException);
+
+	// valid operations return correct results
+	u64_t u1(1000);
+	auto u2 = u1 + 500;
+	REQUIRE(u2 == 1500u);
+
+	i64_t s1(-100);
+	auto s2 = s1 - 50;
+	REQUIRE(s2 == -150);
+}
+
+TEST_CASE("Checked integer comparisons", "[checked_integer]") {
+	i64_t a(100);
+	i64_t b(200);
+
+	REQUIRE(a < b);
+	REQUIRE(a <= b);
+	REQUIRE(b > a);
+	REQUIRE(b >= a);
+	REQUIRE(a != b);
+	REQUIRE_FALSE(a == b);
+
+	REQUIRE(a < 150);
+	REQUIRE(a == 100);
+}
+
+TEST_CASE("CheckedInteger mixed type arithmetic", "[checked_integer]") {
+	// int8_t * double -> int8_t (as per user request)
+	i8_t a(10);
+	auto b = a * 2.5;  // Should cast 2.5 to int8_t (2) and multiply
+	REQUIRE(b.GetValue() == 20);
+
+	// int8_t + double
+	auto c = a + 1.7;  // Casts to 1
+	REQUIRE(c.GetValue() == 11);
+
+	// Compound assignment with different type
+	i16_t d(100);
+	d += 50.9;  // Casts to 50
+	REQUIRE(d.GetValue() == 150);
+
+	// int64_t - float
+	i64_t e(1000);
+	auto f = e - 123.9f;  // Casts to 123
+	REQUIRE(f.GetValue() == 877);
+
+	// uint32_t / int
+	u32_t g(100);
+	auto h = g / 3;  // Casts int(3) to uint32_t
+	REQUIRE(h.GetValue() == 33u);
+
+	// Compound assignment: int8_t *= double
+	i8_t i(5);
+	i *= 3.9;  // Casts to 3
+	REQUIRE(i.GetValue() == 15);
+}
+
+TEST_CASE("CheckedInteger unsigned cannot be negative", "[checked_integer]") {
+	// Cannot construct unsigned from negative
+	REQUIRE_THROWS_AS(u32_t(-1), InternalException);
+	REQUIRE_THROWS_AS(u64_t(-100), InternalException);
+	REQUIRE_THROWS_AS(u8_t(-1), InternalException);
+
+	// Can construct from positive
+	REQUIRE_NOTHROW(u32_t(100));
+	REQUIRE(u32_t(100).GetValue() == 100u);
+
+	// Cross-type: unsigned += negative is valid when result is non-negative
+	u16_t x(50);
+	x += -10;
+	REQUIRE(x.GetValue() == 40u);
+	REQUIRE_THROWS_AS(x -= 100, InternalException);  // underflow caught by checked sub
+
+	// Mixed: uint32_t * negative double truncates -2.5 to uint32_t, wraps → overflow
+	u32_t y(10);
+	REQUIRE_THROWS_AS(y *= -2.5, InternalException);
+
+	// Conforms to normal C++ arithmetic: uint16_t(9) -= -10 → 19
+	u16_t z(9);
+	z -= -10;
+	REQUIRE(z.GetValue() == 19u);
+}
+
+#define CHECK_MATCHES_NATIVE(checked_val, native_expr) \
+	REQUIRE(static_cast<decltype(native_expr)>((checked_val).GetValue()) == (native_expr))
+
+TEST_CASE("Cross-type binary arithmetic matches native behavior", "[checked_integer]") {
+	SECTION("unsigned + signed") {
+		u16_t a(100);
+		auto r = a + int8_t(-30);
+		CHECK_MATCHES_NATIVE(r, static_cast<uint16_t>(uint16_t(100) + int8_t(-30)));
+		REQUIRE(r.GetValue() == 70u);
+	}
+
+	SECTION("unsigned - negative signed") {
+		u32_t a(50);
+		auto r = a - int16_t(-25);
+		CHECK_MATCHES_NATIVE(r, static_cast<uint32_t>(uint32_t(50) - int16_t(-25)));
+		REQUIRE(r.GetValue() == 75u);
+	}
+
+	SECTION("signed + unsigned") {
+		i32_t a(-200);
+		auto r = a + uint16_t(300);
+		CHECK_MATCHES_NATIVE(r, static_cast<int32_t>(int32_t(-200) + uint16_t(300)));
+		REQUIRE(r.GetValue() == 100);
+	}
+
+	SECTION("signed - unsigned") {
+		i64_t a(10);
+		auto r = a - uint32_t(30);
+		CHECK_MATCHES_NATIVE(r, static_cast<int64_t>(int64_t(10) - uint32_t(30)));
+		REQUIRE(r.GetValue() == -20);
+	}
+
+	SECTION("small unsigned * large signed") {
+		u8_t a(10);
+		auto r = a * int32_t(20);
+		CHECK_MATCHES_NATIVE(r, static_cast<uint8_t>(uint8_t(10) * int32_t(20)));
+		REQUIRE(r.GetValue() == 200u);
+	}
+
+	SECTION("signed / unsigned") {
+		i32_t a(100);
+		auto r = a / uint16_t(7);
+		CHECK_MATCHES_NATIVE(r, static_cast<int32_t>(int32_t(100) / uint16_t(7)));
+		REQUIRE(r.GetValue() == 14);
+	}
+
+	SECTION("unsigned / signed") {
+		u64_t a(1000);
+		auto r = a / int32_t(3);
+		CHECK_MATCHES_NATIVE(r, static_cast<uint64_t>(uint64_t(1000) / int32_t(3)));
+		REQUIRE(r.GetValue() == 333u);
+	}
+
+	SECTION("narrower signed + wider unsigned") {
+		i16_t a(500);
+		auto r = a + uint32_t(100);
+		CHECK_MATCHES_NATIVE(r, static_cast<int16_t>(static_cast<uint32_t>(int16_t(500)) + uint32_t(100)));
+		REQUIRE(r.GetValue() == 600);
+	}
+}
+
+TEST_CASE("Cross-type compound assignment matches native behavior", "[checked_integer]") {
+	SECTION("unsigned += negative signed") {
+		u32_t a(100);
+		a += int8_t(-40);
+		REQUIRE(a.GetValue() == 60u);
+	}
+
+	SECTION("unsigned -= negative signed") {
+		u16_t a(50);
+		a -= int16_t(-50);
+		REQUIRE(a.GetValue() == 100u);
+	}
+
+	SECTION("signed += unsigned") {
+		i32_t a(-50);
+		a += uint16_t(200);
+		REQUIRE(a.GetValue() == 150);
+	}
+
+	SECTION("signed -= unsigned") {
+		i64_t a(100);
+		a -= uint32_t(250);
+		REQUIRE(a.GetValue() == -150);
+	}
+
+	SECTION("signed *= unsigned") {
+		i16_t a(-7);
+		a *= uint8_t(6);
+		REQUIRE(a.GetValue() == -42);
+	}
+
+	SECTION("unsigned *= signed positive") {
+		u32_t a(25);
+		a *= int16_t(4);
+		REQUIRE(a.GetValue() == 100u);
+	}
+
+	SECTION("signed /= unsigned") {
+		i32_t a(-100);
+		a /= uint8_t(10);
+		REQUIRE(a.GetValue() == -10);
+	}
+
+	SECTION("unsigned /= signed positive") {
+		u64_t a(999);
+		a /= int32_t(10);
+		REQUIRE(a.GetValue() == 99u);
+	}
+}
+
+TEST_CASE("Cross-type arithmetic overflow detection", "[checked_integer]") {
+	SECTION("unsigned + signed overflows T") {
+		u8_t a(250);
+		REQUIRE_THROWS_AS(a + int32_t(10), InternalException);
+	}
+
+	SECTION("unsigned - signed underflows T") {
+		u16_t a(5);
+		REQUIRE_THROWS_AS(a + int32_t(-10), InternalException);
+	}
+
+	SECTION("signed * unsigned overflows T") {
+		i16_t a(200);
+		REQUIRE_THROWS_AS(a * uint16_t(200), InternalException);
+	}
+
+	SECTION("compound: unsigned += signed overflows") {
+		u8_t a(200);
+		REQUIRE_THROWS_AS(a += int32_t(100), InternalException);
+	}
+
+	SECTION("compound: signed -= unsigned underflows") {
+		i16_t a(-30000);
+		REQUIRE_THROWS_AS(a -= uint16_t(5000), InternalException);
+	}
+
+	SECTION("compound: unsigned *= signed overflows") {
+		u16_t a(1000);
+		REQUIRE_THROWS_AS(a *= int32_t(100), InternalException);
+	}
+
+	SECTION("cross-type division by zero") {
+		u32_t a(100);
+		REQUIRE_THROWS_AS(a / int16_t(0), InternalException);
+		REQUIRE_THROWS_AS(a /= int8_t(0), InternalException);
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new integer wrapper type and a dedicated test suite; it is currently self-contained and does not modify existing runtime logic, so risk is limited to compilation/behavior where adopted later.
> 
> **Overview**
> Introduces `duckdb/common/checked_integer.hpp`, a `CheckedInteger<T>` wrapper that performs overflow/underflow checking for integer arithmetic (`++/--`, `+/-/*//`, and compound assignments) and throws `InternalException` on invalid operations (including divide-by-zero and `INT_MIN / -1`).
> 
> Adds comprehensive Catch2 tests covering overflow/underflow detection, mixed-type arithmetic (including float-to-int truncation semantics), unsigned negative-input guards, and cross-type behavior comparisons against native C++ results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 345f6d4f8f77b608a9a11e993d10429b5cef0c4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->