### PR TITLE
Enable external file cache for parquet metadata

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -121,7 +121,7 @@ static shared_ptr<ParquetFileMetadataCache>
 LoadMetadata(ClientContext &context, Allocator &allocator, CachingFileHandle &file_handle,
              const shared_ptr<const ParquetEncryptionConfig> &encryption_config,
              shared_ptr<EncryptionUtil> &encryption_util, optional_idx footer_size) {
-	auto file_proto = CreateThriftFileProtocol(context, file_handle, false);
+	auto file_proto = CreateThriftFileProtocol(context, file_handle, ShouldAndCanPrefetch(context, file_handle));
 	auto &transport = reinterpret_cast<ThriftFileTransport &>(*file_proto->getTransport());
 	auto file_size = transport.GetSize();
 	if (file_size < 12) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Parquet footer/metadata loading to use prefetch-capable transports, which can alter I/O behavior especially for remote files and external caching paths.
> 
> **Overview**
> Enables Parquet metadata loading (`LoadMetadata`) to create the Thrift transport in prefetch mode when `ShouldAndCanPrefetch` allows it, instead of always disabling prefetching.
> 
> This aligns footer/metadata reads with the existing prefetch/external file caching logic, potentially reducing round trips for remote Parquet files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285cd7259fbdcf4d3d3b4f7bfda7cf0c436915de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->