### PR TITLE
Fix monotonic timestamp

### DIFF
--- a/.github/patches/extensions/httpfs/combined.patch
+++ b/.github/patches/extensions/httpfs/combined.patch
@@ -1,5 +1,5 @@
 diff --git a/src/httpfs.cpp b/src/httpfs.cpp
-index 1a9c466..973a3a5 100644
+index 1a9c466..09cf021 100644
 --- a/src/httpfs.cpp
 +++ b/src/httpfs.cpp
 @@ -365,6 +365,19 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
@@ -11,9 +11,9 @@ index 1a9c466..973a3a5 100644
 +	if (response && (response->Success() || response->status == HTTPStatusCode::PartialContent_206 ||
 +	                 response->status == HTTPStatusCode::Accepted_202)) {
 +		double total_seconds = 0;
-+		if (get_request.request_end.value > get_request.request_start.value) {
++		if (get_request.request_monotonic_end.value > get_request.request_monotonic_start.value) {
 +			total_seconds =
-+			    static_cast<double>(get_request.request_end.value - get_request.request_start.value) / 1e6;
++			    static_cast<double>(get_request.request_monotonic_end.value - get_request.request_monotonic_start.value) / 1e6;
 +		}
 +		const idx_t bytes = get_request.bytes_received != 0 ? get_request.bytes_received : buffer_out_len;
 +		hfh.RecordNetworkSample(total_seconds, bytes, get_request.have_time_to_fst_byte,
@@ -122,7 +122,7 @@ index efdc87d..3852958 100644
  		AddUserAgentIfAvailable(static_cast<HTTPFSParams &>(info.params), info.headers);
  		ResetRequestInfo();
 diff --git a/src/httpfs_httplib_client.cpp b/src/httpfs_httplib_client.cpp
-index f4e01f7..9e197d1 100644
+index f4e01f7..87339fa 100644
 --- a/src/httpfs_httplib_client.cpp
 +++ b/src/httpfs_httplib_client.cpp
 @@ -54,18 +54,32 @@ public:
@@ -131,7 +131,7 @@ index f4e01f7..9e197d1 100644
  		} else {
 -			return TransformResult(client->Get(
 +			// The httplib client streams per chunk, so the first chunk gives us TTFB, used by the prefetch cost model as the latency estimate.
-+			const auto request_start = Timestamp::GetCurrentTimestamp();
++			const auto request_monotonic_start = Timestamp::GetMonotonicTimestamp();
 +			idx_t total_bytes = 0;
 +			bool first_chunk = true;
 +			auto result = TransformResult(client->Get(
@@ -146,7 +146,7 @@ index f4e01f7..9e197d1 100644
 +					    info.have_time_to_fst_byte = true;
 +			            // We calculate the time to first byte as the time from when the request was issues to the chunk arrived.
 +					    info.time_to_fst_byte_sec =
-+					        static_cast<double>(Timestamp::GetCurrentTimestamp().value - request_start.value) / 1e6;
++					        static_cast<double>(Timestamp::GetMonotonicTimestamp().value - request_monotonic_start.value) / 1e6;
 +				    }
 +				    total_bytes += data_length;
  				    if (state) {

--- a/src/common/allocator/allocator_standard.cpp
+++ b/src/common/allocator/allocator_standard.cpp
@@ -58,7 +58,7 @@ static void MallocTrim(idx_t pad) {
 	static atomic<int64_t> LAST_TRIM_TIMESTAMP_MS {0};
 
 	int64_t last_trim_timestamp_ms = LAST_TRIM_TIMESTAMP_MS.load();
-	auto current_ts = Timestamp::GetCurrentTimestamp();
+	auto current_ts = Timestamp::GetMonotonicTimestamp();
 	auto current_timestamp_ms = Cast::Operation<timestamp_t, timestamp_ms_t>(current_ts).value;
 
 	if (current_timestamp_ms - last_trim_timestamp_ms < TRIM_INTERVAL_MS) {

--- a/src/common/thread_util.cpp
+++ b/src/common/thread_util.cpp
@@ -10,12 +10,12 @@ namespace duckdb {
 
 #ifndef DUCKDB_NO_THREADS
 void ThreadUtil::SleepMs(idx_t sleep_ms, optional_ptr<ClientContext> context) {
-	auto target_time = Timestamp::GetCurrentTimestamp();
+	auto target_time = Timestamp::GetMonotonicTimestamp();
 	target_time.value += static_cast<int64_t>(sleep_ms) * Interval::MICROS_PER_MSEC;
 	static constexpr idx_t DEFAULT_SLEEP_INTERVAL_MS = 100;
 
 	while (true) {
-		auto current_time = Timestamp::GetCurrentTimestamp();
+		auto current_time = Timestamp::GetMonotonicTimestamp();
 		if (context && context->IsInterrupted()) {
 			throw InterruptException();
 		}

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -454,6 +454,11 @@ timestamp_t Timestamp::GetMonotonicTimestamp() {
 	return timestamp_t(micros);
 }
 
+int64_t Timestamp::GetMonotonicNanoSeconds() {
+	auto now = steady_clock::now();
+	return duration_cast<nanoseconds>(now.time_since_epoch()).count();
+}
+
 timestamp_t Timestamp::FromEpochSecondsPossiblyInfinite(int64_t sec) {
 	timestamp_t input(sec);
 	if (!input.IsFinite()) {

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -448,6 +448,12 @@ timestamp_t Timestamp::GetCurrentTimestamp() {
 	return FromEpochMicroSeconds(epoch_micros);
 }
 
+timestamp_t Timestamp::GetMonotonicTimestamp() {
+	auto now = steady_clock::now();
+	auto micros = duration_cast<microseconds>(now.time_since_epoch()).count();
+	return timestamp_t(micros);
+}
+
 timestamp_t Timestamp::FromEpochSecondsPossiblyInfinite(int64_t sec) {
 	timestamp_t input(sec);
 	if (!input.IsFinite()) {

--- a/src/execution/adaptive_filter.cpp
+++ b/src/execution/adaptive_filter.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/common/types/interval.hpp"
 #include "duckdb/planner/table_filter_set.hpp"
 
 namespace duckdb {
@@ -93,7 +94,7 @@ AdaptiveFilterState AdaptiveFilter::BeginFilter() const {
 		return AdaptiveFilterState();
 	}
 	AdaptiveFilterState state;
-	state.start_time = high_resolution_clock::now();
+	state.monotonic_start = Timestamp::GetMonotonicTimestamp();
 	return state;
 }
 
@@ -102,8 +103,9 @@ void AdaptiveFilter::EndFilter(AdaptiveFilterState state) {
 		// nothing to permute
 		return;
 	}
-	auto end_time = high_resolution_clock::now();
-	AdaptRuntimeStatistics(duration_cast<duration<double>>(end_time - state.start_time).count());
+	auto duration = static_cast<double>(Timestamp::GetMonotonicTimestamp().value - state.monotonic_start.value) /
+	                static_cast<double>(Interval::MICROS_PER_SEC);
+	AdaptRuntimeStatistics(duration);
 }
 
 void AdaptiveFilter::AdaptRuntimeStatistics(double duration) {

--- a/src/include/duckdb/common/chrono.hpp
+++ b/src/include/duckdb/common/chrono.hpp
@@ -13,7 +13,6 @@
 namespace duckdb {
 using std::chrono::duration;
 using std::chrono::duration_cast;
-using std::chrono::high_resolution_clock;
 using std::chrono::microseconds;
 using std::chrono::milliseconds;
 using std::chrono::nanoseconds;

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -151,8 +151,11 @@ struct BaseRequest {
 
 	//! Requests will optionally contain their timings
 	bool have_request_timing = false;
-	timestamp_t request_start;
-	timestamp_t request_end;
+	// System clock start timestamp
+	timestamp_t request_system_start;
+	// Monotonic clock start and end timestamp
+	timestamp_t request_monotonic_start;
+	timestamp_t request_monotonic_end;
 
 	//! Optional per-request network measurements, populated by clients that measure them.
 	bool have_time_to_fst_byte = false;

--- a/src/include/duckdb/common/types/timestamp.hpp
+++ b/src/include/duckdb/common/types/timestamp.hpp
@@ -95,6 +95,8 @@ public:
 	DUCKDB_API static timestamp_t GetCurrentTimestamp();
 	//! Returns current monotonic timestamp in microseconds (for interval calculations only)
 	DUCKDB_API static timestamp_t GetMonotonicTimestamp();
+	//! Returns current monotonic time in nanoseconds (for interval calculations only)
+	DUCKDB_API static int64_t GetMonotonicNanoSeconds();
 
 	//! Convert the epoch (in sec) to a timestamp
 	DUCKDB_API static timestamp_t FromEpochSecondsPossiblyInfinite(int64_t s);

--- a/src/include/duckdb/common/types/timestamp.hpp
+++ b/src/include/duckdb/common/types/timestamp.hpp
@@ -93,6 +93,8 @@ public:
 	DUCKDB_API static void Convert(timestamp_ns_t date, date_t &out_date, dtime_t &out_time, int32_t &out_nanos);
 	//! Returns current timestamp
 	DUCKDB_API static timestamp_t GetCurrentTimestamp();
+	//! Returns current monotonic timestamp in microseconds (for interval calculations only)
+	DUCKDB_API static timestamp_t GetMonotonicTimestamp();
 
 	//! Convert the epoch (in sec) to a timestamp
 	DUCKDB_API static timestamp_t FromEpochSecondsPossiblyInfinite(int64_t s);

--- a/src/include/duckdb/execution/adaptive_filter.hpp
+++ b/src/include/duckdb/execution/adaptive_filter.hpp
@@ -10,17 +10,17 @@
 
 #include "duckdb/planner/table_filter_set.hpp"
 #include "duckdb/common/common.hpp"
-#include "duckdb/common/chrono.hpp"
 #include "duckdb/common/random_engine.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/pair.hpp"
+#include "duckdb/common/types/timestamp.hpp"
 
 namespace duckdb {
 
 class Logger;
 
 struct AdaptiveFilterState {
-	time_point<high_resolution_clock> start_time;
+	timestamp_t monotonic_start;
 };
 
 enum class AdaptiveFilterSource : uint8_t {

--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -223,7 +223,7 @@ public:
 	//! Get the compression level to use based on current write times
 	TemporaryCompressionLevel GetCompressionLevel();
 	//! Update write time for given compression level
-	void Update(TemporaryCompressionLevel level, int64_t time_before_micros);
+	void Update(TemporaryCompressionLevel level, int64_t time_before_ns);
 
 private:
 	//! Convert from level to index into write time array and back
@@ -235,7 +235,7 @@ private:
 
 private:
 	//! The value to initialize the atomic write counters to
-	static constexpr int64_t INITIAL_MICROS = 50;
+	static constexpr int64_t INITIAL_NS = 50000;
 	//! How many compression levels we adapt between
 	static constexpr idx_t LEVELS = 6;
 	//! Bias towards compressed writes: we only choose uncompressed if it is more than 2x faster than compressed
@@ -248,9 +248,9 @@ private:
 	//! Random engine to (sometimes) randomize compression
 	RandomEngine random_engine;
 	//! Duration of the last uncompressed write
-	int64_t last_uncompressed_write_micros;
+	int64_t last_uncompressed_write_ns;
 	//! Duration of the last compressed writes
-	int64_t last_compressed_writes_micros[LEVELS];
+	int64_t last_compressed_writes_ns[LEVELS];
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -220,12 +220,10 @@ public:
 	TemporaryFileCompressionAdaptivity();
 
 public:
-	//! Get current time in nanoseconds to measure write times
-	static int64_t GetCurrentTimeNanos();
 	//! Get the compression level to use based on current write times
 	TemporaryCompressionLevel GetCompressionLevel();
 	//! Update write time for given compression level
-	void Update(TemporaryCompressionLevel level, int64_t time_before_ns);
+	void Update(TemporaryCompressionLevel level, int64_t time_before_micros);
 
 private:
 	//! Convert from level to index into write time array and back
@@ -237,7 +235,7 @@ private:
 
 private:
 	//! The value to initialize the atomic write counters to
-	static constexpr int64_t INITIAL_NS = 50000;
+	static constexpr int64_t INITIAL_MICROS = 50;
 	//! How many compression levels we adapt between
 	static constexpr idx_t LEVELS = 6;
 	//! Bias towards compressed writes: we only choose uncompressed if it is more than 2x faster than compressed
@@ -250,9 +248,9 @@ private:
 	//! Random engine to (sometimes) randomize compression
 	RandomEngine random_engine;
 	//! Duration of the last uncompressed write
-	int64_t last_uncompressed_write_ns;
+	int64_t last_uncompressed_write_micros;
 	//! Duration of the last compressed writes
-	int64_t last_compressed_writes_ns[LEVELS];
+	int64_t last_compressed_writes_micros[LEVELS];
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -100,9 +100,10 @@ string HTTPLogType::ConstructLogMessage(BaseRequest &request, optional_ptr<HTTPR
 	    {"url", Value(request.url)},
 	    {"headers", CreateHTTPHeadersValue(request.headers)},
 	    {"start_time", request.have_request_timing ? Value::TIMESTAMP(request.request_system_start) : Value()},
-	    {"duration_ms", request.have_request_timing ? Value::BIGINT(Timestamp::GetEpochMs(request.request_monotonic_end) -
-	                                                                Timestamp::GetEpochMs(request.request_monotonic_start))
-	                                                : Value()}};
+	    {"duration_ms", request.have_request_timing
+	                        ? Value::BIGINT(Timestamp::GetEpochMs(request.request_monotonic_end) -
+	                                        Timestamp::GetEpochMs(request.request_monotonic_start))
+	                        : Value()}};
 	auto request_value = Value::STRUCT(request_child_list);
 	Value response_value;
 	if (response) {

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -99,9 +99,9 @@ string HTTPLogType::ConstructLogMessage(BaseRequest &request, optional_ptr<HTTPR
 	    {"type", Value(EnumUtil::ToString(request.type))},
 	    {"url", Value(request.url)},
 	    {"headers", CreateHTTPHeadersValue(request.headers)},
-	    {"start_time", request.have_request_timing ? Value::TIMESTAMP(request.request_start) : Value()},
-	    {"duration_ms", request.have_request_timing ? Value::BIGINT(Timestamp::GetEpochMs(request.request_end) -
-	                                                                Timestamp::GetEpochMs(request.request_start))
+	    {"start_time", request.have_request_timing ? Value::TIMESTAMP(request.request_system_start) : Value()},
+	    {"duration_ms", request.have_request_timing ? Value::BIGINT(Timestamp::GetEpochMs(request.request_monotonic_end) -
+	                                                                Timestamp::GetEpochMs(request.request_monotonic_start))
 	                                                : Value()}};
 	auto request_value = Value::STRUCT(request_child_list);
 	Value response_value;

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -266,14 +266,15 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<
 		}
 
 		try {
-			request.request_start = Timestamp::GetCurrentTimestamp();
+			request.request_system_start = Timestamp::GetCurrentTimestamp();
+			request.request_monotonic_start = Timestamp::GetMonotonicTimestamp();
 			response = client->Request(request);
 		} catch (...) {
-			request.request_end = Timestamp::GetCurrentTimestamp();
+			request.request_monotonic_end = Timestamp::GetMonotonicTimestamp();
 			LogRequest(request, nullptr);
 			throw;
 		}
-		request.request_end = Timestamp::GetCurrentTimestamp();
+		request.request_monotonic_end = Timestamp::GetMonotonicTimestamp();
 		LogRequest(request, response ? response.get() : nullptr);
 		return response;
 	});

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -18,7 +18,6 @@
 #include "duckdb/parallel/pipeline_prepare_finish_event.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/parallel/thread_context.hpp"
-#include "duckdb/common/types/interval.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 
 #include <algorithm>
@@ -480,18 +479,18 @@ void Executor::WaitForTask() {
 	auto begin = Timestamp::GetMonotonicTimestamp();
 	std::unique_lock<mutex> l(executor_lock);
 	auto end = Timestamp::GetMonotonicTimestamp();
-	auto ms = NumericCast<idx_t>((end.value - begin.value) / Interval::MICROS_PER_MSEC);
+	auto blocked_micros = NumericCast<idx_t>(end.value - begin.value);
 	if (to_be_rescheduled_tasks.empty()) {
-		blocked_thread_time += ms;
+		blocked_thread_time += blocked_micros;
 		return;
 	}
 	if (ResultCollectorIsBlocked()) {
 		// If the result collector is blocked, it won't get unblocked until the connection calls Fetch
-		blocked_thread_time += ms;
+		blocked_thread_time += blocked_micros;
 		return;
 	}
 
-	blocked_thread_time += ms + WAIT_TIME_MS.count();
+	blocked_thread_time += blocked_micros + WAIT_TIME_MS.count();
 	task_reschedule.wait_for(l, WAIT_TIME_MS);
 #endif
 }

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -18,6 +18,8 @@
 #include "duckdb/parallel/pipeline_prepare_finish_event.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/parallel/thread_context.hpp"
+#include "duckdb/common/types/interval.hpp"
+#include "duckdb/common/types/timestamp.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -475,11 +477,10 @@ void Executor::SignalTaskRescheduled(lock_guard<mutex> &) {
 void Executor::WaitForTask() {
 #ifndef DUCKDB_NO_THREADS
 	static constexpr std::chrono::microseconds WAIT_TIME_MS = std::chrono::microseconds(WAIT_TIME * 1000);
-	auto begin = std::chrono::high_resolution_clock::now();
+	auto begin = Timestamp::GetMonotonicTimestamp();
 	std::unique_lock<mutex> l(executor_lock);
-	auto end = std::chrono::high_resolution_clock::now();
-	auto dur = end - begin;
-	auto ms = NumericCast<idx_t>(std::chrono::duration_cast<std::chrono::microseconds>(dur).count());
+	auto end = Timestamp::GetMonotonicTimestamp();
+	auto ms = NumericCast<idx_t>((end.value - begin.value) / Interval::MICROS_PER_MSEC);
 	if (to_be_rescheduled_tasks.empty()) {
 		blocked_thread_time += ms;
 		return;

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -404,9 +404,9 @@ void TemporaryFileMap::EraseFile(const TemporaryFileIdentifier &identifier) {
 //===--------------------------------------------------------------------===//
 // TemporaryFileCompressionLevel/TemporaryFileCompressionAdaptivity
 //===--------------------------------------------------------------------===//
-TemporaryFileCompressionAdaptivity::TemporaryFileCompressionAdaptivity() : last_uncompressed_write_micros(INITIAL_MICROS) {
+TemporaryFileCompressionAdaptivity::TemporaryFileCompressionAdaptivity() : last_uncompressed_write_ns(INITIAL_NS) {
 	for (idx_t i = 0; i < LEVELS; i++) {
-		last_compressed_writes_micros[i] = INITIAL_MICROS;
+		last_compressed_writes_ns[i] = INITIAL_NS;
 	}
 }
 
@@ -438,9 +438,9 @@ TemporaryCompressionLevel TemporaryFileCompressionAdaptivity::GetCompressionLeve
 	{
 		lock_guard<mutex> guard(random_engine.lock);
 
-		auto min_compressed_time = last_compressed_writes_micros[min_compression_idx];
+		auto min_compressed_time = last_compressed_writes_ns[min_compression_idx];
 		for (idx_t compression_idx = 1; compression_idx < LEVELS; compression_idx++) {
-			const auto time = last_compressed_writes_micros[compression_idx];
+			const auto time = last_compressed_writes_ns[compression_idx];
 			if (time < min_compressed_time) {
 				min_compression_idx = compression_idx;
 				min_compressed_time = time;
@@ -448,7 +448,7 @@ TemporaryCompressionLevel TemporaryFileCompressionAdaptivity::GetCompressionLeve
 		}
 		level = IndexToLevel(min_compression_idx);
 
-		ratio = static_cast<double>(min_compressed_time) / static_cast<double>(last_uncompressed_write_micros);
+		ratio = static_cast<double>(min_compressed_time) / static_cast<double>(last_uncompressed_write_ns);
 		should_compress = ratio < DURATION_RATIO_THRESHOLD;
 
 		should_deviate = random_engine.NextRandom() < COMPRESSION_DEVIATION;
@@ -474,13 +474,13 @@ TemporaryCompressionLevel TemporaryFileCompressionAdaptivity::GetCompressionLeve
 	return result;
 }
 
-void TemporaryFileCompressionAdaptivity::Update(const TemporaryCompressionLevel level, const int64_t time_before_micros) {
-	const auto duration = Timestamp::GetMonotonicTimestamp().value - time_before_micros;
-	auto &last_write_micros = level == TemporaryCompressionLevel::UNCOMPRESSED
-	                              ? last_uncompressed_write_micros
-	                              : last_compressed_writes_micros[LevelToIndex(level)];
+void TemporaryFileCompressionAdaptivity::Update(const TemporaryCompressionLevel level, const int64_t time_before_ns) {
+	const auto duration = Timestamp::GetMonotonicNanoSeconds() - time_before_ns;
+	auto &last_write_ns = level == TemporaryCompressionLevel::UNCOMPRESSED
+	                          ? last_uncompressed_write_ns
+	                          : last_compressed_writes_ns[LevelToIndex(level)];
 	lock_guard<mutex> guard(random_engine.lock);
-	last_write_micros = (last_write_micros * (WEIGHT - 1) + duration) / WEIGHT;
+	last_write_ns = (last_write_ns * (WEIGHT - 1) + duration) / WEIGHT;
 }
 
 //===--------------------------------------------------------------------===//
@@ -506,7 +506,7 @@ idx_t TemporaryFileManager::WriteTemporaryBuffer(block_id_t block_id, FileBuffer
 	const auto adaptivity_idx = TaskScheduler::GetEstimatedCPUId() % COMPRESSION_ADAPTIVITIES;
 	auto &compression_adaptivity = compression_adaptivities[adaptivity_idx];
 
-	const auto time_before_micros = Timestamp::GetMonotonicTimestamp().value;
+	const auto time_before_ns = Timestamp::GetMonotonicNanoSeconds();
 	AllocatedData compressed_buffer;
 	const auto compression_result = CompressBuffer(compression_adaptivity, buffer, compressed_buffer);
 
@@ -540,7 +540,7 @@ idx_t TemporaryFileManager::WriteTemporaryBuffer(block_id_t block_id, FileBuffer
 
 	handle->WriteTemporaryBuffer(buffer, index.block_index.GetIndex(), compressed_buffer);
 
-	compression_adaptivity.Update(compression_result.level, time_before_micros);
+	compression_adaptivity.Update(compression_result.level, time_before_ns);
 	return static_cast<idx_t>(compression_result.size);
 }
 

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/common/encryption_functions.hpp"
+#include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/storage/storage_options.hpp"
 #include "zstd.h"
 
@@ -403,14 +404,10 @@ void TemporaryFileMap::EraseFile(const TemporaryFileIdentifier &identifier) {
 //===--------------------------------------------------------------------===//
 // TemporaryFileCompressionLevel/TemporaryFileCompressionAdaptivity
 //===--------------------------------------------------------------------===//
-TemporaryFileCompressionAdaptivity::TemporaryFileCompressionAdaptivity() : last_uncompressed_write_ns(INITIAL_NS) {
+TemporaryFileCompressionAdaptivity::TemporaryFileCompressionAdaptivity() : last_uncompressed_write_micros(INITIAL_MICROS) {
 	for (idx_t i = 0; i < LEVELS; i++) {
-		last_compressed_writes_ns[i] = INITIAL_NS;
+		last_compressed_writes_micros[i] = INITIAL_MICROS;
 	}
-}
-
-int64_t TemporaryFileCompressionAdaptivity::GetCurrentTimeNanos() {
-	return duration_cast<nanoseconds>(high_resolution_clock::now().time_since_epoch()).count();
 }
 
 TemporaryCompressionLevel TemporaryFileCompressionAdaptivity::IndexToLevel(const idx_t index) {
@@ -441,9 +438,9 @@ TemporaryCompressionLevel TemporaryFileCompressionAdaptivity::GetCompressionLeve
 	{
 		lock_guard<mutex> guard(random_engine.lock);
 
-		auto min_compressed_time = last_compressed_writes_ns[min_compression_idx];
+		auto min_compressed_time = last_compressed_writes_micros[min_compression_idx];
 		for (idx_t compression_idx = 1; compression_idx < LEVELS; compression_idx++) {
-			const auto time = last_compressed_writes_ns[compression_idx];
+			const auto time = last_compressed_writes_micros[compression_idx];
 			if (time < min_compressed_time) {
 				min_compression_idx = compression_idx;
 				min_compressed_time = time;
@@ -451,7 +448,7 @@ TemporaryCompressionLevel TemporaryFileCompressionAdaptivity::GetCompressionLeve
 		}
 		level = IndexToLevel(min_compression_idx);
 
-		ratio = static_cast<double>(min_compressed_time) / static_cast<double>(last_uncompressed_write_ns);
+		ratio = static_cast<double>(min_compressed_time) / static_cast<double>(last_uncompressed_write_micros);
 		should_compress = ratio < DURATION_RATIO_THRESHOLD;
 
 		should_deviate = random_engine.NextRandom() < COMPRESSION_DEVIATION;
@@ -477,13 +474,13 @@ TemporaryCompressionLevel TemporaryFileCompressionAdaptivity::GetCompressionLeve
 	return result;
 }
 
-void TemporaryFileCompressionAdaptivity::Update(const TemporaryCompressionLevel level, const int64_t time_before_ns) {
-	const auto duration = GetCurrentTimeNanos() - time_before_ns;
-	auto &last_write_ns = level == TemporaryCompressionLevel::UNCOMPRESSED
-	                          ? last_uncompressed_write_ns
-	                          : last_compressed_writes_ns[LevelToIndex(level)];
+void TemporaryFileCompressionAdaptivity::Update(const TemporaryCompressionLevel level, const int64_t time_before_micros) {
+	const auto duration = Timestamp::GetMonotonicTimestamp().value - time_before_micros;
+	auto &last_write_micros = level == TemporaryCompressionLevel::UNCOMPRESSED
+	                              ? last_uncompressed_write_micros
+	                              : last_compressed_writes_micros[LevelToIndex(level)];
 	lock_guard<mutex> guard(random_engine.lock);
-	last_write_ns = (last_write_ns * (WEIGHT - 1) + duration) / WEIGHT;
+	last_write_micros = (last_write_micros * (WEIGHT - 1) + duration) / WEIGHT;
 }
 
 //===--------------------------------------------------------------------===//
@@ -509,7 +506,7 @@ idx_t TemporaryFileManager::WriteTemporaryBuffer(block_id_t block_id, FileBuffer
 	const auto adaptivity_idx = TaskScheduler::GetEstimatedCPUId() % COMPRESSION_ADAPTIVITIES;
 	auto &compression_adaptivity = compression_adaptivities[adaptivity_idx];
 
-	const auto time_before_ns = TemporaryFileCompressionAdaptivity::GetCurrentTimeNanos();
+	const auto time_before_micros = Timestamp::GetMonotonicTimestamp().value;
 	AllocatedData compressed_buffer;
 	const auto compression_result = CompressBuffer(compression_adaptivity, buffer, compressed_buffer);
 
@@ -543,7 +540,7 @@ idx_t TemporaryFileManager::WriteTemporaryBuffer(block_id_t block_id, FileBuffer
 
 	handle->WriteTemporaryBuffer(buffer, index.block_index.GetIndex(), compressed_buffer);
 
-	compression_adaptivity.Update(compression_result.level, time_before_ns);
+	compression_adaptivity.Update(compression_result.level, time_before_micros);
 	return static_cast<idx_t>(compression_result.size);
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad timing changes affect adaptivity, profiling, and HTTP metrics; behavior shifts only on clock skew but touches parallel execution and remote I/O paths.
> 
> **Overview**
> Fixes **incorrect or negative durations** when wall-clock time is adjusted (NTP, leap seconds, etc.) by introducing **`Timestamp::GetMonotonicTimestamp()`** and **`GetMonotonicNanoSeconds()`** on `steady_clock`, and routing **elapsed-time** logic through them instead of **`GetCurrentTimestamp()`** or **`high_resolution_clock`**.
> 
> **HTTP** request metadata now keeps **`request_system_start`** for logged wall-clock start while **`request_monotonic_start` / `request_monotonic_end`** drive **`duration_ms`** in HTTP logs and range-request timing in the **httpfs** patch (including TTFB and prefetch network samples). **Adaptive filters**, **executor** blocked-thread accounting, **malloc trim** throttling, **thread sleep**, and **temporary-file compression adaptivity** all switch to monotonic deltas for their measurements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 020c04968b2458b620ea1dd4d43f74da6cd0be77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->