### PR TITLE
[demo] Evict external file cache

### DIFF
--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -26,8 +26,10 @@
 namespace duckdb {
 
 // Forward declaration.
+class BlockMemory;
 class ClientContext;
 class DatabaseInstance;
+class BlockHandle;
 class BufferManager;
 
 class ExternalFileCache {
@@ -77,21 +79,36 @@ public:
 
 	//! Re-index to `current_block_size` if it differs from the cache block size.
 	//! Return the blocks cached for the given range.
-	vector<shared_ptr<CacheBlock>> ReindexAndAcquireBlocks(CachedFile &cached_file, idx_t current_block_size,
-	                                                       idx_t first_block, idx_t num_blocks);
+	vector<shared_ptr<CacheBlock>> ReindexAndAcquireBlocks(const shared_ptr<CachedFile> &cached_file,
+	                                                       idx_t current_block_size, idx_t first_block,
+	                                                       idx_t num_blocks);
 
 	BufferManager &GetBufferManager() const;
 	//! Gets the shared cached file for the given path, creating it if not yet present.
 	//! When caching is disabled, returns a transient CachedFile that is not tracked in the cached file map.
 	shared_ptr<CachedFile> GetOrCreateCachedFile(const string &path);
 
+	//! Register a cached block with the buffer pool block backing it.
+	void RegisterBlock(const shared_ptr<BlockHandle> &block_handle, const shared_ptr<CachedFile> &cached_file,
+	                   idx_t block_idx);
+	//! Called by the buffer pool when an external file cache block is evicted.
+	void Evict(BlockMemory &memory);
+
 	DUCKDB_API static bool IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
 	                               const string &current_version_tag, timestamp_t current_last_modified);
 
 private:
+	struct ExternalFileCacheBlockKey {
+		shared_ptr<CachedFile> cached_file;
+		idx_t block_idx;
+	};
+
+	//! Remove a block from the reverse lookup map without updating cached file state.
+	void UnregisterBlock(BlockMemory &memory) DUCKDB_REQUIRES(block_keys_lock);
+
 	//! Re-index blocks of a single cached file.
-	void ReindexCachedFileCore(CachedFile &cached_file, idx_t file_size, idx_t old_block_size, idx_t new_block_size)
-	    DUCKDB_REQUIRES(cached_file.map_lock);
+	void ReindexCachedFileCore(const shared_ptr<CachedFile> &cached_file, idx_t file_size, idx_t old_block_size,
+	                           idx_t new_block_size) DUCKDB_REQUIRES(cached_file->map_lock);
 
 	//! The BufferManager used to cache files
 	BufferManager &buffer_manager;
@@ -101,6 +118,10 @@ private:
 	atomic<idx_t> generation;
 	//! Mapping from file path to cached file with cached blocks
 	unordered_map<string, shared_ptr<CachedFile>> cached_files;
+	//! Reverse lookup from buffer pool block memory to cached file block
+	unordered_map<BlockMemory *, ExternalFileCacheBlockKey> block_keys;
+	//! Lock for accessing block_keys
+	mutable mutex block_keys_lock;
 	//! Lock for accessing the cached files
 	mutable mutex lock;
 };

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/storage/buffer/buffer_pool.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
+#include "duckdb/common/enums/memory_tag.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/thread.hpp"
 #include "duckdb/common/typedefs.hpp"
@@ -7,10 +8,18 @@
 #include "duckdb/parallel/concurrentqueue.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/storage/block_allocator.hpp"
