### PR TITLE
Clean async tasks after schedule

### DIFF
--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -44,11 +44,11 @@ public:
 	AsyncResult &operator=(AsyncResultType t);
 	AsyncResult &operator=(AsyncResult &&) noexcept;
 	//! Schedule held async_tasks into the Executor, eventually unblocking InterruptState
-	//! needs to be called with non-emopty async_tasks and from BLOCKED state, will empty the async_tasks and transform
+	//! needs to be called with non-empty async_tasks and from BLOCKED state, will empty the async_tasks and transform
 	//! into INVALID
 	void ScheduleTasks(InterruptState &interrupt_state, Executor &executor);
 	//! Execute tasks synchronously at callsite
-	//! needs to be called with non-emopty async_tasks and from BLOCKED state, will empty the async_tasks and transform
+	//! needs to be called with non-empty async_tasks and from BLOCKED state, will empty the async_tasks and transform
 	//! into HAVE_MORE_OUTPUT
 	void ExecuteTasksSynchronously();
 

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -128,6 +128,9 @@ void AsyncResult::ScheduleTasks(InterruptState &interrupt_state, Executor &execu
 		auto task = make_uniq<AsyncExecutionTask>(executor, std::move(async_task), interrupt_state, completion);
 		TaskScheduler::GetScheduler(executor.context).ScheduleTask(executor.GetToken(), std::move(task), pool_type);
 	}
+
+	async_tasks.clear();
+	result_type = AsyncResultType::INVALID;
 }
 
 void AsyncResult::ExecuteTasksSynchronously() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes async task handoff in the parallel executor path (e.g. physical table scan blocking), but the behavior aligns with existing docs and sibling methods, reducing risk of stale BLOCKED state or double use of tasks.
> 
> **Overview**
> **`AsyncResult::ScheduleTasks`** now matches its documented contract: after enqueueing work on the executor it **clears `async_tasks`** and sets **`result_type` to `INVALID`**, same as **`ExecuteTasksSynchronously`** already did for the sync path.
> 
> Header comments fix a typo (**non-emopty** → **non-empty**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 810ed2293e0dbbede371f42332c727b49dd88c6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->