### PR TITLE
Fix parquet metadata cache validation

### DIFF
--- a/extension/parquet/include/parquet_file_metadata_cache.hpp
+++ b/extension/parquet/include/parquet_file_metadata_cache.hpp
@@ -57,7 +57,6 @@ public:
 	ParquetCacheValidity IsValid(const OpenFileInfo &info, ClientContext &context) const;
 
 private:
-	bool validate;
 	timestamp_t last_modified;
 	string version_tag;
 };

--- a/extension/parquet/parquet_file_metadata_cache.cpp
+++ b/extension/parquet/parquet_file_metadata_cache.cpp
@@ -60,7 +60,7 @@ optional_idx ParquetFileMetadataCache::GetEstimatedCacheMemory() const {
 }
 
 bool ParquetFileMetadataCache::IsValid(CachingFileHandle &new_handle) const {
-	return ExternalFileCache::IsValid(validate, version_tag, last_modified, new_handle.GetVersionTag(),
+	return ExternalFileCache::IsValid(new_handle.Validate(), version_tag, last_modified, new_handle.GetVersionTag(),
 	                                  new_handle.GetLastModifiedTime());
 }
 

--- a/extension/parquet/parquet_file_metadata_cache.cpp
+++ b/extension/parquet/parquet_file_metadata_cache.cpp
@@ -22,7 +22,7 @@ ParquetFileMetadataCache::ParquetFileMetadataCache(unique_ptr<duckdb_parquet::Fi
                                                    unique_ptr<GeoParquetFileMetadata> geo_metadata,
                                                    unique_ptr<FileCryptoMetaData> crypto_metadata, idx_t footer_size)
     : metadata(std::move(file_metadata)), geo_metadata(std::move(geo_metadata)),
-      crypto_metadata(std::move(crypto_metadata)), footer_size(footer_size), validate(handle.Validate()),
+      crypto_metadata(std::move(crypto_metadata)), footer_size(footer_size),
       last_modified(handle.GetLastModifiedTime()), version_tag(handle.GetVersionTag()) {
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how Parquet metadata cache entries are validated, which can affect correctness (stale vs. unnecessary invalidation) when reopening files under different validation settings. Scope is small and localized to the Parquet metadata cache.
> 
> **Overview**
> Fixes Parquet metadata cache validation to use the *current* `CachingFileHandle`’s `Validate()` setting when checking an existing cache entry, instead of persisting the original handle’s validation flag in the cache object.
> 
> This removes the stored `validate` field from `ParquetFileMetadataCache` and updates `IsValid(CachingFileHandle&)` to pass `new_handle.Validate()` into `ExternalFileCache::IsValid`, aligning cache validity with the reopening context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32160bbf531035af12741a387bfcdf09855b47ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->