+#include "duckdb/storage/external_file_cache/external_file_cache.hpp"
 #include "duckdb/storage/object_cache.hpp"
 #include "duckdb/storage/temporary_memory_manager.hpp"
 
 namespace duckdb {
+
+static void EvictExternalFileCacheBlock(BlockMemory &memory) {
+	if (memory.GetMemoryTag() != MemoryTag::EXTERNAL_FILE_CACHE) {
+		return;
+	}
+	ExternalFileCache::Get(memory.GetBufferManager().GetDatabase()).Evict(memory);
+}
 
 static idx_t FileBufferTypeToEvictionQueueTypeIdx(const FileBufferType &type) {
 	switch (type) {
@@ -422,12 +431,14 @@ BufferPool::EvictionResult BufferPool::EvictBlocksInternal(EvictionQueue &queue,
 		if (buffer && handle->GetBuffer(lock)->AllocSize() == extra_memory) {
 			// we can re-use the memory directly
 			*buffer = handle->UnloadAndTakeBlock(lock);
+			EvictExternalFileCacheBlock(*handle);
 			found = true;
 			return false;
 		}
 
 		// release the memory and mark the block as unloaded
 		handle->Unload(lock);
+		EvictExternalFileCacheBlock(*handle);
 
 		if (memory_usage.GetUsedMemory(MemoryUsageCaches::NO_FLUSH) <= memory_limit) {
 			found = true;
@@ -471,6 +482,7 @@ idx_t BufferPool::PurgeAgedBlocksInternal(EvictionQueue &queue, uint32_t max_age
 		    bool is_fresh = lru_timestamp_msec >= limit && lru_timestamp_msec <= now;
 		    purged_bytes += handle->GetMemoryUsage();
 		    handle->Unload(lock);
+		    EvictExternalFileCacheBlock(*handle);
 		    // Return false to stop iterating if the current block is_fresh
 		    return !is_fresh;
 	    });

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -23,11 +23,13 @@ class DatabaseInstance;
 class FetchBlockTask : public BaseExecutorTask {
 public:
 	FetchBlockTask(CachingFileHandle &caching_file_handle_p, TaskExecutor &executor, QueryContext context_p,
-	               BufferManager &buffer_manager_p, shared_ptr<CacheBlock> block_p, idx_t block_idx_p,
-	               idx_t block_size_p, BufferHandle &result_pin_p)
+	               BufferManager &buffer_manager_p, ExternalFileCache &external_file_cache_p,
+	               shared_ptr<CachingFileHandle::CachedFile> cached_file_p, shared_ptr<CacheBlock> block_p,
+	               idx_t block_idx_p, idx_t block_size_p, BufferHandle &result_pin_p)
 	    : BaseExecutorTask(executor), caching_file_handle(caching_file_handle_p), context(context_p),
-	      buffer_manager(buffer_manager_p), block(std::move(block_p)), block_idx(block_idx_p), block_size(block_size_p),
-	      result_pin(result_pin_p) {
+	      buffer_manager(buffer_manager_p), external_file_cache(external_file_cache_p),
+	      cached_file(std::move(cached_file_p)), block(std::move(block_p)), block_idx(block_idx_p),
+	      block_size(block_size_p), result_pin(result_pin_p) {
 	}
 
 	void ExecuteTask() override {
@@ -72,6 +74,7 @@ public:
 					block->block_handle = buf.GetBlockHandle();
 					block->nr_bytes = to_read;
 					block->state = CacheBlockState::LOADED;
+					external_file_cache.RegisterBlock(block->block_handle, cached_file, block_idx);
 #ifdef DEBUG
 					block->checksum = Checksum(buf.Ptr(), to_read);
 #endif
@@ -103,6 +106,8 @@ private:
 	CachingFileHandle &caching_file_handle;
 	QueryContext context;
 	BufferManager &buffer_manager;
+	ExternalFileCache &external_file_cache;
+	shared_ptr<CachingFileHandle::CachedFile> cached_file;
 	shared_ptr<CacheBlock> block;
 	idx_t block_idx;
 	idx_t block_size;
@@ -267,8 +272,8 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 	const idx_t num_blocks = last_block - first_block + 1;
 
 	// Atomically reindex (if needed) and acquire the block range.
-	auto blocks =
-	    external_file_cache.ReindexAndAcquireBlocks(*current_cached_file, block_size, first_block, num_blocks);
+	auto blocks = external_file_cache.ReindexAndAcquireBlocks(current_cached_file, block_size, first_block,
+	                                                          num_blocks);
 
 	// Schedule block fetch tasks for all blocks.
 	vector<BufferHandle> pins(num_blocks);
@@ -277,8 +282,9 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 
 	for (idx_t idx = 0; idx < num_blocks; idx++) {
 		executor.ScheduleTask(make_uniq<FetchBlockTask>(*this, executor, context,
-		                                                external_file_cache.GetBufferManager(), blocks[idx],
-		                                                first_block + idx, block_size, pins[idx]));
+		                                                external_file_cache.GetBufferManager(), external_file_cache,
+		                                                current_cached_file, blocks[idx], first_block + idx,
+		                                                block_size, pins[idx]));
 	}
 	executor.WorkOnTasks();
 

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -21,14 +21,23 @@ idx_t ExternalFileCache::GetCacheBlockSize(const string &path) const {
 	return Settings::Get<ExternalFileCacheLocalBlockSizeSetting>(db);
 }
 
-void ExternalFileCache::ReindexCachedFileCore(CachedFile &cached_file, idx_t file_size, idx_t old_block_size,
-                                              idx_t new_block_size) {
+void ExternalFileCache::ReindexCachedFileCore(const shared_ptr<CachedFile> &cached_file, idx_t file_size,
+                                              idx_t old_block_size, idx_t new_block_size) {
 	D_ASSERT(old_block_size > 0);
 	D_ASSERT(new_block_size > 0);
 
+	// Unregister old blocks before replacing the block map.
+	for (auto &block_entry : cached_file->blocks) {
+		auto &block = *block_entry.second;
+		const annotated_lock_guard<annotated_mutex> block_guard(block.mtx);
+		if (block.block_handle) {
+			UnregisterBlock(block.block_handle->GetMemory());
+		}
+	}
+
 	// Phase 1: Pin all LOADED old blocks, sorted by block index.
 	map<idx_t, pair<BufferHandle, idx_t>> pinned;
-	for (auto &block_entry : cached_file.blocks) {
+	for (auto &block_entry : cached_file->blocks) {
 		const idx_t old_idx = block_entry.first;
 		auto &block = *block_entry.second;
 		const annotated_lock_guard<annotated_mutex> block_guard(block.mtx);
@@ -42,7 +51,7 @@ void ExternalFileCache::ReindexCachedFileCore(CachedFile &cached_file, idx_t fil
 	}
 
 	if (pinned.empty()) {
-		cached_file.blocks.clear();
+		cached_file->blocks.clear();
 		return;
 	}
 
@@ -110,34 +119,44 @@ void ExternalFileCache::ReindexCachedFileCore(CachedFile &cached_file, idx_t fil
 	}
 
 	// Phase 3: Replace old blocks with new blocks.
-	cached_file.blocks = std::move(new_blocks);
+	cached_file->blocks = std::move(new_blocks);
+
+	for (auto &block_entry : cached_file->blocks) {
+		const idx_t block_idx = block_entry.first;
+		auto &block = *block_entry.second;
+		const annotated_lock_guard<annotated_mutex> block_guard(block.mtx);
+		if (block.state == CacheBlockState::LOADED && block.block_handle) {
+			RegisterBlock(block.block_handle, cached_file, block_idx);
+		}
+	}
 }
 
-vector<shared_ptr<CacheBlock>> ExternalFileCache::ReindexAndAcquireBlocks(CachedFile &cached_file,
+vector<shared_ptr<CacheBlock>> ExternalFileCache::ReindexAndAcquireBlocks(const shared_ptr<CachedFile> &cached_file,
                                                                           idx_t current_block_size, idx_t first_block,
                                                                           idx_t num_blocks) {
 	D_ASSERT(current_block_size > 0);
+	D_ASSERT(cached_file);
 
 	idx_t file_size = 0;
 	{
-		const annotated_lock_guard<annotated_mutex> meta_guard(cached_file.meta_lock);
-		file_size = cached_file.file_size;
+		const annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);
+		file_size = cached_file->file_size;
 	}
 
-	const annotated_lock_guard<annotated_mutex> map_guard(cached_file.map_lock);
+	const annotated_lock_guard<annotated_mutex> map_guard(cached_file->map_lock);
 
-	if (cached_file.cached_block_size.IsValid() && cached_file.cached_block_size.GetIndex() != current_block_size) {
-		const idx_t old_block_size = cached_file.cached_block_size.GetIndex();
+	if (cached_file->cached_block_size.IsValid() && cached_file->cached_block_size.GetIndex() != current_block_size) {
+		const idx_t old_block_size = cached_file->cached_block_size.GetIndex();
 		if (file_size > 0) {
 			ReindexCachedFileCore(cached_file, file_size, old_block_size, current_block_size);
 		}
 	}
-	cached_file.cached_block_size = current_block_size;
+	cached_file->cached_block_size = current_block_size;
 
 	vector<shared_ptr<CacheBlock>> blocks(num_blocks);
 	for (idx_t idx = 0; idx < num_blocks; idx++) {
 		const idx_t block_idx = first_block + idx;
-		auto &entry = cached_file.blocks[block_idx];
+		auto &entry = cached_file->blocks[block_idx];
 		if (!entry) {
 			entry = make_shared_ptr<CacheBlock>();
 		}
@@ -209,6 +228,10 @@ void ExternalFileCache::SetEnabled(bool enable_p) {
 	generation++;
 	if (!enable) {
 		cached_files.clear();
+		{
+			const lock_guard<mutex> keys_guard(block_keys_lock);
+			block_keys.clear();
+		}
 	}
 }
 
@@ -266,6 +289,70 @@ shared_ptr<ExternalFileCache::CachedFile> ExternalFileCache::GetOrCreateCachedFi
 		entry = make_shared_ptr<CachedFile>(path, generation);
 	}
 	return entry;
+}
+
+void ExternalFileCache::RegisterBlock(const shared_ptr<BlockHandle> &block_handle,
+                                      const shared_ptr<CachedFile> &cached_file, idx_t block_idx) {
+	if (!enable || !block_handle || !cached_file) {
+		return;
+	}
+	const lock_guard<mutex> guard(block_keys_lock);
+	block_keys[&block_handle->GetMemory()] = ExternalFileCacheBlockKey {cached_file, block_idx};
+}
+
+void ExternalFileCache::UnregisterBlock(BlockMemory &memory) {
+	const lock_guard<mutex> guard(block_keys_lock);
+	block_keys.erase(&memory);
+}
+
+void ExternalFileCache::Evict(BlockMemory &memory) {
+	if (!enable) {
+		return;
+	}
+
+	ExternalFileCacheBlockKey key;
+	{
+		const lock_guard<mutex> guard(block_keys_lock);
+		const auto it = block_keys.find(&memory);
+		if (it == block_keys.end()) {
+			return;
+		}
+		key = it->second;
+		block_keys.erase(it);
+	}
+
+	auto cached_file = std::move(key.cached_file);
+	if (!cached_file) {
+		return;
+	}
+
+	bool blocks_empty = false;
+	{
+		const annotated_lock_guard<annotated_mutex> map_guard(cached_file->map_lock);
+		const auto block_it = cached_file->blocks.find(key.block_idx);
+		if (block_it != cached_file->blocks.end()) {
+			auto &block = *block_it->second;
+			const annotated_lock_guard<annotated_mutex> block_guard(block.mtx);
+			if (block.block_handle && &block.block_handle->GetMemory() == &memory) {
+				block.state = CacheBlockState::EMPTY;
+				block.block_handle = nullptr;
+				block.nr_bytes = 0;
+#ifdef DEBUG
+				block.checksum = 0;
+#endif
+				cached_file->blocks.erase(block_it);
+			}
+		}
+		blocks_empty = cached_file->blocks.empty();
+	}
+
+	if (blocks_empty) {
+		const lock_guard<mutex> guard(lock);
+		const auto it = cached_files.find(cached_file->path);
+		if (it != cached_files.end() && it->second.get() == cached_file.get()) {
+			cached_files.erase(it);
+		}
+	}
 }
 
 } // namespace duckdb

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -302,6 +302,38 @@ TEST_CASE("Re-enabled external file cache refreshes live handle metadata", "[ext
 	REQUIRE(cache.GetCachedFileCount() == 1);
 }
 
+TEST_CASE("Evicted external file cache blocks are removed from the block map", "[external_file_cache]") {
+	DuckDB db(":memory:");
+	auto &db_instance = *db.instance;
+	auto tracking_fs = make_uniq<EFCTrackingFileSystem>();
+
+	const idx_t BLOCK_SIZE = 32768;
+	const idx_t NUM_BLOCKS = 16;
+	const idx_t FILE_SIZE = BLOCK_SIZE * NUM_BLOCKS;
+
+	Connection con(db);
+	con.Query(StringUtil::Format("SET external_file_cache_local_block_size=%llu", BLOCK_SIZE));
+	con.Query("SET memory_limit='96KB'");
+
+	auto content = MakeTestContent(FILE_SIZE);
+	EFCTestFileGuard test_file("test_evict_map_entries.bin", content);
+
+	CachingFileSystem cfs(*tracking_fs, db_instance);
+	auto &cache = db_instance.GetExternalFileCache();
+
+	{
+		auto handle = cfs.OpenFile(MakeTestOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, FILE_SIZE) == content);
+	}
+
+	// Force buffer pool eviction.
+	con.Query("CREATE TABLE memory_pressure AS SELECT range::BIGINT AS x FROM range(500000)");
+
+	for (auto &info : cache.GetCachedFileInformation()) {
+		REQUIRE(info.loaded);
+	}
+}
+
 TEST_CASE("Concurrent SET and Read do not corrupt data or cache state", "[external_file_cache]") {
 	DuckDB db(":memory:");
 	auto &db_instance = *db.instance;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes buffer-pool eviction hooks and cache metadata locking; incorrect eviction/sync could cause stale cache entries or extra I/O, but scope is limited to external file caching.
> 
> **Overview**
> Keeps the **external file cache** in sync when the **buffer pool** evicts `EXTERNAL_FILE_CACHE` blocks, instead of leaving stale entries in per-file block maps.
> 
> A reverse map from `BlockMemory` to `(cached file, block index)` is added. Blocks are **registered** when loaded (including after **reindex**), **unregistered** during reindex teardown, and **evicted** from `BufferPool` unload paths (normal eviction and aged purge). Eviction clears the cache block, drops it from the file’s block map, and removes the file from `cached_files` when it has no blocks left. Disabling the cache also clears `block_keys`. `ReindexAndAcquireBlocks` now takes `shared_ptr<CachedFile>`.
> 
> A test exercises eviction under a tight `memory_limit` after a full-file read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5894ddf383b1c4a96fb7999ddbd7860fd264824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->