### PR TITLE
Fix small decimal write for variant write

### DIFF
--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -572,7 +572,7 @@ static void WritePrimitiveValueData(const UnifiedVariantVectorData &variant, idx
 			// DuckDB uses INT16 to store small decimals, but parquet only supports DECIMAL4 at minimum, so here we
 			// promote to INT32.
 			WritePrimitiveTypeHeader<VariantPrimitiveType::DECIMAL4>(value_data);
-			Store<int8_t>(decimal_data.scale, value_data);
+			Store<int8_t>(NumericCast<int8_t>(decimal_data.scale), value_data);
 			value_data++;
 			const int32_t promoted = Load<int16_t>(decimal_data.value_ptr);
 			Store<int32_t>(promoted, value_data);

--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -565,9 +565,18 @@ static void WritePrimitiveValueData(const UnifiedVariantVectorData &variant, idx
 	case VariantLogicalType::DECIMAL: {
 		auto decimal_data = VariantUtils::DecodeDecimalData(variant, row, values_index);
 
-		if (decimal_data.width <= 4 || decimal_data.width > 38) {
+		if (decimal_data.width > 38) {
 			throw InvalidInputException("Can't convert VARIANT DECIMAL(%d, %d) to Parquet VARIANT", decimal_data.width,
 			                            decimal_data.scale);
+		} else if (decimal_data.width <= 4) {
+			// DuckDB uses INT16 to store small decimals, but parquet only supports DECIMAL4 at minimum, so here we
+			// promote to INT32.
+			WritePrimitiveTypeHeader<VariantPrimitiveType::DECIMAL4>(value_data);
+			Store<int8_t>(decimal_data.scale, value_data);
+			value_data++;
+			const int32_t promoted = Load<int16_t>(decimal_data.value_ptr);
+			Store<int32_t>(promoted, value_data);
+			value_data += sizeof(int32_t);
 		} else if (decimal_data.width <= 9) {
 			WritePrimitiveTypeHeader<VariantPrimitiveType::DECIMAL4>(value_data);
 			Store<int8_t>(NumericCast<int8_t>(decimal_data.scale), value_data);

--- a/test/parquet/variant/variant_small_decimal.test
+++ b/test/parquet/variant/variant_small_decimal.test
@@ -1,0 +1,22 @@
+# name: test/parquet/variant/variant_small_decimal.test
+# group: [variant]
+
+require parquet
+
+statement ok
+CREATE TABLE t (data VARIANT);
+
+statement ok
+INSERT INTO t VALUES (1.23::DECIMAL(3, 2)::VARIANT);
+
+statement ok
+INSERT INTO t VALUES (12.345::DECIMAL(5, 3)::VARIANT);
+
+statement ok
+COPY t TO '{TEST_DIR}/small_variant.parquet';
+
+query I
+SELECT * FROM '{TEST_DIR}/small_variant.parquet' ORDER BY data
+----
+1.23
+12.345


### PR DESCRIPTION
https://github.com/duckdb/duckdb/issues/22539

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Parquet VARIANT encoding for small DECIMAL values, which affects exported file contents and could impact compatibility if edge cases are missed. Scope is limited to VARIANT decimal serialization plus a targeted regression test.
> 
> **Overview**
> Fixes Parquet VARIANT serialization of *small* `DECIMAL` values by no longer rejecting widths `<= 4` and instead promoting DuckDB’s INT16-backed decimals to the minimum Parquet-supported `DECIMAL4` representation.
> 
> Adds `variant_small_decimal.test` to cover writing and reading back small-decimal VARIANT values via `COPY ... TO parquet`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dcb5670b19e9094b2f1c3db433d356f8613a2e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->