### PR TITLE
Fix memory limit reset

### DIFF
--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1301,6 +1301,9 @@ void MaxMemorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const V
 
 void MaxMemorySetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.SetDefaultMaxMemory();
+	if (db) {
+		BufferManager::GetBufferManager(*db).SetMemoryLimit(config.options.maximum_memory);
+	}
 }
 
 Value MaxMemorySetting::GetSetting(const ClientContext &context) {

--- a/test/sql/settings/reset/reset_memory_limit.test
+++ b/test/sql/settings/reset/reset_memory_limit.test
@@ -1,0 +1,23 @@
+# name: test/sql/settings/reset/reset_memory_limit.test
+# description: Test that RESET memory_limit actually applies to the buffer manager
+# group: [reset]
+
+# Disable temp directory so the buffer manager cannot spill to disk
+statement ok
+PRAGMA temp_directory='';
+
+# Set an impossibly low limit
+statement ok
+SET memory_limit='2MB';
+
+# Takes ~8MiB
+statement error
+CREATE TABLE t1 AS SELECT * FROM range(1000000);
+----
+
+statement ok
+RESET memory_limit;
+
+# After reset, the buffer manager should allow the allocation again
+statement ok
+CREATE TABLE t1 AS SELECT * FROM range(1000000);


### PR DESCRIPTION
https://github.com/duckdb/duckdb/issues/22203

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, targeted change to settings reset behavior plus a focused SQL regression test; impact is limited to runtime memory limit resets.
> 
> **Overview**
> `RESET memory_limit` now re-applies the default `maximum_memory` to the active `BufferManager`, matching the behavior of `SET memory_limit` and ensuring the runtime allocator limit is actually updated.
> 
> Adds a regression test (`reset_memory_limit.test`) that forces an out-of-memory error under a tiny limit (with spilling disabled) and verifies that `RESET memory_limit` restores the ability to allocate again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3417bff59a6abd738e7ad9e6c12ea508a6a657b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->