### PR TITLE
appender benchmark

### DIFF
--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
   duckdb_benchmark_micro OBJECT
   append.cpp
   append_mix.cpp
+  appender_lineitem.cpp
   bulkupdate.cpp
   cast.cpp
   in.cpp

--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(
   appender_lineitem.cpp
   bulkupdate.cpp
   cast.cpp
+  compression_detection.cpp
   in.cpp
   storage.cpp
   string_serialize.cpp)

--- a/benchmark/micro/appender_lineitem.cpp
+++ b/benchmark/micro/appender_lineitem.cpp
@@ -1,0 +1,269 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark.hpp"
+#include "duckdb/main/appender.hpp"
+
+using namespace duckdb;
+
+// Benchmarks Appender ingestion using a TPC-H lineitem-inspired schema.
+// The lineitem table is the largest and most column-diverse table in TPC-H (16 columns),
+// making it a well-known target for bulk ingestion performance evaluation.
+//
+// Schema: 4x INTEGER, 4x DOUBLE, 2x VARCHAR (1-char flags), 3x INTEGER (dates as days
+//         since epoch), 1x VARCHAR (shipinstruct), 1x VARCHAR (shipmode), 1x VARCHAR (comment)
+//
+// l_orderkey / l_linenumber are assigned so that every (orderkey, linenumber) pair is
+// unique (each orderkey gets at most 7 line items, linenumber 1–7), allowing the
+// PRIMARY KEY variant to run without constraint violations.
+//
+// All variants persist to disk (InMemory() returns false) to reflect realistic ingestion.
+
+static constexpr int32_t LINEITEM_ROW_COUNT = 1000000;
+
+// Days since 1970-01-01 for 1994-01-01 (start of the TPC-H date range)
+static constexpr int32_t LINEITEM_BASE_DATE = 8827;
+
+static const char CREATE_LINEITEM_NO_PK[] =
+    "CREATE TABLE lineitem("
+    "l_orderkey INTEGER, "
+    "l_partkey INTEGER, "
+    "l_suppkey INTEGER, "
+    "l_linenumber INTEGER, "
+    "l_quantity DOUBLE, "
+    "l_extendedprice DOUBLE, "
+    "l_discount DOUBLE, "
+    "l_tax DOUBLE, "
+    "l_returnflag VARCHAR, "
+    "l_linestatus VARCHAR, "
+    "l_shipdate INTEGER, "
+    "l_commitdate INTEGER, "
+    "l_receiptdate INTEGER, "
+    "l_shipinstruct VARCHAR, "
+    "l_shipmode VARCHAR, "
+    "l_comment VARCHAR)";
+
+static const char CREATE_LINEITEM_PK[] =
+    "CREATE TABLE lineitem("
+    "l_orderkey INTEGER, "
+    "l_partkey INTEGER, "
+    "l_suppkey INTEGER, "
+    "l_linenumber INTEGER, "
+    "l_quantity DOUBLE, "
+    "l_extendedprice DOUBLE, "
+    "l_discount DOUBLE, "
+    "l_tax DOUBLE, "
+    "l_returnflag VARCHAR, "
+    "l_linestatus VARCHAR, "
+    "l_shipdate INTEGER, "
+    "l_commitdate INTEGER, "
+    "l_receiptdate INTEGER, "
+    "l_shipinstruct VARCHAR, "
+    "l_shipmode VARCHAR, "
+    "l_comment VARCHAR, "
+    "PRIMARY KEY (l_orderkey, l_linenumber))";
+
+// TPC-H enumeration domains
+static const char *const RETURNFLAGS[] = {"A", "N", "R"};
+static const uint32_t RETURNFLAG_LENS[] = {1, 1, 1};
+
+static const char *const LINESTATUS[] = {"O", "F"};
+static const uint32_t LINESTATUS_LENS[] = {1, 1};
+
+static const char *const SHIPINSTRUCT[] = {"DELIVER IN PERSON", "COLLECT COD", "NONE", "TAKE BACK RETURN"};
+static const uint32_t SHIPINSTRUCT_LENS[] = {17, 11, 4, 16};
+
+static const char *const SHIPMODE[] = {"AIR", "AIR REG", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK"};
+static const uint32_t SHIPMODE_LENS[] = {3, 7, 3, 4, 4, 7, 4, 5};
+
+static const char COMMENT_STR[] = "regular annual package";
+static constexpr uint32_t COMMENT_LEN = 22;
+
+// ---------------------------------------------------------------------------
+// Base class: shared RunBenchmark / Cleanup / VerifyResult / BenchmarkInfo
+// All variants persist to disk.
+// ---------------------------------------------------------------------------
+class AppenderLineitemBenchmark : public DuckDBBenchmark {
+protected:
+	AppenderLineitemBenchmark(bool register_benchmark, const string &name)
+	    : DuckDBBenchmark(register_benchmark, name, "[appender_lineitem]") {
+	}
+
+public:
+	bool InMemory() override {
+		return false;
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		Appender appender(state->conn, "lineitem");
+		for (int32_t i = 0; i < LINEITEM_ROW_COUNT; i++) {
+			const idx_t rf = idx_t(i) % 3;
+			const idx_t ls = idx_t(i) % 2;
+			const idx_t si = idx_t(i) % 4;
+			const idx_t sm = idx_t(i) % 8;
+			appender.BeginRow();
+			appender.Append<int32_t>(i / 7 + 1);                                        // l_orderkey
+			appender.Append<int32_t>(i % 200000 + 1);                                   // l_partkey
+			appender.Append<int32_t>(i % 10000 + 1);                                    // l_suppkey
+			appender.Append<int32_t>(i % 7 + 1);                                        // l_linenumber
+			appender.Append<double>(1.0 + double(i % 50));                              // l_quantity
+			appender.Append<double>(900.0 + double(i % 104949) * 0.01);                 // l_extendedprice
+			appender.Append<double>(double(i % 11) * 0.01);                             // l_discount
+			appender.Append<double>(double(i % 9) * 0.01);                              // l_tax
+			appender.Append<string_t>(string_t(RETURNFLAGS[rf], RETURNFLAG_LENS[rf]));  // l_returnflag
+			appender.Append<string_t>(string_t(LINESTATUS[ls], LINESTATUS_LENS[ls]));   // l_linestatus
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                    // l_shipdate
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                    // l_commitdate
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                    // l_receiptdate
+			appender.Append<string_t>(string_t(SHIPINSTRUCT[si], SHIPINSTRUCT_LENS[si])); // l_shipinstruct
+			appender.Append<string_t>(string_t(SHIPMODE[sm], SHIPMODE_LENS[sm]));       // l_shipmode
+			appender.Append<string_t>(string_t(COMMENT_STR, COMMENT_LEN));              // l_comment
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE lineitem");
+		Load(state);
+	}
+
+	string VerifyResult(QueryResult *result) override {
+		return string();
+	}
+
+	string BenchmarkInfo() override {
+		return "Ingest 1M rows into a 16-column TPC-H lineitem-like table using the Appender (persistent storage)";
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Variant 1: no primary key
+// ---------------------------------------------------------------------------
+class AppenderLineitem1MBenchmark : public AppenderLineitemBenchmark {
+	AppenderLineitem1MBenchmark(bool register_benchmark)
+	    : AppenderLineitemBenchmark(register_benchmark, "AppenderLineitem1M") {
+	}
+
+public:
+	static AppenderLineitem1MBenchmark *GetInstance() {
+		static AppenderLineitem1MBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderLineitem1MBenchmark>(new AppenderLineitem1MBenchmark(false));
+		return &singleton;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(CREATE_LINEITEM_NO_PK);
+	}
+};
+auto global_instance_AppenderLineitem1M = AppenderLineitem1MBenchmark::GetInstance();
+
+// ---------------------------------------------------------------------------
+// Variant 2: composite primary key (l_orderkey, l_linenumber)
+// ---------------------------------------------------------------------------
+class AppenderLineitem1MPrimaryKeyBenchmark : public AppenderLineitemBenchmark {
+	AppenderLineitem1MPrimaryKeyBenchmark(bool register_benchmark)
+	    : AppenderLineitemBenchmark(register_benchmark, "AppenderLineitem1MPrimaryKey") {
+	}
+
+public:
+	static AppenderLineitem1MPrimaryKeyBenchmark *GetInstance() {
+		static AppenderLineitem1MPrimaryKeyBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderLineitem1MPrimaryKeyBenchmark>(
+		    new AppenderLineitem1MPrimaryKeyBenchmark(false));
+		return &singleton;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(CREATE_LINEITEM_PK);
+	}
+};
+auto global_instance_AppenderLineitem1MPrimaryKey = AppenderLineitem1MPrimaryKeyBenchmark::GetInstance();
+
+// ---------------------------------------------------------------------------
+// DirectAppender base: same schema / data / disk persistence as above, but
+// uses DirectAppender which flushes directly into the table without going
+// through the full query pipeline.
+// ---------------------------------------------------------------------------
+class DirectAppenderLineitemBenchmark : public AppenderLineitemBenchmark {
+protected:
+	DirectAppenderLineitemBenchmark(bool register_benchmark, const string &name)
+	    : AppenderLineitemBenchmark(register_benchmark, name) {
+	}
+
+public:
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		DirectAppender appender(state->conn, "lineitem");
+		for (int32_t i = 0; i < LINEITEM_ROW_COUNT; i++) {
+			const idx_t rf = idx_t(i) % 3;
+			const idx_t ls = idx_t(i) % 2;
+			const idx_t si = idx_t(i) % 4;
+			const idx_t sm = idx_t(i) % 8;
+			appender.BeginRow();
+			appender.Append<int32_t>(i / 7 + 1);                                        // l_orderkey
+			appender.Append<int32_t>(i % 200000 + 1);                                   // l_partkey
+			appender.Append<int32_t>(i % 10000 + 1);                                    // l_suppkey
+			appender.Append<int32_t>(i % 7 + 1);                                        // l_linenumber
+			appender.Append<double>(1.0 + double(i % 50));                              // l_quantity
+			appender.Append<double>(900.0 + double(i % 104949) * 0.01);                 // l_extendedprice
+			appender.Append<double>(double(i % 11) * 0.01);                             // l_discount
+			appender.Append<double>(double(i % 9) * 0.01);                              // l_tax
+			appender.Append<string_t>(string_t(RETURNFLAGS[rf], RETURNFLAG_LENS[rf]));  // l_returnflag
+			appender.Append<string_t>(string_t(LINESTATUS[ls], LINESTATUS_LENS[ls]));   // l_linestatus
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                    // l_shipdate
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                    // l_commitdate
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                    // l_receiptdate
+			appender.Append<string_t>(string_t(SHIPINSTRUCT[si], SHIPINSTRUCT_LENS[si])); // l_shipinstruct
+			appender.Append<string_t>(string_t(SHIPMODE[sm], SHIPMODE_LENS[sm]));       // l_shipmode
+			appender.Append<string_t>(string_t(COMMENT_STR, COMMENT_LEN));              // l_comment
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	string BenchmarkInfo() override {
+		return "Ingest 1M rows into a 16-column TPC-H lineitem-like table using DirectAppender (persistent storage)";
+	}
+};
+
+// ---------------------------------------------------------------------------
+// DirectAppender variant 1: no primary key
+// ---------------------------------------------------------------------------
+class DirectAppenderLineitem1MBenchmark : public DirectAppenderLineitemBenchmark {
+	DirectAppenderLineitem1MBenchmark(bool register_benchmark)
+	    : DirectAppenderLineitemBenchmark(register_benchmark, "DirectAppenderLineitem1M") {
+	}
+
+public:
+	static DirectAppenderLineitem1MBenchmark *GetInstance() {
+		static DirectAppenderLineitem1MBenchmark singleton(true);
+		auto b =
+		    duckdb::unique_ptr<DirectAppenderLineitem1MBenchmark>(new DirectAppenderLineitem1MBenchmark(false));
+		return &singleton;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(CREATE_LINEITEM_NO_PK);
+	}
+};
+auto global_instance_DirectAppenderLineitem1M = DirectAppenderLineitem1MBenchmark::GetInstance();
+
+// ---------------------------------------------------------------------------
+// DirectAppender variant 2: composite primary key (l_orderkey, l_linenumber)
+// ---------------------------------------------------------------------------
+class DirectAppenderLineitem1MPrimaryKeyBenchmark : public DirectAppenderLineitemBenchmark {
+	DirectAppenderLineitem1MPrimaryKeyBenchmark(bool register_benchmark)
+	    : DirectAppenderLineitemBenchmark(register_benchmark, "DirectAppenderLineitem1MPrimaryKey") {
+	}
+
+public:
+	static DirectAppenderLineitem1MPrimaryKeyBenchmark *GetInstance() {
+		static DirectAppenderLineitem1MPrimaryKeyBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<DirectAppenderLineitem1MPrimaryKeyBenchmark>(
+		    new DirectAppenderLineitem1MPrimaryKeyBenchmark(false));
+		return &singleton;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(CREATE_LINEITEM_PK);
+	}
+};
+auto global_instance_DirectAppenderLineitem1MPrimaryKey = DirectAppenderLineitem1MPrimaryKeyBenchmark::GetInstance();

--- a/benchmark/micro/appender_lineitem.cpp
+++ b/benchmark/micro/appender_lineitem.cpp
@@ -22,44 +22,42 @@ static constexpr int32_t LINEITEM_ROW_COUNT = 1000000;
 // Days since 1970-01-01 for 1994-01-01 (start of the TPC-H date range)
 static constexpr int32_t LINEITEM_BASE_DATE = 8827;
 
-static const char CREATE_LINEITEM_NO_PK[] =
-    "CREATE TABLE lineitem("
-    "l_orderkey INTEGER, "
-    "l_partkey INTEGER, "
-    "l_suppkey INTEGER, "
-    "l_linenumber INTEGER, "
-    "l_quantity DOUBLE, "
-    "l_extendedprice DOUBLE, "
-    "l_discount DOUBLE, "
-    "l_tax DOUBLE, "
-    "l_returnflag VARCHAR, "
-    "l_linestatus VARCHAR, "
-    "l_shipdate INTEGER, "
-    "l_commitdate INTEGER, "
-    "l_receiptdate INTEGER, "
-    "l_shipinstruct VARCHAR, "
-    "l_shipmode VARCHAR, "
-    "l_comment VARCHAR)";
+static const char CREATE_LINEITEM_NO_PK[] = "CREATE TABLE lineitem("
+                                            "l_orderkey INTEGER, "
+                                            "l_partkey INTEGER, "
+                                            "l_suppkey INTEGER, "
+                                            "l_linenumber INTEGER, "
+                                            "l_quantity DOUBLE, "
+                                            "l_extendedprice DOUBLE, "
+                                            "l_discount DOUBLE, "
+                                            "l_tax DOUBLE, "
+                                            "l_returnflag VARCHAR, "
+                                            "l_linestatus VARCHAR, "
+                                            "l_shipdate INTEGER, "
+                                            "l_commitdate INTEGER, "
+                                            "l_receiptdate INTEGER, "
+                                            "l_shipinstruct VARCHAR, "
+                                            "l_shipmode VARCHAR, "
+                                            "l_comment VARCHAR)";
 
-static const char CREATE_LINEITEM_PK[] =
-    "CREATE TABLE lineitem("
-    "l_orderkey INTEGER, "
-    "l_partkey INTEGER, "
-    "l_suppkey INTEGER, "
-    "l_linenumber INTEGER, "
-    "l_quantity DOUBLE, "
-    "l_extendedprice DOUBLE, "
-    "l_discount DOUBLE, "
-    "l_tax DOUBLE, "
-    "l_returnflag VARCHAR, "
-    "l_linestatus VARCHAR, "
-    "l_shipdate INTEGER, "
-    "l_commitdate INTEGER, "
-    "l_receiptdate INTEGER, "
-    "l_shipinstruct VARCHAR, "
-    "l_shipmode VARCHAR, "
-    "l_comment VARCHAR, "
-    "PRIMARY KEY (l_orderkey, l_linenumber))";
+static const char CREATE_LINEITEM_PK[] = "CREATE TABLE lineitem("
+                                         "l_orderkey INTEGER, "
+                                         "l_partkey INTEGER, "
+                                         "l_suppkey INTEGER, "
+                                         "l_linenumber INTEGER, "
+                                         "l_quantity DOUBLE, "
+                                         "l_extendedprice DOUBLE, "
+                                         "l_discount DOUBLE, "
+                                         "l_tax DOUBLE, "
+                                         "l_returnflag VARCHAR, "
+                                         "l_linestatus VARCHAR, "
+                                         "l_shipdate INTEGER, "
+                                         "l_commitdate INTEGER, "
+                                         "l_receiptdate INTEGER, "
+                                         "l_shipinstruct VARCHAR, "
+                                         "l_shipmode VARCHAR, "
+                                         "l_comment VARCHAR, "
+                                         "PRIMARY KEY (l_orderkey, l_linenumber))";
 
 // TPC-H enumeration domains
 static const char *const RETURNFLAGS[] = {"A", "N", "R"};
@@ -92,6 +90,10 @@ public:
 		return false;
 	}
 
+	size_t NRuns() override {
+		return 200;
+	}
+
 	void RunBenchmark(DuckDBBenchmarkState *state) override {
 		Appender appender(state->conn, "lineitem");
 		for (int32_t i = 0; i < LINEITEM_ROW_COUNT; i++) {
@@ -100,22 +102,22 @@ public:
 			const idx_t si = idx_t(i) % 4;
 			const idx_t sm = idx_t(i) % 8;
 			appender.BeginRow();
-			appender.Append<int32_t>(i / 7 + 1);                                        // l_orderkey
-			appender.Append<int32_t>(i % 200000 + 1);                                   // l_partkey
-			appender.Append<int32_t>(i % 10000 + 1);                                    // l_suppkey
-			appender.Append<int32_t>(i % 7 + 1);                                        // l_linenumber
-			appender.Append<double>(1.0 + double(i % 50));                              // l_quantity
-			appender.Append<double>(900.0 + double(i % 104949) * 0.01);                 // l_extendedprice
-			appender.Append<double>(double(i % 11) * 0.01);                             // l_discount
-			appender.Append<double>(double(i % 9) * 0.01);                              // l_tax
-			appender.Append<string_t>(string_t(RETURNFLAGS[rf], RETURNFLAG_LENS[rf]));  // l_returnflag
-			appender.Append<string_t>(string_t(LINESTATUS[ls], LINESTATUS_LENS[ls]));   // l_linestatus
-			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                    // l_shipdate
-			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                    // l_commitdate
-			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                    // l_receiptdate
+			appender.Append<int32_t>(i / 7 + 1);                                          // l_orderkey
+			appender.Append<int32_t>(i % 200000 + 1);                                     // l_partkey
+			appender.Append<int32_t>(i % 10000 + 1);                                      // l_suppkey
+			appender.Append<int32_t>(i % 7 + 1);                                          // l_linenumber
+			appender.Append<double>(1.0 + double(i % 50));                                // l_quantity
+			appender.Append<double>(900.0 + double(i % 104949) * 0.01);                   // l_extendedprice
+			appender.Append<double>(double(i % 11) * 0.01);                               // l_discount
+			appender.Append<double>(double(i % 9) * 0.01);                                // l_tax
+			appender.Append<string_t>(string_t(RETURNFLAGS[rf], RETURNFLAG_LENS[rf]));    // l_returnflag
+			appender.Append<string_t>(string_t(LINESTATUS[ls], LINESTATUS_LENS[ls]));     // l_linestatus
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                      // l_shipdate
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                      // l_commitdate
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                      // l_receiptdate
 			appender.Append<string_t>(string_t(SHIPINSTRUCT[si], SHIPINSTRUCT_LENS[si])); // l_shipinstruct
-			appender.Append<string_t>(string_t(SHIPMODE[sm], SHIPMODE_LENS[sm]));       // l_shipmode
-			appender.Append<string_t>(string_t(COMMENT_STR, COMMENT_LEN));              // l_comment
+			appender.Append<string_t>(string_t(SHIPMODE[sm], SHIPMODE_LENS[sm]));         // l_shipmode
+			appender.Append<string_t>(string_t(COMMENT_STR, COMMENT_LEN));                // l_comment
 			appender.EndRow();
 		}
 		appender.Close();
@@ -167,8 +169,8 @@ class AppenderLineitem1MPrimaryKeyBenchmark : public AppenderLineitemBenchmark {
 public:
 	static AppenderLineitem1MPrimaryKeyBenchmark *GetInstance() {
 		static AppenderLineitem1MPrimaryKeyBenchmark singleton(true);
-		auto b = duckdb::unique_ptr<AppenderLineitem1MPrimaryKeyBenchmark>(
-		    new AppenderLineitem1MPrimaryKeyBenchmark(false));
+		auto b =
+		    duckdb::unique_ptr<AppenderLineitem1MPrimaryKeyBenchmark>(new AppenderLineitem1MPrimaryKeyBenchmark(false));
 		return &singleton;
 	}
 
@@ -198,22 +200,22 @@ public:
 			const idx_t si = idx_t(i) % 4;
 			const idx_t sm = idx_t(i) % 8;
 			appender.BeginRow();
-			appender.Append<int32_t>(i / 7 + 1);                                        // l_orderkey
-			appender.Append<int32_t>(i % 200000 + 1);                                   // l_partkey
-			appender.Append<int32_t>(i % 10000 + 1);                                    // l_suppkey
-			appender.Append<int32_t>(i % 7 + 1);                                        // l_linenumber
-			appender.Append<double>(1.0 + double(i % 50));                              // l_quantity
-			appender.Append<double>(900.0 + double(i % 104949) * 0.01);                 // l_extendedprice
-			appender.Append<double>(double(i % 11) * 0.01);                             // l_discount
-			appender.Append<double>(double(i % 9) * 0.01);                              // l_tax
-			appender.Append<string_t>(string_t(RETURNFLAGS[rf], RETURNFLAG_LENS[rf]));  // l_returnflag
-			appender.Append<string_t>(string_t(LINESTATUS[ls], LINESTATUS_LENS[ls]));   // l_linestatus
-			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                    // l_shipdate
-			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                    // l_commitdate
-			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                    // l_receiptdate
+			appender.Append<int32_t>(i / 7 + 1);                                          // l_orderkey
+			appender.Append<int32_t>(i % 200000 + 1);                                     // l_partkey
+			appender.Append<int32_t>(i % 10000 + 1);                                      // l_suppkey
+			appender.Append<int32_t>(i % 7 + 1);                                          // l_linenumber
+			appender.Append<double>(1.0 + double(i % 50));                                // l_quantity
+			appender.Append<double>(900.0 + double(i % 104949) * 0.01);                   // l_extendedprice
+			appender.Append<double>(double(i % 11) * 0.01);                               // l_discount
+			appender.Append<double>(double(i % 9) * 0.01);                                // l_tax
+			appender.Append<string_t>(string_t(RETURNFLAGS[rf], RETURNFLAG_LENS[rf]));    // l_returnflag
+			appender.Append<string_t>(string_t(LINESTATUS[ls], LINESTATUS_LENS[ls]));     // l_linestatus
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                      // l_shipdate
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                      // l_commitdate
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                      // l_receiptdate
 			appender.Append<string_t>(string_t(SHIPINSTRUCT[si], SHIPINSTRUCT_LENS[si])); // l_shipinstruct
-			appender.Append<string_t>(string_t(SHIPMODE[sm], SHIPMODE_LENS[sm]));       // l_shipmode
-			appender.Append<string_t>(string_t(COMMENT_STR, COMMENT_LEN));              // l_comment
+			appender.Append<string_t>(string_t(SHIPMODE[sm], SHIPMODE_LENS[sm]));         // l_shipmode
+			appender.Append<string_t>(string_t(COMMENT_STR, COMMENT_LEN));                // l_comment
 			appender.EndRow();
 		}
 		appender.Close();
@@ -235,8 +237,7 @@ class DirectAppenderLineitem1MBenchmark : public DirectAppenderLineitemBenchmark
 public:
 	static DirectAppenderLineitem1MBenchmark *GetInstance() {
 		static DirectAppenderLineitem1MBenchmark singleton(true);
-		auto b =
-		    duckdb::unique_ptr<DirectAppenderLineitem1MBenchmark>(new DirectAppenderLineitem1MBenchmark(false));
+		auto b = duckdb::unique_ptr<DirectAppenderLineitem1MBenchmark>(new DirectAppenderLineitem1MBenchmark(false));
 		return &singleton;
 	}
 
@@ -267,3 +268,76 @@ public:
 	}
 };
 auto global_instance_DirectAppenderLineitem1MPrimaryKey = DirectAppenderLineitem1MPrimaryKeyBenchmark::GetInstance();
+
+// ---------------------------------------------------------------------------
+// DirectAppender no-WAL variant: same schema, but the attached database runs
+// with RecoveryMode::NO_WAL_WRITES so every FlushInternal commit skips the
+// WriteToWAL → LocalStorage::Flush → ColumnDataCheckpointer path entirely.
+// Use to isolate the pure row-loop + local-append cost from compression cost.
+// ---------------------------------------------------------------------------
+class DirectAppenderLineitem1MNoWALBenchmark : public DirectAppenderLineitemBenchmark {
+	DirectAppenderLineitem1MNoWALBenchmark(bool register_benchmark)
+	    : DirectAppenderLineitemBenchmark(register_benchmark, "DirectAppenderLineitem1MNoWAL") {
+	}
+
+public:
+	static DirectAppenderLineitem1MNoWALBenchmark *GetInstance() {
+		static DirectAppenderLineitem1MNoWALBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<DirectAppenderLineitem1MNoWALBenchmark>(
+		    new DirectAppenderLineitem1MNoWALBenchmark(false));
+		return &singleton;
+	}
+
+	// Use in-memory for the primary connection; real storage is the attached no-WAL db.
+	bool InMemory() override {
+		return false;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		DeleteDatabase("lineitem_nowal.db");
+		state->conn.Query("ATTACH 'lineitem_nowal.db' AS nowal (recovery_mode 'NO_WAL_WRITES')");
+		state->conn.Query(string("CREATE TABLE nowal.lineitem") +
+		                  string(CREATE_LINEITEM_NO_PK).substr(strlen("CREATE TABLE lineitem")));
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		DirectAppender appender(state->conn, "nowal", "main", "lineitem");
+		for (int32_t i = 0; i < LINEITEM_ROW_COUNT; i++) {
+			const idx_t rf = idx_t(i) % 3;
+			const idx_t ls = idx_t(i) % 2;
+			const idx_t si = idx_t(i) % 4;
+			const idx_t sm = idx_t(i) % 8;
+			appender.BeginRow();
+			appender.Append<int32_t>(i / 7 + 1);                                          // l_orderkey
+			appender.Append<int32_t>(i % 200000 + 1);                                     // l_partkey
+			appender.Append<int32_t>(i % 10000 + 1);                                      // l_suppkey
+			appender.Append<int32_t>(i % 7 + 1);                                          // l_linenumber
+			appender.Append<double>(1.0 + double(i % 50));                                // l_quantity
+			appender.Append<double>(900.0 + double(i % 104949) * 0.01);                   // l_extendedprice
+			appender.Append<double>(double(i % 11) * 0.01);                               // l_discount
+			appender.Append<double>(double(i % 9) * 0.01);                                // l_tax
+			appender.Append<string_t>(string_t(RETURNFLAGS[rf], RETURNFLAG_LENS[rf]));    // l_returnflag
+			appender.Append<string_t>(string_t(LINESTATUS[ls], LINESTATUS_LENS[ls]));     // l_linestatus
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                      // l_shipdate
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                      // l_commitdate
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);                      // l_receiptdate
+			appender.Append<string_t>(string_t(SHIPINSTRUCT[si], SHIPINSTRUCT_LENS[si])); // l_shipinstruct
+			appender.Append<string_t>(string_t(SHIPMODE[sm], SHIPMODE_LENS[sm]));         // l_shipmode
+			appender.Append<string_t>(string_t(COMMENT_STR, COMMENT_LEN));                // l_comment
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE nowal.lineitem");
+		state->conn.Query(string("CREATE TABLE nowal.lineitem") +
+		                  string(CREATE_LINEITEM_NO_PK).substr(strlen("CREATE TABLE lineitem")));
+	}
+
+	string BenchmarkInfo() override {
+		return "Ingest 1M rows using DirectAppender with WAL disabled (NO_WAL_WRITES) — "
+		       "isolates pure append cost from compression/checkpoint overhead";
+	}
+};
+auto global_instance_DirectAppenderLineitem1MNoWAL = DirectAppenderLineitem1MNoWALBenchmark::GetInstance();

--- a/benchmark/micro/compression_detection.cpp
+++ b/benchmark/micro/compression_detection.cpp
@@ -1,0 +1,483 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark.hpp"
+#include "duckdb/main/appender.hpp"
+#include "duckdb/storage/storage_info.hpp"
+
+using namespace duckdb;
+
+// Microbenchmark for ColumnDataCheckpointer::DetectBestCompressionMethod.
+//
+// Pattern: RunBenchmark times ONLY the COMMIT step, which triggers
+//   LocalStorage::Flush → OptimisticDataWriter::WriteUnflushedRowGroups
+//     → RowGroup::WriteToDisk → ColumnDataCheckpointer::DetectBestCompressionMethod
+//
+// Since detection accounts for ~98% of WriteToDisk cost, this effectively
+// benchmarks DetectBestCompressionMethod in isolation.
+//
+// Each run commits exactly one row group (DEFAULT_ROW_GROUP_SIZE = 122,880 rows).
+// Cleanup re-arms the next run: drops the table, recreates it, opens a transaction,
+// and appends one row group without committing so RunBenchmark can commit it.
+//
+// Variants:
+//   *Auto         — force_compression='auto' (all analyzers compete; default)
+//   *Uncompressed — force_compression='uncompressed' (single trivial candidate;
+//                   measures write-only baseline, no real detection work)
+//   *Cached       — force_compression='auto' but detection cache warm from run 1
+//                   (TODO: needs cache to persist across COMMIT boundaries)
+//
+// Column type suites:
+//   IntOnly    — 16 x INTEGER  (Bitpacking, RLE, Uncompressed)
+//   DoubleOnly — 16 x DOUBLE   (ALP, RLE, Uncompressed)
+//   VarcharOnly— 16 x VARCHAR  (Dictionary, FSST, Uncompressed)
+//   Mixed      — same 16-column TPC-H lineitem schema as appender_lineitem.cpp
+
+static constexpr idx_t DETECTION_ROW_COUNT = DEFAULT_ROW_GROUP_SIZE; // 122,880 rows = exactly 1 row group
+
+// ---------------------------------------------------------------------------
+// Shared string data for VARCHAR columns
+// ---------------------------------------------------------------------------
+static const char *const CD_RETURNFLAGS[] = {"A", "N", "R"};
+static const uint32_t CD_RETURNFLAG_LENS[] = {1, 1, 1};
+static const char *const CD_SHIPMODE[] = {"AIR", "FOB", "MAIL", "RAIL", "SHIP", "TRUCK", "REG AIR", "AIR REG"};
+static const uint32_t CD_SHIPMODE_LENS[] = {3, 3, 4, 4, 4, 5, 7, 7};
+static const char CD_COMMENT[] = "regular annual package";
+static constexpr uint32_t CD_COMMENT_LEN = 22;
+
+// ---------------------------------------------------------------------------
+// Base class: manages the COMMIT-only RunBenchmark + table reset in Cleanup
+// ---------------------------------------------------------------------------
+class CompressionDetectBenchmark : public DuckDBBenchmark {
+protected:
+	CompressionDetectBenchmark(bool register_benchmark, const string &name)
+	    : DuckDBBenchmark(register_benchmark, name, "[compression_detect]") {
+	}
+
+	// Subclasses fill the table schema.
+	virtual string CreateTableSQL() = 0;
+	// Subclasses append exactly DETECTION_ROW_COUNT rows via DirectAppender.
+	virtual void AppendRows(DuckDBBenchmarkState *state) = 0;
+	// Subclasses may set force_compression before the table is created.
+	virtual string ForceCompressionSQL() {
+		return "";
+	}
+
+public:
+	bool InMemory() override {
+		return false;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		auto force = ForceCompressionSQL();
+		if (!force.empty()) {
+			state->conn.Query(force);
+		}
+		state->conn.Query(CreateTableSQL());
+		// Open a transaction and append one row group without committing.
+		// RunBenchmark will commit it, triggering DetectBestCompressionMethod.
+		state->conn.Query("BEGIN TRANSACTION");
+		AppendRows(state);
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		// This COMMIT is the hot path: it triggers LocalStorage::Flush
+		// → ColumnDataCheckpointer::DetectBestCompressionMethod for every column.
+		state->conn.Query("COMMIT");
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE detect_bench");
+		state->conn.Query(CreateTableSQL());
+		// Re-arm: begin a new transaction and append one row group so the
+		// next RunBenchmark call has something to commit.
+		state->conn.Query("BEGIN TRANSACTION");
+		AppendRows(state);
+	}
+
+	string VerifyResult(QueryResult *result) override {
+		return string();
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Integer-only suite (16 x INTEGER) — exercises Bitpacking, RLE, Uncompressed
+// ---------------------------------------------------------------------------
+#define INT_ONLY_SCHEMA                                                                                                \
+	"CREATE TABLE detect_bench("                                                                                       \
+	"c0 INTEGER, c1 INTEGER, c2 INTEGER, c3 INTEGER, c4 INTEGER, c5 INTEGER, c6 INTEGER, c7 INTEGER,"                  \
+	"c8 INTEGER, c9 INTEGER, c10 INTEGER, c11 INTEGER, c12 INTEGER, c13 INTEGER, c14 INTEGER, c15 INTEGER)"
+
+class CompressionDetectIntOnlyBase : public CompressionDetectBenchmark {
+protected:
+	CompressionDetectIntOnlyBase(bool register_benchmark, const string &name)
+	    : CompressionDetectBenchmark(register_benchmark, name) {
+	}
+
+	string CreateTableSQL() override {
+		return INT_ONLY_SCHEMA;
+	}
+
+	void AppendRows(DuckDBBenchmarkState *state) override {
+		DirectAppender appender(state->conn, "detect_bench");
+		for (idx_t i = 0; i < DETECTION_ROW_COUNT; i++) {
+			appender.BeginRow();
+			for (int col = 0; col < 16; col++) {
+				appender.Append<int32_t>(NumericCast<int32_t>(i % 10000 + col));
+			}
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	string BenchmarkInfo() override {
+		return "Compression detection for 1 row group of 16 x INTEGER columns";
+	}
+};
+
+class CompressionDetectIntOnlyAuto : public CompressionDetectIntOnlyBase {
+	CompressionDetectIntOnlyAuto(bool register_benchmark)
+	    : CompressionDetectIntOnlyBase(register_benchmark, "CompressionDetectIntOnlyAuto") {
+	}
+
+public:
+	static CompressionDetectIntOnlyAuto *GetInstance() {
+		static CompressionDetectIntOnlyAuto singleton(true);
+		auto b = duckdb::unique_ptr<CompressionDetectIntOnlyAuto>(new CompressionDetectIntOnlyAuto(false));
+		return &singleton;
+	}
+};
+auto global_instance_CompressionDetectIntOnlyAuto = CompressionDetectIntOnlyAuto::GetInstance();
+
+class CompressionDetectIntOnlyUncompressed : public CompressionDetectIntOnlyBase {
+	CompressionDetectIntOnlyUncompressed(bool register_benchmark)
+	    : CompressionDetectIntOnlyBase(register_benchmark, "CompressionDetectIntOnlyUncompressed") {
+	}
+
+public:
+	static CompressionDetectIntOnlyUncompressed *GetInstance() {
+		static CompressionDetectIntOnlyUncompressed singleton(true);
+		auto b =
+		    duckdb::unique_ptr<CompressionDetectIntOnlyUncompressed>(new CompressionDetectIntOnlyUncompressed(false));
+		return &singleton;
+	}
+
+	string ForceCompressionSQL() override {
+		return "SET force_compression='uncompressed'";
+	}
+
+	string BenchmarkInfo() override {
+		return "Compression write (no detection) for 1 row group of 16 x INTEGER — forced uncompressed baseline";
+	}
+};
+auto global_instance_CompressionDetectIntOnlyUncompressed = CompressionDetectIntOnlyUncompressed::GetInstance();
+
+// ---------------------------------------------------------------------------
+// Double-only suite (16 x DOUBLE) — exercises ALP, RLE, Uncompressed
+// ---------------------------------------------------------------------------
+#define DOUBLE_ONLY_SCHEMA                                                                                             \
+	"CREATE TABLE detect_bench("                                                                                       \
+	"c0 DOUBLE, c1 DOUBLE, c2 DOUBLE, c3 DOUBLE, c4 DOUBLE, c5 DOUBLE, c6 DOUBLE, c7 DOUBLE,"                         \
+	"c8 DOUBLE, c9 DOUBLE, c10 DOUBLE, c11 DOUBLE, c12 DOUBLE, c13 DOUBLE, c14 DOUBLE, c15 DOUBLE)"
+
+class CompressionDetectDoubleOnlyBase : public CompressionDetectBenchmark {
+protected:
+	CompressionDetectDoubleOnlyBase(bool register_benchmark, const string &name)
+	    : CompressionDetectBenchmark(register_benchmark, name) {
+	}
+
+	string CreateTableSQL() override {
+		return DOUBLE_ONLY_SCHEMA;
+	}
+
+	void AppendRows(DuckDBBenchmarkState *state) override {
+		DirectAppender appender(state->conn, "detect_bench");
+		for (idx_t i = 0; i < DETECTION_ROW_COUNT; i++) {
+			appender.BeginRow();
+			for (int col = 0; col < 16; col++) {
+				appender.Append<double>(1.0 + double(i % 50) + col * 0.01);
+			}
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	string BenchmarkInfo() override {
+		return "Compression detection for 1 row group of 16 x DOUBLE columns";
+	}
+};
+
+class CompressionDetectDoubleOnlyAuto : public CompressionDetectDoubleOnlyBase {
+	CompressionDetectDoubleOnlyAuto(bool register_benchmark)
+	    : CompressionDetectDoubleOnlyBase(register_benchmark, "CompressionDetectDoubleOnlyAuto") {
+	}
+
+public:
+	static CompressionDetectDoubleOnlyAuto *GetInstance() {
+		static CompressionDetectDoubleOnlyAuto singleton(true);
+		auto b =
+		    duckdb::unique_ptr<CompressionDetectDoubleOnlyAuto>(new CompressionDetectDoubleOnlyAuto(false));
+		return &singleton;
+	}
+};
+auto global_instance_CompressionDetectDoubleOnlyAuto = CompressionDetectDoubleOnlyAuto::GetInstance();
+
+class CompressionDetectDoubleOnlyUncompressed : public CompressionDetectDoubleOnlyBase {
+	CompressionDetectDoubleOnlyUncompressed(bool register_benchmark)
+	    : CompressionDetectDoubleOnlyBase(register_benchmark, "CompressionDetectDoubleOnlyUncompressed") {
+	}
+
+public:
+	static CompressionDetectDoubleOnlyUncompressed *GetInstance() {
+		static CompressionDetectDoubleOnlyUncompressed singleton(true);
+		auto b = duckdb::unique_ptr<CompressionDetectDoubleOnlyUncompressed>(
+		    new CompressionDetectDoubleOnlyUncompressed(false));
+		return &singleton;
+	}
+
+	string ForceCompressionSQL() override {
+		return "SET force_compression='uncompressed'";
+	}
+
+	string BenchmarkInfo() override {
+		return "Compression write (no detection) for 1 row group of 16 x DOUBLE — forced uncompressed baseline";
+	}
+};
+auto global_instance_CompressionDetectDoubleOnlyUncompressed = CompressionDetectDoubleOnlyUncompressed::GetInstance();
+
+// ---------------------------------------------------------------------------
+// VARCHAR-only suite (16 x VARCHAR) — exercises Dictionary, FSST, Uncompressed
+// ---------------------------------------------------------------------------
+#define VARCHAR_ONLY_SCHEMA                                                                                            \
+	"CREATE TABLE detect_bench("                                                                                       \
+	"c0 VARCHAR, c1 VARCHAR, c2 VARCHAR, c3 VARCHAR, c4 VARCHAR, c5 VARCHAR, c6 VARCHAR, c7 VARCHAR,"                   \
+	"c8 VARCHAR, c9 VARCHAR, c10 VARCHAR, c11 VARCHAR, c12 VARCHAR, c13 VARCHAR, c14 VARCHAR, c15 VARCHAR)"
+
+class CompressionDetectVarcharOnlyBase : public CompressionDetectBenchmark {
+protected:
+	CompressionDetectVarcharOnlyBase(bool register_benchmark, const string &name)
+	    : CompressionDetectBenchmark(register_benchmark, name) {
+	}
+
+	string CreateTableSQL() override {
+		return VARCHAR_ONLY_SCHEMA;
+	}
+
+	void AppendRows(DuckDBBenchmarkState *state) override {
+		DirectAppender appender(state->conn, "detect_bench");
+		for (idx_t i = 0; i < DETECTION_ROW_COUNT; i++) {
+			const idx_t rf = i % 3;
+			const idx_t sm = i % 8;
+			appender.BeginRow();
+			// Mix of low-cardinality short strings (like returnflag) and longer strings
+			for (int col = 0; col < 8; col++) {
+				appender.Append<string_t>(string_t(CD_RETURNFLAGS[rf], CD_RETURNFLAG_LENS[rf]));
+			}
+			for (int col = 0; col < 7; col++) {
+				appender.Append<string_t>(string_t(CD_SHIPMODE[sm], CD_SHIPMODE_LENS[sm]));
+			}
+			appender.Append<string_t>(string_t(CD_COMMENT, CD_COMMENT_LEN));
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	string BenchmarkInfo() override {
+		return "Compression detection for 1 row group of 16 x VARCHAR columns";
+	}
+};
+
+class CompressionDetectVarcharOnlyAuto : public CompressionDetectVarcharOnlyBase {
+	CompressionDetectVarcharOnlyAuto(bool register_benchmark)
+	    : CompressionDetectVarcharOnlyBase(register_benchmark, "CompressionDetectVarcharOnlyAuto") {
+	}
+
+public:
+	static CompressionDetectVarcharOnlyAuto *GetInstance() {
+		static CompressionDetectVarcharOnlyAuto singleton(true);
+		auto b =
+		    duckdb::unique_ptr<CompressionDetectVarcharOnlyAuto>(new CompressionDetectVarcharOnlyAuto(false));
+		return &singleton;
+	}
+};
+auto global_instance_CompressionDetectVarcharOnlyAuto = CompressionDetectVarcharOnlyAuto::GetInstance();
+
+class CompressionDetectVarcharOnlyUncompressed : public CompressionDetectVarcharOnlyBase {
+	CompressionDetectVarcharOnlyUncompressed(bool register_benchmark)
+	    : CompressionDetectVarcharOnlyBase(register_benchmark, "CompressionDetectVarcharOnlyUncompressed") {
+	}
+
+public:
+	static CompressionDetectVarcharOnlyUncompressed *GetInstance() {
+		static CompressionDetectVarcharOnlyUncompressed singleton(true);
+		auto b = duckdb::unique_ptr<CompressionDetectVarcharOnlyUncompressed>(
+		    new CompressionDetectVarcharOnlyUncompressed(false));
+		return &singleton;
+	}
+
+	string ForceCompressionSQL() override {
+		return "SET force_compression='uncompressed'";
+	}
+
+	string BenchmarkInfo() override {
+		return "Compression write (no detection) for 1 row group of 16 x VARCHAR — forced uncompressed baseline";
+	}
+};
+auto global_instance_CompressionDetectVarcharOnlyUncompressed =
+    CompressionDetectVarcharOnlyUncompressed::GetInstance();
+
+// ---------------------------------------------------------------------------
+// Mixed suite — 16-column TPC-H lineitem schema (same as appender_lineitem.cpp)
+// ---------------------------------------------------------------------------
+#define LINEITEM_DETECT_SCHEMA                                                                                         \
+	"CREATE TABLE detect_bench("                                                                                       \
+	"l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"                                   \
+	"l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"                                      \
+	"l_returnflag VARCHAR, l_linestatus VARCHAR,"                                                                       \
+	"l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"                                                  \
+	"l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR)"
+
+static const char *const CD_LINESTATUS[] = {"O", "F"};
+static const uint32_t CD_LINESTATUS_LENS[] = {1, 1};
+static const char *const CD_SHIPINSTRUCT[] = {"DELIVER IN PERSON", "COLLECT COD", "NONE", "TAKE BACK RETURN"};
+static const uint32_t CD_SHIPINSTRUCT_LENS[] = {17, 11, 4, 16};
+static constexpr int32_t CD_BASE_DATE = 8827;
+
+class CompressionDetectLineitemBase : public CompressionDetectBenchmark {
+protected:
+	CompressionDetectLineitemBase(bool register_benchmark, const string &name)
+	    : CompressionDetectBenchmark(register_benchmark, name) {
+	}
+
+	string CreateTableSQL() override {
+		return LINEITEM_DETECT_SCHEMA;
+	}
+
+	void AppendRows(DuckDBBenchmarkState *state) override {
+		DirectAppender appender(state->conn, "detect_bench");
+		for (idx_t i = 0; i < DETECTION_ROW_COUNT; i++) {
+			const idx_t rf = i % 3;
+			const idx_t ls = i % 2;
+			const idx_t si = i % 4;
+			const idx_t sm = i % 8;
+			appender.BeginRow();
+			appender.Append<int32_t>(NumericCast<int32_t>(i / 7 + 1));
+			appender.Append<int32_t>(NumericCast<int32_t>(i % 200000 + 1));
+			appender.Append<int32_t>(NumericCast<int32_t>(i % 10000 + 1));
+			appender.Append<int32_t>(NumericCast<int32_t>(i % 7 + 1));
+			appender.Append<double>(1.0 + double(i % 50));
+			appender.Append<double>(900.0 + double(i % 104949) * 0.01);
+			appender.Append<double>(double(i % 11) * 0.01);
+			appender.Append<double>(double(i % 9) * 0.01);
+			appender.Append<string_t>(string_t(CD_RETURNFLAGS[rf], CD_RETURNFLAG_LENS[rf]));
+			appender.Append<string_t>(string_t(CD_LINESTATUS[ls], CD_LINESTATUS_LENS[ls]));
+			appender.Append<int32_t>(CD_BASE_DATE + NumericCast<int32_t>(i % 2557));
+			appender.Append<int32_t>(CD_BASE_DATE + NumericCast<int32_t>(i % 2557));
+			appender.Append<int32_t>(CD_BASE_DATE + NumericCast<int32_t>(i % 2557));
+			appender.Append<string_t>(string_t(CD_SHIPINSTRUCT[si], CD_SHIPINSTRUCT_LENS[si]));
+			appender.Append<string_t>(string_t(CD_SHIPMODE[sm], CD_SHIPMODE_LENS[sm]));
+			appender.Append<string_t>(string_t(CD_COMMENT, CD_COMMENT_LEN));
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	string BenchmarkInfo() override {
+		return "Compression detection for 1 row group of TPC-H lineitem (16 mixed columns)";
+	}
+};
+
+class CompressionDetectLineitemAuto : public CompressionDetectLineitemBase {
+	CompressionDetectLineitemAuto(bool register_benchmark)
+	    : CompressionDetectLineitemBase(register_benchmark, "CompressionDetectLineitemAuto") {
+	}
+
+public:
+	static CompressionDetectLineitemAuto *GetInstance() {
+		static CompressionDetectLineitemAuto singleton(true);
+		auto b = duckdb::unique_ptr<CompressionDetectLineitemAuto>(new CompressionDetectLineitemAuto(false));
+		return &singleton;
+	}
+};
+auto global_instance_CompressionDetectLineitemAuto = CompressionDetectLineitemAuto::GetInstance();
+
+class CompressionDetectLineitemUncompressed : public CompressionDetectLineitemBase {
+	CompressionDetectLineitemUncompressed(bool register_benchmark)
+	    : CompressionDetectLineitemBase(register_benchmark, "CompressionDetectLineitemUncompressed") {
+	}
+
+public:
+	static CompressionDetectLineitemUncompressed *GetInstance() {
+		static CompressionDetectLineitemUncompressed singleton(true);
+		auto b = duckdb::unique_ptr<CompressionDetectLineitemUncompressed>(
+		    new CompressionDetectLineitemUncompressed(false));
+		return &singleton;
+	}
+
+	string ForceCompressionSQL() override {
+		return "SET force_compression='uncompressed'";
+	}
+
+	string BenchmarkInfo() override {
+		return "Compression write (no detection) for 1 row group of TPC-H lineitem — forced uncompressed baseline";
+	}
+};
+auto global_instance_CompressionDetectLineitemUncompressed = CompressionDetectLineitemUncompressed::GetInstance();
+
+// ---------------------------------------------------------------------------
+// Sample-rate variants for CompressionDetectLineitemAuto — tuning the new
+// compression_analyze_sample_size setting.
+// These show the speed/quality trade-off of analyzing fewer vectors.
+// ---------------------------------------------------------------------------
+class CompressionDetectLineitemAutoSampleBase : public CompressionDetectLineitemBase {
+	string sample_sql;
+
+protected:
+	CompressionDetectLineitemAutoSampleBase(bool register_benchmark, const string &name, const string &sql)
+	    : CompressionDetectLineitemBase(register_benchmark, name), sample_sql(sql) {
+	}
+
+	string ForceCompressionSQL() override {
+		return sample_sql;
+	}
+};
+
+// 50% sample: analyze every other vector (stride=2)
+class CompressionDetectLineitemAutoSample50 : public CompressionDetectLineitemAutoSampleBase {
+	CompressionDetectLineitemAutoSample50(bool register_benchmark)
+	    : CompressionDetectLineitemAutoSampleBase(register_benchmark, "CompressionDetectLineitemAutoSample50",
+	                                              "SET compression_analyze_sample_size=0.5") {
+	}
+
+public:
+	static CompressionDetectLineitemAutoSample50 *GetInstance() {
+		static CompressionDetectLineitemAutoSample50 singleton(true);
+		auto b = duckdb::unique_ptr<CompressionDetectLineitemAutoSample50>(
+		    new CompressionDetectLineitemAutoSample50(false));
+		return &singleton;
+	}
+
+	string BenchmarkInfo() override {
+		return "Detection for 1 row group of TPC-H lineitem, 50% vector sample (stride=2)";
+	}
+};
+auto global_instance_CompressionDetectLineitemAutoSample50 = CompressionDetectLineitemAutoSample50::GetInstance();
+
+// 25% sample: analyze every 4th vector (stride=4) — matches FSST's string sample rate
+class CompressionDetectLineitemAutoSample25 : public CompressionDetectLineitemAutoSampleBase {
+	CompressionDetectLineitemAutoSample25(bool register_benchmark)
+	    : CompressionDetectLineitemAutoSampleBase(register_benchmark, "CompressionDetectLineitemAutoSample25",
+	                                              "SET compression_analyze_sample_size=0.25") {
+	}
+
+public:
+	static CompressionDetectLineitemAutoSample25 *GetInstance() {
+		static CompressionDetectLineitemAutoSample25 singleton(true);
+		auto b = duckdb::unique_ptr<CompressionDetectLineitemAutoSample25>(
+		    new CompressionDetectLineitemAutoSample25(false));
+		return &singleton;
+	}
+
+	string BenchmarkInfo() override {
+		return "Detection for 1 row group of TPC-H lineitem, 25% vector sample (stride=4)";
+	}
+};
+auto global_instance_CompressionDetectLineitemAutoSample25 = CompressionDetectLineitemAutoSample25::GetInstance();

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -239,6 +239,13 @@
         ]
     },
     {
+        "name": "compression_analyze_sample_size",
+        "description": "Fraction of vectors sampled during compression analysis (0.0-1.0). Lower values reduce CPU overhead from DetectBestCompressionMethod at the cost of potentially selecting a suboptimal compression method. Defaults to 1.0 (analyze all data).",
+        "type": "DOUBLE",
+        "scope": "global",
+        "default_value": "1.0"
+    },
+    {
         "name": "configure_profiling",
         "description": "Accepts a JSON enabling custom metrics",
         "type": "VARCHAR",

--- a/src/include/duckdb/main/appender.hpp
+++ b/src/include/duckdb/main/appender.hpp
@@ -201,6 +201,26 @@ protected:
 	void FlushInternal(ColumnDataCollection &collection) override;
 };
 
+class DirectAppender : public BaseAppender {
+public:
+	DUCKDB_API DirectAppender(Connection &con, const Identifier &database_name, const Identifier &schema_name,
+	                          const Identifier &table_name,
+	                          const idx_t flush_memory_threshold = DConstants::INVALID_INDEX);
+	DUCKDB_API DirectAppender(Connection &con, const Identifier &schema_name, const Identifier &table_name,
+	                          const idx_t flush_memory_threshold = DConstants::INVALID_INDEX);
+	DUCKDB_API DirectAppender(Connection &con, const Identifier &table_name,
+	                          const idx_t flush_memory_threshold = DConstants::INVALID_INDEX);
+	DUCKDB_API ~DirectAppender() override;
+
+protected:
+	void FlushInternal(ColumnDataCollection &collection) override;
+
+private:
+	weak_ptr<ClientContext> context;
+	unique_ptr<TableDescription> description;
+	vector<LogicalIndex> column_ids; // empty = all columns
+};
+
 class InternalAppender : public BaseAppender {
 	//! The client context
 	ClientContext &context;

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -106,1961 +106,1862 @@ static constexpr idx_t SETTING_INDEX_BASE = __COUNTER__ + 1;
 //===----------------------------------------------------------------------===//
 
 struct DeltaOnlyVariantEncodingEnabledSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "__delta_only_variant_encoding_enabled";
-	static constexpr const char *Description = "Enables the Parquet reader to identify a Variant structurally.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "__delta_only_variant_encoding_enabled";
+    static constexpr const char *Description = "Enables the Parquet reader to identify a Variant structurally.";
+    static constexpr const char *InputType = "BOOLEAN";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct AccessModeSetting {
-	using RETURN_TYPE = AccessMode;
-	static constexpr const char *Name = "access_mode";
-	static constexpr const char *Description = "Access mode of the database (AUTOMATIC, READ_ONLY or READ_WRITE)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = AccessMode;
+    static constexpr const char *Name = "access_mode";
+    static constexpr const char *Description = "Access mode of the database (AUTOMATIC, READ_ONLY or READ_WRITE)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct AllocatorBackgroundThreadsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "allocator_background_threads";
-	static constexpr const char *Description = "Whether to enable the allocator background thread.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "allocator_background_threads";
+    static constexpr const char *Description = "Whether to enable the allocator background thread.";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct AllocatorBulkDeallocationFlushThresholdSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "allocator_bulk_deallocation_flush_threshold";
-	static constexpr const char *Description =
-	    "If a bulk deallocation larger than this occurs, flush outstanding allocations.";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "allocator_bulk_deallocation_flush_threshold";
+    static constexpr const char *Description = "If a bulk deallocation larger than this occurs, flush outstanding allocations.";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct AllocatorFlushThresholdSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "allocator_flush_threshold";
-	static constexpr const char *Description =
-	    "Peak allocation threshold at which to flush the allocator after completing a task.";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "134217728B";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "allocator_flush_threshold";
+    static constexpr const char *Description = "Peak allocation threshold at which to flush the allocator after completing a task.";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "134217728B";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct AllowCommunityExtensionsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "allow_community_extensions";
-	static constexpr const char *Description = "Allow to load community built extensions";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "true";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "allow_community_extensions";
+    static constexpr const char *Description = "Allow to load community built extensions";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "true";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct AllowExtensionsMetadataMismatchSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "allow_extensions_metadata_mismatch";
-	static constexpr const char *Description = "Allow to load extensions with not compatible metadata";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "allow_extensions_metadata_mismatch";
+    static constexpr const char *Description = "Allow to load extensions with not compatible metadata";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct AllowParserOverrideExtensionSetting {
-	using RETURN_TYPE = AllowParserOverride;
-	static constexpr const char *Name = "allow_parser_override_extension";
-	static constexpr const char *Description = "Allow extensions to override the current parser";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "DEFAULT";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = AllowParserOverride;
+    static constexpr const char *Name = "allow_parser_override_extension";
+    static constexpr const char *Description = "Allow extensions to override the current parser";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "DEFAULT";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct AllowPersistentSecretsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "allow_persistent_secrets";
-	static constexpr const char *Description =
-	    "Allow the creation of persistent secrets, that are stored and loaded on restarts";
-	static constexpr const char *InputType = "BOOLEAN";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "allow_persistent_secrets";
+    static constexpr const char *Description = "Allow the creation of persistent secrets, that are stored and loaded on restarts";
+    static constexpr const char *InputType = "BOOLEAN";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct AllowUnredactedSecretsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "allow_unredacted_secrets";
-	static constexpr const char *Description = "Allow printing unredacted secrets";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "allow_unredacted_secrets";
+    static constexpr const char *Description = "Allow printing unredacted secrets";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct AllowUnsignedExtensionsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "allow_unsigned_extensions";
-	static constexpr const char *Description = "Allow to load extensions with invalid or missing signatures";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "allow_unsigned_extensions";
+    static constexpr const char *Description = "Allow to load extensions with invalid or missing signatures";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct AllowedConfigsSetting {
-	using RETURN_TYPE = vector<string>;
-	static constexpr const char *Name = "allowed_configs";
-	static constexpr const char *Description =
-	    "List of configuration options that are ALWAYS allowed to be changed - even when lock_configuration is true";
-	static constexpr const char *InputType = "VARCHAR[]";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = vector<string>;
+    static constexpr const char *Name = "allowed_configs";
+    static constexpr const char *Description = "List of configuration options that are ALWAYS allowed to be changed - even when lock_configuration is true";
+    static constexpr const char *InputType = "VARCHAR[]";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct AllowedDirectoriesSetting {
-	using RETURN_TYPE = vector<string>;
-	static constexpr const char *Name = "allowed_directories";
-	static constexpr const char *Description = "List of directories/prefixes that are ALWAYS allowed to be queried - "
-	                                           "even when enable_external_access is false";
-	static constexpr const char *InputType = "VARCHAR[]";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = vector<string>;
+    static constexpr const char *Name = "allowed_directories";
+    static constexpr const char *Description = "List of directories/prefixes that are ALWAYS allowed to be queried - even when enable_external_access is false";
+    static constexpr const char *InputType = "VARCHAR[]";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct AllowedPathsSetting {
-	using RETURN_TYPE = vector<string>;
-	static constexpr const char *Name = "allowed_paths";
-	static constexpr const char *Description =
-	    "List of files that are ALWAYS allowed to be queried - even when enable_external_access is false";
-	static constexpr const char *InputType = "VARCHAR[]";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = vector<string>;
+    static constexpr const char *Name = "allowed_paths";
+    static constexpr const char *Description = "List of files that are ALWAYS allowed to be queried - even when enable_external_access is false";
+    static constexpr const char *InputType = "VARCHAR[]";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct ArrowLargeBufferSizeSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "arrow_large_buffer_size";
-	static constexpr const char *Description =
-	    "Whether Arrow buffers for strings, blobs, uuids and bits should be exported using large buffers";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "arrow_large_buffer_size";
+    static constexpr const char *Description = "Whether Arrow buffers for strings, blobs, uuids and bits should be exported using large buffers";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ArrowLosslessConversionSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "arrow_lossless_conversion";
-	static constexpr const char *Description =
-	    "Whenever a DuckDB type does not have a clear native or canonical extension match in Arrow, export the types "
-	    "with a duckdb.type_name extension name.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "arrow_lossless_conversion";
+    static constexpr const char *Description = "Whenever a DuckDB type does not have a clear native or canonical extension match in Arrow, export the types with a duckdb.type_name extension name.";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ArrowOutputListViewSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "arrow_output_list_view";
-	static constexpr const char *Description =
-	    "Whether export to Arrow format should use ListView as the physical layout for LIST columns";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "arrow_output_list_view";
+    static constexpr const char *Description = "Whether export to Arrow format should use ListView as the physical layout for LIST columns";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ArrowOutputVersionSetting {
-	using RETURN_TYPE = ArrowFormatVersion;
-	static constexpr const char *Name = "arrow_output_version";
-	static constexpr const char *Description =
-	    "Whether strings should be produced by DuckDB in Utf8View format instead of Utf8";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "1.0";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = ArrowFormatVersion;
+    static constexpr const char *Name = "arrow_output_version";
+    static constexpr const char *Description = "Whether strings should be produced by DuckDB in Utf8View format instead of Utf8";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "1.0";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct AsofLoopJoinThresholdSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "asof_loop_join_threshold";
-	static constexpr const char *Description =
-	    "The maximum number of rows we need on the left side of an ASOF join to use a nested loop join";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "64";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "asof_loop_join_threshold";
+    static constexpr const char *Description = "The maximum number of rows we need on the left side of an ASOF join to use a nested loop join";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "64";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct AsyncThreadsSetting {
-	using RETURN_TYPE = int64_t;
-	static constexpr const char *Name = "async_threads";
-	static constexpr const char *Description =
-	    "The number of total async threads used by the system for tasks like I/O.";
-	static constexpr const char *InputType = "BIGINT";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = int64_t;
+    static constexpr const char *Name = "async_threads";
+    static constexpr const char *Description = "The number of total async threads used by the system for tasks like I/O.";
+    static constexpr const char *InputType = "BIGINT";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct AutoCheckpointSkipWalThresholdSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "auto_checkpoint_skip_wal_threshold";
-	static constexpr const char *Description =
-	    "The estimated WAL write size at which point we will skip writing to the WAL and only checkpoint. Skipping "
-	    "writing to the WAL means concurrent commits are blocked while the checkpoint is happening.";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "100000";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "auto_checkpoint_skip_wal_threshold";
+    static constexpr const char *Description = "The estimated WAL write size at which point we will skip writing to the WAL and only checkpoint. Skipping writing to the WAL means concurrent commits are blocked while the checkpoint is happening.";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "100000";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct AutoinstallExtensionRepositorySetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "autoinstall_extension_repository";
-	static constexpr const char *Description =
-	    "Overrides the custom endpoint for extension installation on autoloading";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "autoinstall_extension_repository";
+    static constexpr const char *Description = "Overrides the custom endpoint for extension installation on autoloading";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct AutoinstallKnownExtensionsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "autoinstall_known_extensions";
-	static constexpr const char *Description =
-	    "Whether known extensions are allowed to be automatically installed when a query depends on them";
-	static constexpr const char *InputType = "BOOLEAN";
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "autoinstall_known_extensions";
+    static constexpr const char *Description = "Whether known extensions are allowed to be automatically installed when a query depends on them";
+    static constexpr const char *InputType = "BOOLEAN";
 #if defined(DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT) && DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT
-	static constexpr const char *DefaultValue = "true";
+    static constexpr const char *DefaultValue = "true";
 #else
-	static constexpr const char *DefaultValue = "false";
+    static constexpr const char *DefaultValue = "false";
 #endif
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct AutoloadKnownExtensionsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "autoload_known_extensions";
-	static constexpr const char *Description =
-	    "Whether known extensions are allowed to be automatically loaded when a query depends on them";
-	static constexpr const char *InputType = "BOOLEAN";
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "autoload_known_extensions";
+    static constexpr const char *Description = "Whether known extensions are allowed to be automatically loaded when a query depends on them";
+    static constexpr const char *InputType = "BOOLEAN";
 #if defined(DUCKDB_EXTENSION_AUTOLOAD_DEFAULT) && DUCKDB_EXTENSION_AUTOLOAD_DEFAULT
-	static constexpr const char *DefaultValue = "true";
+    static constexpr const char *DefaultValue = "true";
 #else
-	static constexpr const char *DefaultValue = "false";
+    static constexpr const char *DefaultValue = "false";
 #endif
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct BlockAllocatorMemorySetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "block_allocator_memory";
-	static constexpr const char *Description = "Physical memory that the block allocator is allowed to use (this "
-	                                           "memory is never freed and cannot be reduced).";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "block_allocator_memory";
+    static constexpr const char *Description = "Physical memory that the block allocator is allowed to use (this memory is never freed and cannot be reduced).";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct CacheLocalFilesSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "cache_local_files";
-	static constexpr const char *Description =
-	    "Whether the external file cache also caches local files (remote files are always cached)";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "cache_local_files";
+    static constexpr const char *Description = "Whether the external file cache also caches local files (remote files are always cached)";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct CatalogErrorMaxSchemasSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "catalog_error_max_schemas";
-	static constexpr const char *Description =
-	    "The maximum number of schemas the system will scan for \"did you mean...\" style errors in the catalog";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "100";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "catalog_error_max_schemas";
+    static constexpr const char *Description = "The maximum number of schemas the system will scan for \"did you mean...\" style errors in the catalog";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "100";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct CheckpointOnDetachSetting {
-	using RETURN_TYPE = CheckpointOnDetach;
-	static constexpr const char *Name = "checkpoint_on_detach";
-	static constexpr const char *Description =
-	    "Override checkpoint behavior when detaching a database. ENABLED always checkpoints, DISABLED never "
-	    "checkpoints, DEFAULT defers to the global checkpoint_on_shutdown setting.";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "DEFAULT";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = CheckpointOnDetach;
+    static constexpr const char *Name = "checkpoint_on_detach";
+    static constexpr const char *Description = "Override checkpoint behavior when detaching a database. ENABLED always checkpoints, DISABLED never checkpoints, DEFAULT defers to the global checkpoint_on_shutdown setting.";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "DEFAULT";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct CheckpointThresholdSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "checkpoint_threshold";
-	static constexpr const char *Description =
-	    "The WAL size threshold at which to automatically trigger a checkpoint (e.g. 1GB)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "checkpoint_threshold";
+    static constexpr const char *Description = "The WAL size threshold at which to automatically trigger a checkpoint (e.g. 1GB)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
+};
+
+struct CompressionAnalyzeSampleSizeSetting {
+    using RETURN_TYPE = double;
+    static constexpr const char *Name = "compression_analyze_sample_size";
+    static constexpr const char *Description = "Fraction of vectors sampled during compression analysis (0.0-1.0). Lower values reduce CPU overhead from DetectBestCompressionMethod at the cost of potentially selecting a suboptimal compression method. Defaults to 1.0 (analyze all data).";
+    static constexpr const char *InputType = "DOUBLE";
+    static constexpr const char *DefaultValue = "1.0";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ConfigureProfilingSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "configure_profiling";
-	static constexpr const char *Description = "Accepts a JSON enabling custom metrics";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "configure_profiling";
+    static constexpr const char *Description = "Accepts a JSON enabling custom metrics";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct CurrentTransactionInvalidationPolicySetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "current_transaction_invalidation_policy";
-	static constexpr const char *Description =
-	    "Which types of exceptions invalidate the database for the current transaction";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "STANDARD_POLICY";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "current_transaction_invalidation_policy";
+    static constexpr const char *Description = "Which types of exceptions invalidate the database for the current transaction";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "STANDARD_POLICY";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct CustomExtensionRepositorySetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "custom_extension_repository";
-	static constexpr const char *Description = "Overrides the custom endpoint for remote extension installation";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "custom_extension_repository";
+    static constexpr const char *Description = "Overrides the custom endpoint for remote extension installation";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct CustomUserAgentSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "custom_user_agent";
-	static constexpr const char *Description = "Metadata from DuckDB callers";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "custom_user_agent";
+    static constexpr const char *Description = "Metadata from DuckDB callers";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct DebugAsofIejoinSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_asof_iejoin";
-	static constexpr const char *Description = "DEBUG SETTING: force use of IEJoin to implement AsOf joins";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_asof_iejoin";
+    static constexpr const char *Description = "DEBUG SETTING: force use of IEJoin to implement AsOf joins";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugCheckpointAbortSetting {
-	using RETURN_TYPE = CheckpointAbort;
-	static constexpr const char *Name = "debug_checkpoint_abort";
-	static constexpr const char *Description =
-	    "DEBUG SETTING: trigger an abort while checkpointing for testing purposes";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "NONE";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = CheckpointAbort;
+    static constexpr const char *Name = "debug_checkpoint_abort";
+    static constexpr const char *Description = "DEBUG SETTING: trigger an abort while checkpointing for testing purposes";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "NONE";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DebugCheckpointSleepMsSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "debug_checkpoint_sleep_ms";
-	static constexpr const char *Description = "DEBUG SETTING: time to sleep before a checkpoint";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "0";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "debug_checkpoint_sleep_ms";
+    static constexpr const char *Description = "DEBUG SETTING: time to sleep before a checkpoint";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "0";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugDisableOptimizerSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_disable_optimizer";
-	static constexpr const char *Description = "DEBUG SETTING: disable optimizer for most queries";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_disable_optimizer";
+    static constexpr const char *Description = "DEBUG SETTING: disable optimizer for most queries";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugEvictionQueueSleepMicroSecondsSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "debug_eviction_queue_sleep_micro_seconds";
-	static constexpr const char *Description =
-	    "DEBUG SETTING: time for the eviction queue to sleep before acquiring shared ownership of block memory";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "0";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "debug_eviction_queue_sleep_micro_seconds";
+    static constexpr const char *Description = "DEBUG SETTING: time for the eviction queue to sleep before acquiring shared ownership of block memory";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "0";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugForceCommitFailureSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_force_commit_failure";
-	static constexpr const char *Description = "DEBUG SETTING: force transaction commit to fail after the undo buffer "
-	                                           "has been committed, used for testing commit error recovery";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_force_commit_failure";
+    static constexpr const char *Description = "DEBUG SETTING: force transaction commit to fail after the undo buffer has been committed, used for testing commit error recovery";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugForceCommitRevertFailureSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_force_commit_revert_failure";
-	static constexpr const char *Description =
-	    "DEBUG SETTING: force RevertCommit to fail while recovering from a commit failure, used for testing";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_force_commit_revert_failure";
+    static constexpr const char *Description = "DEBUG SETTING: force RevertCommit to fail while recovering from a commit failure, used for testing";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugForceExternalSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_force_external";
-	static constexpr const char *Description =
-	    "DEBUG SETTING: force out-of-core computation for operators that support it, used for testing";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_force_external";
+    static constexpr const char *Description = "DEBUG SETTING: force out-of-core computation for operators that support it, used for testing";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugForceFetchRowSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_force_fetch_row";
-	static constexpr const char *Description = "DEBUG SETTING: force per-row fetching during scans, used for testing";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_force_fetch_row";
+    static constexpr const char *Description = "DEBUG SETTING: force per-row fetching during scans, used for testing";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugForceNoCrossProductSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_force_no_cross_product";
-	static constexpr const char *Description =
-	    "DEBUG SETTING: Force disable cross product generation when hyper graph isn't connected, used for testing";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_force_no_cross_product";
+    static constexpr const char *Description = "DEBUG SETTING: Force disable cross product generation when hyper graph isn't connected, used for testing";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugLocalFileSystemDelayMsSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "debug_local_file_system_delay_ms";
-	static constexpr const char *Description =
-	    "DEBUG SETTING: time to sleep before local file system open/read/write operations";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "0";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "debug_local_file_system_delay_ms";
+    static constexpr const char *Description = "DEBUG SETTING: time to sleep before local file system open/read/write operations";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "0";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugOrderVerificationSetting {
-	using RETURN_TYPE = DebugOrderVerification;
-	static constexpr const char *Name = "debug_order_verification";
-	static constexpr const char *Description =
-	    "DEBUG SETTING: verify ORDER BY results by rewriting the ordering (NONE, CREATE_SORT_KEY or VARIANT)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = DebugOrderVerification;
+    static constexpr const char *Name = "debug_order_verification";
+    static constexpr const char *Description = "DEBUG SETTING: verify ORDER BY results by rewriting the ordering (NONE, CREATE_SORT_KEY or VARIANT)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct DebugPhysicalTableScanExecutionStrategySetting {
-	using RETURN_TYPE = PhysicalTableScanExecutionStrategy;
-	static constexpr const char *Name = "debug_physical_table_scan_execution_strategy";
-	static constexpr const char *Description =
-	    "DEBUG SETTING: force use of given strategy for executing physical table scans";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "DEFAULT";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = PhysicalTableScanExecutionStrategy;
+    static constexpr const char *Name = "debug_physical_table_scan_execution_strategy";
+    static constexpr const char *Description = "DEBUG SETTING: force use of given strategy for executing physical table scans";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "DEFAULT";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DebugSkipCheckpointOnCommitSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_skip_checkpoint_on_commit";
-	static constexpr const char *Description = "DEBUG SETTING: skip checkpointing on commit";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_skip_checkpoint_on_commit";
+    static constexpr const char *Description = "DEBUG SETTING: skip checkpointing on commit";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugTransformerTrampolineStyleSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_transformer_trampoline_style";
-	static constexpr const char *Description = "Use the experimental trampoline-style parser transformer";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_transformer_trampoline_style";
+    static constexpr const char *Description = "Use the experimental trampoline-style parser transformer";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugVerificationModeSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "debug_verification_mode";
-	static constexpr const char *Description = "DEBUG SETTING: toggle the verification mode.";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "debug_verification_mode";
+    static constexpr const char *Description = "DEBUG SETTING: toggle the verification mode.";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct DebugVerificationProjectionSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_verification_projection";
-	static constexpr const char *Description =
-	    "DEBUG SETTING: add internal verification projections to stress optimizers";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_verification_projection";
+    static constexpr const char *Description = "DEBUG SETTING: add internal verification projections to stress optimizers";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugVerifyAggregateStateExportSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_verify_aggregate_state_export";
-	static constexpr const char *Description = "DEBUG SETTING: enable verification of aggregate state export";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_verify_aggregate_state_export";
+    static constexpr const char *Description = "DEBUG SETTING: enable verification of aggregate state export";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugVerifyBlocksSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_verify_blocks";
-	static constexpr const char *Description = "DEBUG SETTING: verify block metadata during checkpointing";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_verify_blocks";
+    static constexpr const char *Description = "DEBUG SETTING: verify block metadata during checkpointing";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugVerifyColumnBindingsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_verify_column_bindings";
-	static constexpr const char *Description = "DEBUG SETTING: run extra internal verification of column bindings";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_verify_column_bindings";
+    static constexpr const char *Description = "DEBUG SETTING: run extra internal verification of column bindings";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugVerifySerializerSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_verify_serializer";
-	static constexpr const char *Description = "DEBUG SETTING: verify logical plan serializer";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_verify_serializer";
+    static constexpr const char *Description = "DEBUG SETTING: verify logical plan serializer";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugVerifyStatementSetting {
-	using RETURN_TYPE = DebugStatementVerification;
-	static constexpr const char *Name = "debug_verify_statement";
-	static constexpr const char *Description = "DEBUG SETTING: the type of statement verification to perform";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "NONE";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = DebugStatementVerification;
+    static constexpr const char *Name = "debug_verify_statement";
+    static constexpr const char *Description = "DEBUG SETTING: the type of statement verification to perform";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "NONE";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DebugVerifyStatsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "debug_verify_stats";
-	static constexpr const char *Description =
-	    "DEBUG SETTING: verify statistics are correct during execution, instead of assuming";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "debug_verify_stats";
+    static constexpr const char *Description = "DEBUG SETTING: verify statistics are correct during execution, instead of assuming";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DebugVerifyVectorSetting {
-	using RETURN_TYPE = DebugVectorVerification;
-	static constexpr const char *Name = "debug_verify_vector";
-	static constexpr const char *Description = "DEBUG SETTING: enable vector verification";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "NONE";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = DebugVectorVerification;
+    static constexpr const char *Name = "debug_verify_vector";
+    static constexpr const char *Description = "DEBUG SETTING: enable vector verification";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "NONE";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DebugWindowModeSetting {
-	using RETURN_TYPE = WindowAggregationMode;
-	static constexpr const char *Name = "debug_window_mode";
-	static constexpr const char *Description = "DEBUG SETTING: switch window mode to use";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "WINDOW";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = WindowAggregationMode;
+    static constexpr const char *Name = "debug_window_mode";
+    static constexpr const char *Description = "DEBUG SETTING: switch window mode to use";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "WINDOW";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DefaultBlockSizeSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "default_block_size";
-	static constexpr const char *Description =
-	    "The default block size for new duckdb database files (new as-in, they do not yet exist).";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "262144";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "default_block_size";
+    static constexpr const char *Description = "The default block size for new duckdb database files (new as-in, they do not yet exist).";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "262144";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DefaultCollationSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "default_collation";
-	static constexpr const char *Description = "The collation setting used when none is specified";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "default_collation";
+    static constexpr const char *Description = "The collation setting used when none is specified";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DefaultIoModeSetting {
-	using RETURN_TYPE = FileIOMode;
-	static constexpr const char *Name = "default_io_mode";
-	static constexpr const char *Description =
-	    "The default IO_MODE for newly attached database files when no explicit IO_MODE is given (BUFFERED_IO or MMAP)";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "BUFFERED_IO";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = FileIOMode;
+    static constexpr const char *Name = "default_io_mode";
+    static constexpr const char *Description = "The default IO_MODE for newly attached database files when no explicit IO_MODE is given (BUFFERED_IO or MMAP)";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "BUFFERED_IO";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DefaultNullOrderSetting {
-	using RETURN_TYPE = DefaultOrderByNullType;
-	static constexpr const char *Name = "default_null_order";
-	static constexpr const char *Description = "NULL ordering used when none is specified (NULLS_FIRST or NULLS_LAST)";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "NULLS_LAST";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = DefaultOrderByNullType;
+    static constexpr const char *Name = "default_null_order";
+    static constexpr const char *Description = "NULL ordering used when none is specified (NULLS_FIRST or NULLS_LAST)";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "NULLS_LAST";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DefaultOrderSetting {
-	using RETURN_TYPE = OrderType;
-	static constexpr const char *Name = "default_order";
-	static constexpr const char *Description = "The order type used when none is specified (ASC or DESC)";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "ASCENDING";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = OrderType;
+    static constexpr const char *Name = "default_order";
+    static constexpr const char *Description = "The order type used when none is specified (ASC or DESC)";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "ASCENDING";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DefaultSecretStorageSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "default_secret_storage";
-	static constexpr const char *Description = "Allows switching the default storage for secrets";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "default_secret_storage";
+    static constexpr const char *Description = "Allows switching the default storage for secrets";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct DefaultTransactionInvalidationPolicySetting {
-	using RETURN_TYPE = TransactionInvalidationPolicy;
-	static constexpr const char *Name = "default_transaction_invalidation_policy";
-	static constexpr const char *Description =
-	    "When to invalidate transactions when errors occur (SYNTACTIC_ERRORS_DO_NOT_INVALIDATE, i.e. parser and binder "
-	    "exceptions do not invalidate, or ALL_ERRORS_INVALIDATE_TRANSACTION)";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "ALL_ERRORS_INVALIDATE_TRANSACTION";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = TransactionInvalidationPolicy;
+    static constexpr const char *Name = "default_transaction_invalidation_policy";
+    static constexpr const char *Description = "When to invalidate transactions when errors occur (SYNTACTIC_ERRORS_DO_NOT_INVALIDATE, i.e. parser and binder exceptions do not invalidate, or ALL_ERRORS_INVALIDATE_TRANSACTION)";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "ALL_ERRORS_INVALIDATE_TRANSACTION";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DelimJoinAsCteSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "delim_join_as_cte";
-	static constexpr const char *Description =
-	    "Rewrite delim joins to materialized CTEs during dependent join flattening";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "true";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "delim_join_as_cte";
+    static constexpr const char *Description = "Rewrite delim joins to materialized CTEs during dependent join flattening";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "true";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DeprecatedUsingKeySyntaxSetting {
-	using RETURN_TYPE = DeprecatedUsingKeySyntax;
-	static constexpr const char *Name = "deprecated_using_key_syntax";
-	static constexpr const char *Description = "Configures the use of the deprecated union syntax for USING KEY CTEs.";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "DEFAULT";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = DeprecatedUsingKeySyntax;
+    static constexpr const char *Name = "deprecated_using_key_syntax";
+    static constexpr const char *Description = "Configures the use of the deprecated union syntax for USING KEY CTEs.";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "DEFAULT";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DialectCompatibilityModeSetting {
-	using RETURN_TYPE = DialectCompatibilityMode;
-	static constexpr const char *Name = "dialect_compatibility_mode";
-	static constexpr const char *Description =
-	    "Enable SQL dialect compatibility for a certain engine (e.g. `SET dialect_compatibility_mode='spark'`)";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "NONE";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = DialectCompatibilityMode;
+    static constexpr const char *Name = "dialect_compatibility_mode";
+    static constexpr const char *Description = "Enable SQL dialect compatibility for a certain engine (e.g. `SET dialect_compatibility_mode='spark'`)";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "NONE";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DisableDatabaseInvalidationSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "disable_database_invalidation";
-	static constexpr const char *Description =
-	    "Disables invalidating the database instance when encountering a fatal error. Should be used with great care, "
-	    "as DuckDB cannot guarantee correct behavior after a fatal error.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "disable_database_invalidation";
+    static constexpr const char *Description = "Disables invalidating the database instance when encountering a fatal error. Should be used with great care, as DuckDB cannot guarantee correct behavior after a fatal error.";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DisableTimestamptzCastsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "disable_timestamptz_casts";
-	static constexpr const char *Description = "Disable casting from timestamp to timestamptz ";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "disable_timestamptz_casts";
+    static constexpr const char *Description = "Disable casting from timestamp to timestamptz ";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct DisabledCompressionMethodsSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "disabled_compression_methods";
-	static constexpr const char *Description = "Disable a specific set of compression methods (comma separated)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "disabled_compression_methods";
+    static constexpr const char *Description = "Disable a specific set of compression methods (comma separated)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct DisabledFilesystemsSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "disabled_filesystems";
-	static constexpr const char *Description = "Disable specific file systems preventing access (e.g. LocalFileSystem)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "disabled_filesystems";
+    static constexpr const char *Description = "Disable specific file systems preventing access (e.g. LocalFileSystem)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct DisabledLogTypes {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "disabled_log_types";
-	static constexpr const char *Description = "Sets the list of disabled loggers";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "disabled_log_types";
+    static constexpr const char *Description = "Sets the list of disabled loggers";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct DisabledOptimizersSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "disabled_optimizers";
-	static constexpr const char *Description = "DEBUG SETTING: disable a specific set of optimizers (comma separated)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "disabled_optimizers";
+    static constexpr const char *Description = "DEBUG SETTING: disable a specific set of optimizers (comma separated)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct DuckDBAPISetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "duckdb_api";
-	static constexpr const char *Description = "DuckDB API surface";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "duckdb_api";
+    static constexpr const char *Description = "DuckDB API surface";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DynamicOrFilterThresholdSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "dynamic_or_filter_threshold";
-	static constexpr const char *Description =
-	    "The maximum amount of OR filters we generate dynamically from a hash join";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "50";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "dynamic_or_filter_threshold";
+    static constexpr const char *Description = "The maximum amount of OR filters we generate dynamically from a hash join";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "50";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct EnableCachingOperatorsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "enable_caching_operators";
-	static constexpr const char *Description = "Enables caching operators that cache intermediate results";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "true";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "enable_caching_operators";
+    static constexpr const char *Description = "Enables caching operators that cache intermediate results";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "true";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct EnableExternalAccessSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "enable_external_access";
-	static constexpr const char *Description =
-	    "Allow the database to access external state (through e.g. loading/installing modules, COPY TO/FROM, CSV "
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "enable_external_access";
+    static constexpr const char *Description = "Allow the database to access external state (through e.g. loading/installing modules, COPY TO/FROM, CSV "
 	    "readers, pandas replacement scans, etc)";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "true";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "true";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct EnableExternalFileCacheSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "enable_external_file_cache";
-	static constexpr const char *Description = "Allow the database to cache external files (e.g., Parquet) in memory.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "true";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "enable_external_file_cache";
+    static constexpr const char *Description = "Allow the database to cache external files (e.g., Parquet) in memory.";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "true";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct EnableFSSTVectorsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "enable_fsst_vectors";
-	static constexpr const char *Description =
-	    "Allow scans on FSST compressed segments to emit compressed vectors to utilize late decompression";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "enable_fsst_vectors";
+    static constexpr const char *Description = "Allow scans on FSST compressed segments to emit compressed vectors to utilize late decompression";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct EnableHTTPMetadataCacheSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "enable_http_metadata_cache";
-	static constexpr const char *Description = "Whether or not the global http metadata is used to cache HTTP metadata";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "enable_http_metadata_cache";
+    static constexpr const char *Description = "Whether or not the global http metadata is used to cache HTTP metadata";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct EnableLogging {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "enable_logging";
-	static constexpr const char *Description = "Enables the logger";
-	static constexpr const char *InputType = "BOOLEAN";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "enable_logging";
+    static constexpr const char *Description = "Enables the logger";
+    static constexpr const char *InputType = "BOOLEAN";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct EnableMacroDependenciesSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "enable_macro_dependencies";
-	static constexpr const char *Description =
-	    "Enable created MACROs to create dependencies on the referenced objects (such as tables)";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "enable_macro_dependencies";
+    static constexpr const char *Description = "Enable created MACROs to create dependencies on the referenced objects (such as tables)";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct EnableObjectCacheSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "enable_object_cache";
-	static constexpr const char *Description = "[PLACEHOLDER] Legacy setting - does nothing";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "enable_object_cache";
+    static constexpr const char *Description = "[PLACEHOLDER] Legacy setting - does nothing";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct EnableOptimizerSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "enable_optimizer";
-	static constexpr const char *Description = "Whether or not query optimization is enabled";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "true";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "enable_optimizer";
+    static constexpr const char *Description = "Whether or not query optimization is enabled";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "true";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct EnableProfilingSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "enable_profiling";
-	static constexpr const char *Description =
-	    "Enables profiling, and sets the output format (JSON, QUERY_TREE, QUERY_TREE_OPTIMIZER)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "enable_profiling";
+    static constexpr const char *Description = "Enables profiling, and sets the output format (JSON, QUERY_TREE, QUERY_TREE_OPTIMIZER)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct EnableProgressBarSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "enable_progress_bar";
-	static constexpr const char *Description =
-	    "Enables the progress bar, printing progress to the terminal for long queries";
-	static constexpr const char *InputType = "BOOLEAN";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static bool OnLocalSet(ClientContext &context, const Value &input);
-	static bool OnLocalReset(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "enable_progress_bar";
+    static constexpr const char *Description = "Enables the progress bar, printing progress to the terminal for long queries";
+    static constexpr const char *InputType = "BOOLEAN";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+static bool OnLocalSet(ClientContext &context, const Value &input);
+static bool OnLocalReset(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct EnableProgressBarPrintSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "enable_progress_bar_print";
-	static constexpr const char *Description =
-	    "Controls the printing of the progress bar, when 'enable_progress_bar' is true";
-	static constexpr const char *InputType = "BOOLEAN";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "enable_progress_bar_print";
+    static constexpr const char *Description = "Controls the printing of the progress bar, when 'enable_progress_bar' is true";
+    static constexpr const char *InputType = "BOOLEAN";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct EnableViewDependenciesSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "enable_view_dependencies";
-	static constexpr const char *Description =
-	    "Enable created VIEWs to create dependencies on the referenced objects (such as tables)";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "enable_view_dependencies";
+    static constexpr const char *Description = "Enable created VIEWs to create dependencies on the referenced objects (such as tables)";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct EnabledLogTypes {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "enabled_log_types";
-	static constexpr const char *Description = "Sets the list of enabled loggers";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "enabled_log_types";
+    static constexpr const char *Description = "Sets the list of enabled loggers";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct ErrorsAsJSONSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "errors_as_json";
-	static constexpr const char *Description = "Output error messages as structured JSON instead of as a raw string";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "errors_as_json";
+    static constexpr const char *Description = "Output error messages as structured JSON instead of as a raw string";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ExperimentalMetadataReuseSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "experimental_metadata_reuse";
-	static constexpr const char *Description = "EXPERIMENTAL: Re-use row group and table metadata when checkpointing.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "true";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "experimental_metadata_reuse";
+    static constexpr const char *Description = "EXPERIMENTAL: Re-use row group and table metadata when checkpointing.";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "true";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ExplainOutputSetting {
-	using RETURN_TYPE = ExplainOutputType;
-	static constexpr const char *Name = "explain_output";
-	static constexpr const char *Description = "Output of EXPLAIN statements (ALL, OPTIMIZED_ONLY, PHYSICAL_ONLY)";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "PHYSICAL_ONLY";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = ExplainOutputType;
+    static constexpr const char *Name = "explain_output";
+    static constexpr const char *Description = "Output of EXPLAIN statements (ALL, OPTIMIZED_ONLY, PHYSICAL_ONLY)";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "PHYSICAL_ONLY";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct ExtensionDirectoriesSetting {
-	using RETURN_TYPE = vector<string>;
-	static constexpr const char *Name = "extension_directories";
-	static constexpr const char *Description = "Set the directories to store extensions in";
-	static constexpr const char *InputType = "VARCHAR[]";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = vector<string>;
+    static constexpr const char *Name = "extension_directories";
+    static constexpr const char *Description = "Set the directories to store extensions in";
+    static constexpr const char *InputType = "VARCHAR[]";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct ExtensionDirectorySetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "extension_directory";
-	static constexpr const char *Description = "Set the directory to store extensions in";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "extension_directory";
+    static constexpr const char *Description = "Set the directory to store extensions in";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ExternalFileCacheLocalBlockSizeSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "external_file_cache_local_block_size";
-	static constexpr const char *Description =
-	    "Block size in bytes for the external file cache when reading local (non-remote) files.";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "16384";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "external_file_cache_local_block_size";
+    static constexpr const char *Description = "Block size in bytes for the external file cache when reading local (non-remote) files.";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "16384";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct ExternalFileCacheRemoteBlockSizeSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "external_file_cache_remote_block_size";
-	static constexpr const char *Description =
-	    "Block size in bytes for the external file cache when reading remote files (e.g. HTTP/S3).";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "2097152";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "external_file_cache_remote_block_size";
+    static constexpr const char *Description = "Block size in bytes for the external file cache when reading remote files (e.g. HTTP/S3).";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "2097152";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct ExternalThreadsSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "external_threads";
-	static constexpr const char *Description = "The number of external threads that work on DuckDB tasks.";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "1";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "external_threads";
+    static constexpr const char *Description = "The number of external threads that work on DuckDB tasks.";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "1";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct FileSearchPathSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "file_search_path";
-	static constexpr const char *Description = "A comma separated list of directories to search for input files";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "file_search_path";
+    static constexpr const char *Description = "A comma separated list of directories to search for input files";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ForceBitpackingModeSetting {
-	using RETURN_TYPE = BitpackingMode;
-	static constexpr const char *Name = "force_bitpacking_mode";
-	static constexpr const char *Description = "DEBUG SETTING: forces a specific bitpacking mode";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "AUTO";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = BitpackingMode;
+    static constexpr const char *Name = "force_bitpacking_mode";
+    static constexpr const char *Description = "DEBUG SETTING: forces a specific bitpacking mode";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "AUTO";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct ForceColumnMetadataReuseSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "force_column_metadata_reuse";
-	static constexpr const char *Description =
-	    "Force re-use of row group metadata on a column-level when checkpointing on older storage versions 6 and 7. "
-	    "This breaks storage backward-compatibility with older DuckDB versions.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "force_column_metadata_reuse";
+    static constexpr const char *Description = "Force re-use of row group metadata on a column-level when checkpointing on older storage versions 6 and 7. This breaks storage backward-compatibility with older DuckDB versions.";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ForceCompressionSetting {
-	using RETURN_TYPE = CompressionType;
-	static constexpr const char *Name = "force_compression";
-	static constexpr const char *Description = "DEBUG SETTING: forces a specific compression method to be used";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "auto";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = CompressionType;
+    static constexpr const char *Name = "force_compression";
+    static constexpr const char *Description = "DEBUG SETTING: forces a specific compression method to be used";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "auto";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct ForceMbedtlsUnsafeSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "force_mbedtls_unsafe";
-	static constexpr const char *Description = "Enable mbedtls for encryption (WARNING: unsafe to use)";
-	static constexpr const char *InputType = "BOOLEAN";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "force_mbedtls_unsafe";
+    static constexpr const char *Description = "Enable mbedtls for encryption (WARNING: unsafe to use)";
+    static constexpr const char *InputType = "BOOLEAN";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct ForceUpdateToDelAndInsertSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "force_update_to_del_and_insert";
-	static constexpr const char *Description =
-	    "DEBUG SETTING: forces all updates to use the delete + insert code path instead of in-place updates";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "force_update_to_del_and_insert";
+    static constexpr const char *Description = "DEBUG SETTING: forces all updates to use the delete + insert code path instead of in-place updates";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ForceVariantShredding {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "force_variant_shredding";
-	static constexpr const char *Description =
-	    "Forces the VARIANT shredding that happens at checkpoint to use the provided schema for the shredding.";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "force_variant_shredding";
+    static constexpr const char *Description = "Forces the VARIANT shredding that happens at checkpoint to use the provided schema for the shredding.";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct GeometryMinimumShreddingSize {
-	using RETURN_TYPE = int64_t;
-	static constexpr const char *Name = "geometry_minimum_shredding_size";
-	static constexpr const char *Description = "Minimum size of a rowgroup to enable GEOMETRY shredding, or set to -1 "
-	                                           "to disable entirely. Defaults to 1/4th of a rowgroup";
-	static constexpr const char *InputType = "BIGINT";
-	static constexpr const char *DefaultValue = "30000";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = int64_t;
+    static constexpr const char *Name = "geometry_minimum_shredding_size";
+    static constexpr const char *Description = "Minimum size of a rowgroup to enable GEOMETRY shredding, or set to -1 to disable entirely. Defaults to 1/4th of a rowgroup";
+    static constexpr const char *InputType = "BIGINT";
+    static constexpr const char *DefaultValue = "30000";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct HomeDirectorySetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "home_directory";
-	static constexpr const char *Description = "Sets the home directory used by the system";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "home_directory";
+    static constexpr const char *Description = "Sets the home directory used by the system";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct HTTPProxySetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "http_proxy";
-	static constexpr const char *Description =
-	    "HTTP proxy host (defaults to the HTTP_PROXY environment variable when unset)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "http_proxy";
+    static constexpr const char *Description = "HTTP proxy host (defaults to the HTTP_PROXY environment variable when unset)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct HTTPProxyPasswordSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "http_proxy_password";
-	static constexpr const char *Description = "Password for HTTP proxy";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "http_proxy_password";
+    static constexpr const char *Description = "Password for HTTP proxy";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct HTTPProxyUsernameSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "http_proxy_username";
-	static constexpr const char *Description = "Username for HTTP proxy";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "http_proxy_username";
+    static constexpr const char *Description = "Username for HTTP proxy";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct IeeeFloatingPointOpsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "ieee_floating_point_ops";
-	static constexpr const char *Description =
-	    "Use IEEE 754 behavior for supported floating point operations, returning NAN/INF instead of errors/NULL.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "true";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "ieee_floating_point_ops";
+    static constexpr const char *Description = "Use IEEE 754 behavior for supported floating point operations, returning NAN/INF instead of errors/NULL.";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "true";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct IgnoreUnknownCrsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "ignore_unknown_crs";
-	static constexpr const char *Description =
-	    "Ignore unknown Coordinate Reference Systems (CRS) when creating geometry types or importing geospatial data.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "ignore_unknown_crs";
+    static constexpr const char *Description = "Ignore unknown Coordinate Reference Systems (CRS) when creating geometry types or importing geospatial data.";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ImmediateTransactionModeSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "immediate_transaction_mode";
-	static constexpr const char *Description =
-	    "Whether transactions should be started lazily when needed, or immediately when BEGIN TRANSACTION is called";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "immediate_transaction_mode";
+    static constexpr const char *Description = "Whether transactions should be started lazily when needed, or immediately when BEGIN TRANSACTION is called";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct IndexScanMaxCountSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "index_scan_max_count";
-	static constexpr const char *Description =
-	    "The maximum index scan count sets a threshold for index scans. If fewer than MAX(index_scan_max_count, "
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "index_scan_max_count";
+    static constexpr const char *Description = "The maximum index scan count sets a threshold for index scans. If fewer than MAX(index_scan_max_count, "
 	    "index_scan_percentage * total_row_count) rows match, we perform an index scan instead of a table scan.";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "2048";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "2048";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct IndexScanPercentageSetting {
-	using RETURN_TYPE = double;
-	static constexpr const char *Name = "index_scan_percentage";
-	static constexpr const char *Description =
-	    "The index scan percentage sets a threshold for index scans. If fewer than MAX(index_scan_max_count, "
+    using RETURN_TYPE = double;
+    static constexpr const char *Name = "index_scan_percentage";
+    static constexpr const char *Description = "The index scan percentage sets a threshold for index scans. If fewer than MAX(index_scan_max_count, "
 	    "index_scan_percentage * total_row_count) rows match, we perform an index scan instead of a table scan.";
-	static constexpr const char *InputType = "DOUBLE";
-	static constexpr const char *DefaultValue = "0.001";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    static constexpr const char *InputType = "DOUBLE";
+    static constexpr const char *DefaultValue = "0.001";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct InitialColumnSegmentSizeSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "initial_column_segment_size";
-	static constexpr const char *Description =
-	    "The initial memory (in bytes) reserved for the first transient column segment. Must be a power of two. "
-	    "Internally, we subtract the block header size (typically 8 bytes) for segments with or exceeding 1024 bytes. "
-	    "Subsequent segments double in size until reaching the block size.";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "2048";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "initial_column_segment_size";
+    static constexpr const char *Description = "The initial memory (in bytes) reserved for the first transient column segment. Must be a power of two. Internally, we subtract the block header size (typically 8 bytes) for segments with or exceeding 1024 bytes. Subsequent segments double in size until reaching the block size.";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "2048";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct IntegerDivisionSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "integer_division";
-	static constexpr const char *Description =
-	    "Whether or not the / operator defaults to integer division, or to floating point division";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "integer_division";
+    static constexpr const char *Description = "Whether or not the / operator defaults to integer division, or to floating point division";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct LambdaSyntaxSetting {
-	using RETURN_TYPE = LambdaSyntax;
-	static constexpr const char *Name = "lambda_syntax";
-	static constexpr const char *Description =
-	    "Configures the use of the deprecated single arrow operator (->) for lambda functions.";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "DEFAULT";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = LambdaSyntax;
+    static constexpr const char *Name = "lambda_syntax";
+    static constexpr const char *Description = "Configures the use of the deprecated single arrow operator (->) for lambda functions.";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "DEFAULT";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct LateMaterializationMaxRowsSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "late_materialization_max_rows";
-	static constexpr const char *Description =
-	    "The maximum amount of rows in the LIMIT/SAMPLE for which we trigger late materialization";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "50";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "late_materialization_max_rows";
+    static constexpr const char *Description = "The maximum amount of rows in the LIMIT/SAMPLE for which we trigger late materialization";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "50";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct LegacyDisableNullTypeSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "legacy_disable_null_type";
-	static constexpr const char *Description =
-	    "When enabled, prevent the NULL type from leaving the binder (< v2.0 default behavior)";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "legacy_disable_null_type";
+    static constexpr const char *Description = "When enabled, prevent the NULL type from leaving the binder (< v2.0 default behavior)";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct LegacyMetricsFormatSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "legacy_metrics_format";
-	static constexpr const char *Description =
-	    "When enabled, profiling output uses the legacy flat format instead of the current grouped format";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "legacy_metrics_format";
+    static constexpr const char *Description = "When enabled, profiling output uses the legacy flat format instead of the current grouped format";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct LockConfigurationSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "lock_configuration";
-	static constexpr const char *Description = "Whether or not configurations can be altered";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "lock_configuration";
+    static constexpr const char *Description = "Whether or not configurations can be altered";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct LogQueryPathSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "log_query_path";
-	static constexpr const char *Description =
-	    "Specifies the path to which queries should be logged (default: NULL, queries are not logged)";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "log_query_path";
+    static constexpr const char *Description = "Specifies the path to which queries should be logged (default: NULL, queries are not logged)";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct LoggingLevel {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "logging_level";
-	static constexpr const char *Description = "The log level which will be recorded in the log";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "logging_level";
+    static constexpr const char *Description = "The log level which will be recorded in the log";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct LoggingMode {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "logging_mode";
-	static constexpr const char *Description = "Determines which types of log messages are logged";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "logging_mode";
+    static constexpr const char *Description = "Determines which types of log messages are logged";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct LoggingStorage {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "logging_storage";
-	static constexpr const char *Description = "Set the logging storage (memory/stdout/file/<custom>)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "logging_storage";
+    static constexpr const char *Description = "Set the logging storage (memory/stdout/file/<custom>)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct MaxExecutionTimeSetting {
-	using RETURN_TYPE = int64_t;
-	static constexpr const char *Name = "max_execution_time";
-	static constexpr const char *Description = "The maximum execution time per query in milliseconds (0 = no limit)";
-	static constexpr const char *InputType = "BIGINT";
-	static constexpr const char *DefaultValue = "0";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = int64_t;
+    static constexpr const char *Name = "max_execution_time";
+    static constexpr const char *Description = "The maximum execution time per query in milliseconds (0 = no limit)";
+    static constexpr const char *InputType = "BIGINT";
+    static constexpr const char *DefaultValue = "0";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct MaxExpressionDepthSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "max_expression_depth";
-	static constexpr const char *Description =
-	    "The maximum expression depth limit in the parser. WARNING: increasing this setting and using very deep "
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "max_expression_depth";
+    static constexpr const char *Description = "The maximum expression depth limit in the parser. WARNING: increasing this setting and using very deep "
 	    "expressions might lead to stack overflow errors.";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "1000";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "1000";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct MaxMemorySetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "max_memory";
-	static constexpr const char *Description = "The maximum memory of the system (e.g. 1GB)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "max_memory";
+    static constexpr const char *Description = "The maximum memory of the system (e.g. 1GB)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct MaxTempDirectorySizeSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "max_temp_directory_size";
-	static constexpr const char *Description =
-	    "The maximum amount of data stored inside the 'temp_directory' (when set) (e.g. 1GB)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "max_temp_directory_size";
+    static constexpr const char *Description = "The maximum amount of data stored inside the 'temp_directory' (when set) (e.g. 1GB)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct MaxVacuumTasksSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "max_vacuum_tasks";
-	static constexpr const char *Description = "The maximum vacuum tasks to schedule during a checkpoint.";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "100";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "max_vacuum_tasks";
+    static constexpr const char *Description = "The maximum vacuum tasks to schedule during a checkpoint.";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "100";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct MergeJoinThresholdSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "merge_join_threshold";
-	static constexpr const char *Description = "The maximum number of rows on either table to choose a merge join";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "1000";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "merge_join_threshold";
+    static constexpr const char *Description = "The maximum number of rows on either table to choose a merge join";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "1000";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct NestedLoopJoinThresholdSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "nested_loop_join_threshold";
-	static constexpr const char *Description =
-	    "The maximum number of rows on either table to choose a nested loop join";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "5";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "nested_loop_join_threshold";
+    static constexpr const char *Description = "The maximum number of rows on either table to choose a nested loop join";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "5";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct OldImplicitCastingSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "old_implicit_casting";
-	static constexpr const char *Description = "Allow implicit casting to/from VARCHAR";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "old_implicit_casting";
+    static constexpr const char *Description = "Allow implicit casting to/from VARCHAR";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct OperatorMemoryLimitSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "operator_memory_limit";
-	static constexpr const char *Description =
-	    "The maximum memory for query intermediates (sorts, hash tables) per connection (e.g. 256MB)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "operator_memory_limit";
+    static constexpr const char *Description = "The maximum memory for query intermediates (sorts, hash tables) per connection (e.g. 256MB)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct OrderByNonIntegerLiteralSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "order_by_non_integer_literal";
-	static constexpr const char *Description =
-	    "Allow ordering by non-integer literals - ordering by such literals has no effect.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "order_by_non_integer_literal";
+    static constexpr const char *Description = "Allow ordering by non-integer literals - ordering by such literals has no effect.";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct OrderedAggregateThresholdSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "ordered_aggregate_threshold";
-	static constexpr const char *Description = "The number of rows to accumulate before sorting, used for tuning";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "262144";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "ordered_aggregate_threshold";
+    static constexpr const char *Description = "The number of rows to accumulate before sorting, used for tuning";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "262144";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct ParallelizeSequentialSourcesSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "parallelize_sequential_sources";
-	static constexpr const char *Description = "Whether to automatically parallelize sequential sources";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "true";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "parallelize_sequential_sources";
+    static constexpr const char *Description = "Whether to automatically parallelize sequential sources";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "true";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct PartitionedWriteFlushThresholdSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "partitioned_write_flush_threshold";
-	static constexpr const char *Description =
-	    "The threshold in number of rows after which we flush a thread state when writing using PARTITION_BY";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "524288";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "partitioned_write_flush_threshold";
+    static constexpr const char *Description = "The threshold in number of rows after which we flush a thread state when writing using PARTITION_BY";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "524288";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct PartitionedWriteMaxOpenFilesSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "partitioned_write_max_open_files";
-	static constexpr const char *Description =
-	    "The maximum amount of files the system can keep open before flushing to disk when writing using PARTITION_BY";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "100";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "partitioned_write_max_open_files";
+    static constexpr const char *Description = "The maximum amount of files the system can keep open before flushing to disk when writing using PARTITION_BY";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "100";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct PasswordSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "password";
-	static constexpr const char *Description = "The password to use. Ignored for legacy compatibility.";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "password";
+    static constexpr const char *Description = "The password to use. Ignored for legacy compatibility.";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct PerfectHtThresholdSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "perfect_ht_threshold";
-	static constexpr const char *Description = "Threshold in bytes for when to use a perfect hash table";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "12";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "perfect_ht_threshold";
+    static constexpr const char *Description = "Threshold in bytes for when to use a perfect hash table";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "12";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct PinThreadsSetting {
-	using RETURN_TYPE = ThreadPinMode;
-	static constexpr const char *Name = "pin_threads";
-	static constexpr const char *Description =
-	    "Whether to pin threads to cores (Linux only, default AUTO: on when there are more than 64 cores)";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "auto";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = ThreadPinMode;
+    static constexpr const char *Name = "pin_threads";
+    static constexpr const char *Description = "Whether to pin threads to cores (Linux only, default AUTO: on when there are more than 64 cores)";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "auto";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct PivotFilterThresholdSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "pivot_filter_threshold";
-	static constexpr const char *Description =
-	    "The threshold to switch from using filtered aggregates to LIST with a dedicated pivot operator";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "20";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "pivot_filter_threshold";
+    static constexpr const char *Description = "The threshold to switch from using filtered aggregates to LIST with a dedicated pivot operator";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "20";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct PivotLimitSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "pivot_limit";
-	static constexpr const char *Description = "The maximum number of pivot columns in a pivot statement";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "100000";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "pivot_limit";
+    static constexpr const char *Description = "The maximum number of pivot columns in a pivot statement";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "100000";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct PreferRangeJoinsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "prefer_range_joins";
-	static constexpr const char *Description = "Force use of range joins with mixed predicates";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "prefer_range_joins";
+    static constexpr const char *Description = "Force use of range joins with mixed predicates";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct PreserveIdentifierCaseSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "preserve_identifier_case";
-	static constexpr const char *Description =
-	    "Whether or not to preserve the identifier case, instead of always lowercasing all non-quoted identifiers";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "true";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "preserve_identifier_case";
+    static constexpr const char *Description = "Whether or not to preserve the identifier case, instead of always lowercasing all non-quoted identifiers";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "true";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct PreserveInsertionOrderSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "preserve_insertion_order";
-	static constexpr const char *Description =
-	    "Whether or not to preserve insertion order. If set to false the system is allowed to re-order any results "
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "preserve_insertion_order";
+    static constexpr const char *Description = "Whether or not to preserve insertion order. If set to false the system is allowed to re-order any results "
 	    "that do not contain ORDER BY clauses.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "true";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "true";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ProduceArrowStringViewSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "produce_arrow_string_view";
-	static constexpr const char *Description =
-	    "Whether Arrow strings should be produced by DuckDB in Utf8View format instead of Utf8";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "produce_arrow_string_view";
+    static constexpr const char *Description = "Whether Arrow strings should be produced by DuckDB in Utf8View format instead of Utf8";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct ProfilingCoverageSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "profiling_coverage";
-	static constexpr const char *Description = "The profiling coverage (SELECT or ALL)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "profiling_coverage";
+    static constexpr const char *Description = "The profiling coverage (SELECT or ALL)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct ProfilingModeSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "profiling_mode";
-	static constexpr const char *Description = "DEPRECATED: Sets the profiling mode";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "profiling_mode";
+    static constexpr const char *Description = "DEPRECATED: Sets the profiling mode";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct ProfilingOutputSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "profiling_output";
-	static constexpr const char *Description =
-	    "The file to which profile output should be saved, or empty to print to the terminal";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "profiling_output";
+    static constexpr const char *Description = "The file to which profile output should be saved, or empty to print to the terminal";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct ProfilingRendererSettingsSetting {
-	using RETURN_TYPE = unordered_map<string, string>;
-	static constexpr const char *Name = "profiling_renderer_settings";
-	static constexpr const char *Description =
-	    "A map of settings passed to the renderer of the profiler output (e.g. {'max_extra_lines': 100}) - settings "
-	    "not recognized by the active renderer are ignored";
-	static constexpr const char *InputType = "MAP(VARCHAR, VARCHAR)";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = unordered_map<string, string>;
+    static constexpr const char *Name = "profiling_renderer_settings";
+    static constexpr const char *Description = "A map of settings passed to the renderer of the profiler output (e.g. {'max_extra_lines': 100}) - settings not recognized by the active renderer are ignored";
+    static constexpr const char *InputType = "MAP(VARCHAR, VARCHAR)";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct ProgressBarTimeSetting {
-	using RETURN_TYPE = int64_t;
-	static constexpr const char *Name = "progress_bar_time";
-	static constexpr const char *Description =
-	    "Sets the time (in milliseconds) how long a query needs to take before we start printing a progress bar";
-	static constexpr const char *InputType = "BIGINT";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = int64_t;
+    static constexpr const char *Name = "progress_bar_time";
+    static constexpr const char *Description = "Sets the time (in milliseconds) how long a query needs to take before we start printing a progress bar";
+    static constexpr const char *InputType = "BIGINT";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct RegexMatchOperatorSemanticsSetting {
-	using RETURN_TYPE = RegexMatchOperatorSemantics;
-	static constexpr const char *Name = "regex_match_operator_semantics";
-	static constexpr const char *Description =
-	    "Configures whether regex match operators use partial or full string matching";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "partial";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = RegexMatchOperatorSemantics;
+    static constexpr const char *Name = "regex_match_operator_semantics";
+    static constexpr const char *Description = "Configures whether regex match operators use partial or full string matching";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "partial";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct ScalarSubqueryErrorOnMultipleRowsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "scalar_subquery_error_on_multiple_rows";
-	static constexpr const char *Description =
-	    "When a scalar subquery returns multiple rows - return a random row instead of returning an error.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "true";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "scalar_subquery_error_on_multiple_rows";
+    static constexpr const char *Description = "When a scalar subquery returns multiple rows - return a random row instead of returning an error.";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "true";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct SchedulerProcessPartialSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "scheduler_process_partial";
-	static constexpr const char *Description =
-	    "Partially process tasks before rescheduling - allows for more scheduler fairness between separate queries";
-	static constexpr const char *InputType = "BOOLEAN";
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "scheduler_process_partial";
+    static constexpr const char *Description = "Partially process tasks before rescheduling - allows for more scheduler fairness between separate queries";
+    static constexpr const char *InputType = "BOOLEAN";
 #ifdef DUCKDB_ALTERNATIVE_VERIFY
-	static constexpr const char *DefaultValue = "true";
+    static constexpr const char *DefaultValue = "true";
 #else
-	static constexpr const char *DefaultValue = "false";
+    static constexpr const char *DefaultValue = "false";
 #endif
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct SchemaSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "schema";
-	static constexpr const char *Description =
-	    "Sets the default search schema. Equivalent to setting search_path to a single value.";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "schema";
+    static constexpr const char *Description = "Sets the default search schema. Equivalent to setting search_path to a single value.";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct SearchPathSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "search_path";
-	static constexpr const char *Description =
-	    "Sets the default catalog search path as a comma-separated list of values";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "search_path";
+    static constexpr const char *Description = "Sets the default catalog search path as a comma-separated list of values";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct SecretDirectorySetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "secret_directory";
-	static constexpr const char *Description = "Set the directory to which persistent secrets are stored";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "secret_directory";
+    static constexpr const char *Description = "Set the directory to which persistent secrets are stored";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct StandardVectorSizeSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "standard_vector_size";
-	static constexpr const char *Description = "The compiled-in STANDARD_VECTOR_SIZE (read-only)";
-	static constexpr const char *InputType = "UBIGINT";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "standard_vector_size";
+    static constexpr const char *Description = "The compiled-in STANDARD_VECTOR_SIZE (read-only)";
+    static constexpr const char *InputType = "UBIGINT";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct StorageBlockPrefetchSetting {
-	using RETURN_TYPE = StorageBlockPrefetch;
-	static constexpr const char *Name = "storage_block_prefetch";
-	static constexpr const char *Description = "In which scenarios to use storage block prefetching";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "REMOTE_ONLY";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = StorageBlockPrefetch;
+    static constexpr const char *Name = "storage_block_prefetch";
+    static constexpr const char *Description = "In which scenarios to use storage block prefetching";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "REMOTE_ONLY";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct StorageCompatibilityVersionSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "storage_compatibility_version";
-	static constexpr const char *Description = "Serialize on checkpoint with compatibility for a given duckdb version";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "storage_compatibility_version";
+    static constexpr const char *Description = "Serialize on checkpoint with compatibility for a given duckdb version";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct StreamingBufferSizeSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "streaming_buffer_size";
-	static constexpr const char *Description =
-	    "The maximum memory to buffer between fetching from a streaming result (e.g. 1GB)";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "streaming_buffer_size";
+    static constexpr const char *Description = "The maximum memory to buffer between fetching from a streaming result (e.g. 1GB)";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct TableFunctionIdentifierConversionSetting {
-	using RETURN_TYPE = TableFunctionIdentifierConversion;
-	static constexpr const char *Name = "table_function_identifier_conversion";
-	static constexpr const char *Description = "Configures the use of deprecated implicit conversion of unbound "
-	                                           "identifiers to strings in table function arguments.";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "DEFAULT";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = TableFunctionIdentifierConversion;
+    static constexpr const char *Name = "table_function_identifier_conversion";
+    static constexpr const char *Description = "Configures the use of deprecated implicit conversion of unbound identifiers to strings in table function arguments.";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "DEFAULT";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct TempDirectorySetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "temp_directory";
-	static constexpr const char *Description = "Set the directory to which to write temp files";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "temp_directory";
+    static constexpr const char *Description = "Set the directory to which to write temp files";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct TempFileEncryptionSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "temp_file_encryption";
-	static constexpr const char *Description = "Encrypt all temporary files if database is encrypted";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "temp_file_encryption";
+    static constexpr const char *Description = "Encrypt all temporary files if database is encrypted";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct ThreadsSetting {
-	using RETURN_TYPE = int64_t;
-	static constexpr const char *Name = "threads";
-	static constexpr const char *Description = "The number of total threads used by the system.";
-	static constexpr const char *InputType = "BIGINT";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = int64_t;
+    static constexpr const char *Name = "threads";
+    static constexpr const char *Description = "The number of total threads used by the system.";
+    static constexpr const char *InputType = "BIGINT";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct TrackedMetricsSetting {
-	using RETURN_TYPE = vector<string>;
-	static constexpr const char *Name = "tracked_metrics";
-	static constexpr const char *Description =
-	    "A list of metric glob patterns to enable for collection (e.g. ['query.*', 'optimizer.*'])";
-	static constexpr const char *InputType = "VARCHAR[]";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = vector<string>;
+    static constexpr const char *Name = "tracked_metrics";
+    static constexpr const char *Description = "A list of metric glob patterns to enable for collection (e.g. ['query.*', 'optimizer.*'])";
+    static constexpr const char *InputType = "VARCHAR[]";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct UsernameSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "username";
-	static constexpr const char *Description = "The username to use. Ignored for legacy compatibility.";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "username";
+    static constexpr const char *Description = "The username to use. Ignored for legacy compatibility.";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct VacuumRebuildIndexesSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "vacuum_rebuild_indexes";
-	static constexpr const char *Description =
-	    "(Experimental) Allow vacuum to compact row groups on tables with bound ART indexes, rebuilding the indexes "
-	    "afterward. Tables with a row count exceeding this threshold are skipped. 0 = disabled. Can also be set "
-	    "per-database via the 'vacuum_rebuild_indexes' ATTACH option, which overrides this default.";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "0";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "vacuum_rebuild_indexes";
+    static constexpr const char *Description = "(Experimental) Allow vacuum to compact row groups on tables with bound ART indexes, rebuilding the indexes afterward. Tables with a row count exceeding this threshold are skipped. 0 = disabled. Can also be set per-database via the 'vacuum_rebuild_indexes' ATTACH option, which overrides this default.";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "0";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct ValidateExternalFileCacheSetting {
-	using RETURN_TYPE = CacheValidationMode;
-	static constexpr const char *Name = "validate_external_file_cache";
-	static constexpr const char *Description =
-	    "Cache validation mode: VALIDATE_ALL (default, validate all cache entries), VALIDATE_REMOTE (validate only "
-	    "remote cache entries), or NO_VALIDATION (disable cache validation).";
-	static constexpr const char *InputType = "VARCHAR";
-	static constexpr const char *DefaultValue = "VALIDATE_ALL";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = CacheValidationMode;
+    static constexpr const char *Name = "validate_external_file_cache";
+    static constexpr const char *Description = "Cache validation mode: VALIDATE_ALL (default, validate all cache entries), VALIDATE_REMOTE (validate only remote cache entries), or NO_VALIDATION (disable cache validation).";
+    static constexpr const char *InputType = "VARCHAR";
+    static constexpr const char *DefaultValue = "VALIDATE_ALL";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct VariantMinimumShreddingSizeSetting {
-	using RETURN_TYPE = int64_t;
-	static constexpr const char *Name = "variant_minimum_shredding_size";
-	static constexpr const char *Description = "Minimum size of a rowgroup to enable VARIANT shredding, or set to -1 "
-	                                           "to disable entirely. Defaults to 1/4th of a rowgroup";
-	static constexpr const char *InputType = "BIGINT";
-	static constexpr const char *DefaultValue = "30000";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = int64_t;
+    static constexpr const char *Name = "variant_minimum_shredding_size";
+    static constexpr const char *Description = "Minimum size of a rowgroup to enable VARIANT shredding, or set to -1 to disable entirely. Defaults to 1/4th of a rowgroup";
+    static constexpr const char *InputType = "BIGINT";
+    static constexpr const char *DefaultValue = "30000";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct WalAutocheckpointEntriesSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "wal_autocheckpoint_entries";
-	static constexpr const char *Description =
-	    "Trigger automatic checkpoint when WAL entry count reaches or exceeds N (0 = disabled)";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "0";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "wal_autocheckpoint_entries";
+    static constexpr const char *Description = "Trigger automatic checkpoint when WAL entry count reaches or exceeds N (0 = disabled)";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "0";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct WarningsAsErrorsSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "warnings_as_errors";
-	static constexpr const char *Description = "Escalate all warnings to errors.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "warnings_as_errors";
+    static constexpr const char *Description = "Escalate all warnings to errors.";
+    static constexpr const char *InputType = "BOOLEAN";
+    static constexpr const char *DefaultValue = "false";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct WriteBufferRowGroupCountSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "write_buffer_row_group_count";
-	static constexpr const char *Description = "The amount of row groups to buffer in bulk ingestion prior to flushing "
-	                                           "them together. Reducing this setting can reduce memory consumption.";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "5";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "write_buffer_row_group_count";
+    static constexpr const char *Description = "The amount of row groups to buffer in bulk ingestion prior to flushing them together. Reducing this setting can reduce memory consumption.";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "5";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_DEFAULT;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
 
 struct WriteBufferRowGroupMemoryLimitSetting {
-	using RETURN_TYPE = string;
-	static constexpr const char *Name = "write_buffer_row_group_memory_limit";
-	static constexpr const char *Description =
-	    "The maximum data to buffer in row groups (in bytes) to buffer prior to flushing them together. When either "
-	    "this limit is reached, or write_buffer_row_group_count is reached, we flush the data to disk. Defaults to 20% "
-	    "of memory limit divided by thread count.";
-	static constexpr const char *InputType = "VARCHAR";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
+    using RETURN_TYPE = string;
+    static constexpr const char *Name = "write_buffer_row_group_memory_limit";
+    static constexpr const char *Description = "The maximum data to buffer in row groups (in bytes) to buffer prior to flushing them together. When either this limit is reached, or write_buffer_row_group_count is reached, we flush the data to disk. Defaults to 20% of memory limit divided by thread count.";
+    static constexpr const char *InputType = "VARCHAR";
+    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+    static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+    static Value GetSetting(const ClientContext &context);
 };
 
 struct ZstdMinStringLengthSetting {
-	using RETURN_TYPE = idx_t;
-	static constexpr const char *Name = "zstd_min_string_length";
-	static constexpr const char *Description =
-	    "The (average) length at which to enable ZSTD compression, defaults to 4096";
-	static constexpr const char *InputType = "UBIGINT";
-	static constexpr const char *DefaultValue = "4096";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+    using RETURN_TYPE = idx_t;
+    static constexpr const char *Name = "zstd_min_string_length";
+    static constexpr const char *Description = "The (average) length at which to enable ZSTD compression, defaults to 4096";
+    static constexpr const char *InputType = "UBIGINT";
+    static constexpr const char *DefaultValue = "4096";
+    static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+    static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };
+
 
 struct GeneratedSettingInfo {
 	static constexpr idx_t MaxSettingIndex = NEXT_SETTING_INDEX();

--- a/src/include/duckdb/storage/optimistic_data_writer.hpp
+++ b/src/include/duckdb/storage/optimistic_data_writer.hpp
@@ -23,6 +23,9 @@ struct OptimisticWriteCollection {
 	idx_t unflushed_data_size = 0;
 	idx_t prev_allocated_size = 0;
 	vector<unique_ptr<PartialBlockManager>> partial_block_managers;
+	//! Per-column compression type detected during the first row group written for each column.
+	//! Reused for subsequent row groups to skip running all compression analyzers.
+	vector<CompressionType> detected_compression_types;
 
 	void MergeStorage(OptimisticWriteCollection &collection);
 	void FinalizeFlush();

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -47,6 +47,12 @@ struct ColumnCheckpointInfo {
 public:
 	PartialBlockManager &GetPartialBlockManager();
 	CompressionType GetCompressionType();
+	//! Returns the compression type detected for this column in a previous row group of
+	//! this flush batch, or COMPRESSION_AUTO if not yet cached.
+	CompressionType GetDetectedCompressionType() const;
+	//! Records the winning compression type for this column so subsequent row groups in
+	//! the same flush batch can skip running all other analyzers.
+	void SetDetectedCompressionType(CompressionType type);
 
 private:
 	RowGroupWriteInfo &info;

--- a/src/include/duckdb/storage/table/column_data_checkpointer.hpp
+++ b/src/include/duckdb/storage/table/column_data_checkpointer.hpp
@@ -68,7 +68,7 @@ public:
 	void FinalizeCheckpoint();
 
 private:
-	void ScanSegments(const std::function<void(Vector &)> &callback);
+	void ScanSegments(const std::function<void(Vector &)> &callback, double sample_rate = 1.0);
 	vector<CheckpointAnalyzeResult> DetectBestCompressionMethod();
 	void WriteToDisk();
 	void WritePersistentSegments(ColumnCheckpointState &state);

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -70,6 +70,11 @@ private:
 public:
 	const vector<CompressionType> &compression_types;
 	CheckpointOptions options;
+	//! Detected compression types from previous row groups — points into
+	//! OptimisticWriteCollection::detected_compression_types so the cache
+	//! persists across multiple FlushToDisk calls within the same append session.
+	//! nullptr when writing outside an optimistic append context (e.g. full checkpoint).
+	optional_ptr<vector<CompressionType>> detected_compression_types;
 
 public:
 	PartialBlockManager &GetPartialBlockManager(idx_t column_idx);

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -1,7 +1,9 @@
 #include "duckdb/main/appender.hpp"
 
+#include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/operator/decimal_cast_operators.hpp"
@@ -28,7 +30,9 @@
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression/parameter_expression.hpp"
 #include "duckdb/parser/tableref/expressionlistref.hpp"
+#include "duckdb/common/enums/database_modification_type.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/transaction/meta_transaction.hpp"
 
 namespace duckdb {
 
@@ -725,6 +729,78 @@ void QueryAppender::FlushInternal(ColumnDataCollection &collection) {
 	auto table_ref = GetColumnDataTableRef(collection, table_name, names);
 	auto parsed_statement = ParseStatement(std::move(table_ref), query, table_name.GetIdentifierName());
 	context_ref->Append(std::move(parsed_statement));
+}
+
+//===--------------------------------------------------------------------===//
+// DirectAppender
+//===--------------------------------------------------------------------===//
+
+DirectAppender::DirectAppender(Connection &con, const Identifier &database_name, const Identifier &schema_name,
+                               const Identifier &table_name, const idx_t flush_memory_threshold_p)
+    : BaseAppender(Allocator::DefaultAllocator(), AppenderType::LOGICAL), context(con.context) {
+	flush_memory_threshold = (flush_memory_threshold_p == DConstants::INVALID_INDEX)
+	                             ? optional_idx::Invalid()
+	                             : optional_idx(flush_memory_threshold_p);
+
+	description = con.TableInfo(database_name, schema_name, table_name);
+	if (!description) {
+		throw CatalogException(
+		    StringUtil::Format("Table \"%s.%s.%s\" could not be found", database_name, schema_name, table_name));
+	}
+	if (description->readonly) {
+		throw InvalidInputException("Cannot append to a readonly database.");
+	}
+
+	types.reserve(description->columns.size());
+	for (auto &column : description->columns) {
+		if (column.Generated()) {
+			continue;
+		}
+		types.emplace_back(column.Type());
+	}
+
+	collection = make_uniq<ColumnDataCollection>(allocator, types);
+	InitializeChunk();
+}
+
+DirectAppender::DirectAppender(Connection &con, const Identifier &schema_name, const Identifier &table_name,
+                               const idx_t flush_memory_threshold_p)
+    : DirectAppender(con, Identifier::InvalidCatalog(), schema_name, table_name, flush_memory_threshold_p) {
+}
+
+DirectAppender::DirectAppender(Connection &con, const Identifier &table_name, const idx_t flush_memory_threshold_p)
+    : DirectAppender(con, Identifier::DefaultSchema(), table_name, flush_memory_threshold_p) {
+}
+
+DirectAppender::~DirectAppender() {
+	Destructor();
+}
+
+void DirectAppender::FlushInternal(ColumnDataCollection &collection_p) {
+	auto context_ref = context.lock();
+	if (!context_ref) {
+		throw InvalidInputException("DirectAppender: Attempting to flush data to a closed connection");
+	}
+
+	context_ref->RunFunctionInTransaction([&]() {
+		auto table_entry = Catalog::GetEntry<TableCatalogEntry>(*context_ref,
+		                                                        QualifiedName(description->qualified_name.Catalog(),
+		                                                                      description->qualified_name.Schema(),
+		                                                                      description->qualified_name.Name()),
+		                                                        OnEntryNotFound::THROW_EXCEPTION);
+		auto &duck_table = table_entry->Cast<DuckTableEntry>();
+
+		// Mark the database as modified so the transaction is not read-only when we commit.
+		auto &meta_tx = MetaTransaction::Get(*context_ref);
+		auto &attached = duck_table.catalog.GetAttached();
+		meta_tx.ModifyDatabase(attached, DatabaseModificationType());
+
+		auto binder = Binder::CreateBinder(*context_ref);
+		auto bound_constraints = binder->BindConstraints(*table_entry);
+
+		optional_ptr<const vector<LogicalIndex>> column_ids_ptr = column_ids.empty() ? nullptr : &column_ids;
+		duck_table.GetStorage().LocalAppend(duck_table, *context_ref, collection_p, bound_constraints, column_ids_ptr);
+	});
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -95,6 +95,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(CatalogErrorMaxSchemasSetting),
     DUCKDB_SETTING_CALLBACK(CheckpointOnDetachSetting),
     DUCKDB_GLOBAL(CheckpointThresholdSetting),
+    DUCKDB_SETTING(CompressionAnalyzeSampleSizeSetting),
     DUCKDB_LOCAL(ConfigureProfilingSetting),
     DUCKDB_SETTING_CALLBACK(CurrentTransactionInvalidationPolicySetting),
     DUCKDB_SETTING(CustomExtensionRepositorySetting),
@@ -243,17 +244,16 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING_CALLBACK(WarningsAsErrorsSetting),
     DUCKDB_SETTING(WriteBufferRowGroupCountSetting),
     DUCKDB_GLOBAL(WriteBufferRowGroupMemoryLimitSetting),
-    DUCKDB_SETTING(ZstdMinStringLengthSetting),
-    FINAL_SETTING};
+    DUCKDB_SETTING(ZstdMinStringLengthSetting),    FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 29),
-                                                     DUCKDB_SETTING_ALIAS("custom_profiling_settings", 29),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 128),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 61),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 151),
-                                                     DUCKDB_SETTING_ALIAS("user", 169),
-                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 28),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 167),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 30),
+    DUCKDB_SETTING_ALIAS("custom_profiling_settings", 30),
+    DUCKDB_SETTING_ALIAS("memory_limit", 129),
+    DUCKDB_SETTING_ALIAS("null_order", 62),
+    DUCKDB_SETTING_ALIAS("profile_output", 152),
+    DUCKDB_SETTING_ALIAS("user", 170),
+    DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 28),
+    DUCKDB_SETTING_ALIAS("worker_threads", 168),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -158,6 +158,16 @@ idx_t FSSTStorage::StringFinalAnalyze(AnalyzeState &state_p) {
 		return DConstants::INVALID_INDEX;
 	}
 
+	// FSST encodes repeated sub-string patterns using a symbol table and only yields
+	// a size benefit when strings are long enough to contain recurring byte sequences.
+	// For very short strings the symbol table overhead dominates; dictionary compression
+	// wins instead. Skip the expensive duckdb_fsst_create + duckdb_fsst_compress calls
+	// when the average sampled string length is below this threshold.
+	static constexpr size_t FSST_MIN_AVG_STRING_LENGTH = 10;
+	if (state.fsst_string_total_size / string_count < FSST_MIN_AVG_STRING_LENGTH) {
+		return DConstants::INVALID_INDEX;
+	}
+
 	size_t output_buffer_size = 7 + 2 * state.fsst_string_total_size; // size as specified in fsst.h
 
 	vector<size_t> fsst_string_sizes;

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -84,10 +84,13 @@ public:
 
 template <class T>
 struct RLEAnalyzeState : public AnalyzeState {
-	explicit RLEAnalyzeState(BlockManager &block_manager) : AnalyzeState(block_manager) {
+	explicit RLEAnalyzeState(BlockManager &block_manager) : AnalyzeState(block_manager), total_values_seen(0) {
 	}
 
 	RLEState<T> state;
+	//! Tracks how many values we have passed to the analyzer so far.
+	//! Used to check whether RLE can plausibly win before scanning all data.
+	idx_t total_values_seen;
 };
 
 template <class T>
@@ -105,6 +108,19 @@ bool RLEAnalyze(AnalyzeState &state, const Vector &input) {
 	for (idx_t i = 0; i < input.size(); i++) {
 		auto idx = vdata.sel->get_index(i);
 		rle_state.state.Update(data, vdata.validity, idx);
+	}
+	rle_state.total_values_seen += input.size();
+
+	// After seeing enough data (4 vectors = 8 192 values), check whether RLE can
+	// plausibly compress.  Each RLE entry costs sizeof(rle_count_t) + sizeof(T)
+	// bytes.  If the estimated RLE size already meets or exceeds the raw size, no
+	// amount of additional data can make RLE win — bail out early.
+	static constexpr idx_t MIN_VALUES_FOR_EARLY_EXIT = 4 * STANDARD_VECTOR_SIZE;
+	if (rle_state.total_values_seen >= MIN_VALUES_FOR_EARLY_EXIT) {
+		idx_t rle_entry_size = sizeof(rle_count_t) + sizeof(T);
+		if (rle_state.state.seen_count * rle_entry_size >= rle_state.total_values_seen * sizeof(T)) {
+			return false;
+		}
 	}
 	return true;
 }

--- a/src/storage/optimistic_data_writer.cpp
+++ b/src/storage/optimistic_data_writer.cpp
@@ -177,6 +177,7 @@ void OptimisticDataWriter::FlushToDisk(OptimisticWriteCollection &collection,
 		compression_types.push_back(column.CompressionType());
 	}
 	RowGroupWriteInfo info(*partial_manager, compression_types, collection.partial_block_managers);
+	info.detected_compression_types = &collection.detected_compression_types;
 	auto result = RowGroup::WriteToDisk(info, row_groups);
 	// move new (checkpointed) row groups to the row group collection
 	for (idx_t i = 0; i < row_groups.size(); i++) {

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -89,11 +89,16 @@ ColumnDataCheckpointer::ColumnDataCheckpointer(vector<reference<ColumnCheckpoint
 	CreateIntermediateVector(checkpoint_states, intermediate);
 }
 
-void ColumnDataCheckpointer::ScanSegments(const std::function<void(Vector &)> &callback) {
+void ColumnDataCheckpointer::ScanSegments(const std::function<void(Vector &)> &callback,
+                                           double sample_rate) {
 	auto &first_state = checkpoint_states[0];
 	auto &col_data = first_state.get().original_column;
 
 	// TODO: scan all the nodes from all segments, no need for CheckpointScan to virtualize this I think..
+	idx_t vec_idx = 0;
+	idx_t sample_stride = (sample_rate >= 1.0 || sample_rate <= 0.0)
+	                          ? 1
+	                          : static_cast<idx_t>(std::ceil(1.0 / sample_rate));
 	for (auto &segment_node : col_data.data.SegmentNodes()) {
 		auto &segment = segment_node.GetNode();
 		ColumnScanState scan_state(nullptr);
@@ -102,6 +107,12 @@ void ColumnDataCheckpointer::ScanSegments(const std::function<void(Vector &)> &c
 
 		auto &scan_vector = intermediate.data[0];
 		for (idx_t base_row_index = 0; base_row_index < segment.count; base_row_index += STANDARD_VECTOR_SIZE) {
+			// Always include the first vector so analyzers see at least one sample.
+			// For subsequent vectors, apply the stride to skip non-sampled ones.
+			if (vec_idx > 0 && sample_stride > 1 && (vec_idx % sample_stride) != 0) {
+				vec_idx++;
+				continue;
+			}
 			intermediate.Reset();
 
 			idx_t count = MinValue<idx_t>(segment.count - base_row_index, STANDARD_VECTOR_SIZE);
@@ -110,6 +121,7 @@ void ColumnDataCheckpointer::ScanSegments(const std::function<void(Vector &)> &c
 			col_data.CheckpointScan(segment, scan_state, count, scan_vector);
 			scan_vector.BufferMutable().SetVectorSize(count);
 			callback(scan_vector);
+			vec_idx++;
 		}
 	}
 }
@@ -189,7 +201,21 @@ vector<CheckpointAnalyzeResult> ColumnDataCheckpointer::DetectBestCompressionMet
 		}
 	}
 
+	// For the base data column (state 0), check if a previous row group in this flush batch
+	// already determined the best compression method. If so, narrow the candidate list to that
+	// method only — this eliminates running all other analyzers during ScanSegments.
+	if (!checkpoint_states.empty() && forced_methods[0] == CompressionType::COMPRESSION_AUTO) {
+		auto cached_type = checkpoint_info.GetDetectedCompressionType();
+		if (cached_type != CompressionType::COMPRESSION_AUTO) {
+			forced_methods[0] = ForceCompression(storage_manager, compression_functions[0], cached_type);
+		}
+	}
+
 	InitAnalyze();
+
+	// Read the configured sample rate and apply it to the analyze scan only.
+	// The write scan (below) always uses 100% of the data.
+	double analyze_sample_rate = Settings::Get<CompressionAnalyzeSampleSizeSetting>(config);
 
 	// scan over all the segments and run the analyze step
 	ScanSegments([&](Vector &scan_vector) {
@@ -209,7 +235,7 @@ vector<CheckpointAnalyzeResult> ColumnDataCheckpointer::DetectBestCompressionMet
 				}
 			}
 		}
-	});
+	}, analyze_sample_rate);
 
 	vector<CheckpointAnalyzeResult> result;
 	result.resize(checkpoint_states.size());
@@ -268,6 +294,13 @@ vector<CheckpointAnalyzeResult> ColumnDataCheckpointer::DetectBestCompressionMet
 		                 col_data.info.GetTableName(), col_data.column_index, col_data.type.ToString(), best_score);
 		result[i] = CheckpointAnalyzeResult(std::move(chosen_state), best_function);
 	}
+
+	// Cache the winning compression type for the base data column (state 0) so that
+	// subsequent row groups in this flush batch can skip running all other analyzers.
+	if (!result.empty() && result[0].function) {
+		checkpoint_info.SetDetectedCompressionType(result[0].function->type);
+	}
+
 	return result;
 }
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1312,6 +1312,28 @@ CompressionType ColumnCheckpointInfo::GetCompressionType() {
 	return info.compression_types[column_idx];
 }
 
+CompressionType ColumnCheckpointInfo::GetDetectedCompressionType() const {
+	if (!info.detected_compression_types) {
+		return CompressionType::COMPRESSION_AUTO;
+	}
+	auto &cache = *info.detected_compression_types;
+	if (column_idx < cache.size()) {
+		return cache[column_idx];
+	}
+	return CompressionType::COMPRESSION_AUTO;
+}
+
+void ColumnCheckpointInfo::SetDetectedCompressionType(CompressionType type) {
+	if (!info.detected_compression_types) {
+		return;
+	}
+	auto &cache = *info.detected_compression_types;
+	if (cache.size() <= column_idx) {
+		cache.resize(column_idx + 1, CompressionType::COMPRESSION_AUTO);
+	}
+	cache[column_idx] = type;
+}
+
 shared_ptr<ColumnData> RowGroup::CheckpointColumn(const RowGroup &row_group, idx_t column_idx, RowGroupWriteInfo &info,
                                                   RowGroupWriteData &write_data) {
 	auto &column = row_group.GetColumn(column_idx);

--- a/test/appender/test_appender.cpp
+++ b/test/appender/test_appender.cpp
@@ -880,3 +880,61 @@ TEST_CASE("Test appender_allocator_flush_threshold", "[appender]") {
 	}
 	appender_2.Close();
 }
+
+TEST_CASE("Basic DirectAppender tests", "[appender][direct]") {
+	duckdb::unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	SECTION("Append via DirectAppender::AppendRow") {
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE vals(i TINYINT, j SMALLINT, k BIGINT, l VARCHAR, m DECIMAL)"));
+		{
+			DirectAppender appender(con, "vals");
+			for (idx_t i = 0; i < 500; i++) {
+				appender.AppendRow(int8_t(1), int16_t(2), int64_t(3), "hello", 4.5);
+			}
+			appender.Close();
+		}
+
+		result = con.Query("SELECT l, SUM(k) FROM vals GROUP BY l");
+		REQUIRE(CHECK_COLUMN(result, 0, {"hello"}));
+		REQUIRE(CHECK_COLUMN(result, 1, {1500}));
+	}
+
+	SECTION("Append via DirectAppender::AppendDataChunk") {
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE chunk_test(a INTEGER, b VARCHAR)"));
+		{
+			DirectAppender appender(con, "chunk_test");
+			DataChunk chunk;
+			chunk.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER, LogicalType::VARCHAR});
+			chunk.data[0].Append(Value::INTEGER(42));
+			chunk.data[1].Append(Value("world"));
+			chunk.SetChildCardinality(1);
+			appender.AppendDataChunk(chunk);
+			appender.Close();
+		}
+
+		result = con.Query("SELECT a, b FROM chunk_test");
+		REQUIRE(CHECK_COLUMN(result, 0, {42}));
+		REQUIRE(CHECK_COLUMN(result, 1, {"world"}));
+	}
+
+	SECTION("Generated column handling") {
+		REQUIRE_NO_FAIL(con.Query(R"(
+			CREATE TABLE gen_first (
+				b VARCHAR GENERATED ALWAYS AS (a),
+				a VARCHAR
+			)
+		)"));
+		{
+			DirectAppender appender(con, "gen_first");
+			appender.BeginRow();
+			appender.Append("hello");
+			appender.EndRow();
+			appender.Close();
+		}
+		result = con.Query("SELECT * FROM gen_first");
+		REQUIRE(CHECK_COLUMN(result, 0, {Value("hello")}));
+		REQUIRE(CHECK_COLUMN(result, 1, {Value("hello")}));
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new public DirectAppender API and a global compression-analysis setting that can change checkpoint CPU and codec choices; benchmark-only paths are low risk but the setting affects storage behavior when enabled.
> 
> **Overview**
> Adds **microbenchmark coverage** for bulk ingestion and commit-time compression analysis, plus a **`DirectAppender`** API and **`compression_analyze_sample_size`** setting to support tuning and isolation experiments.
> 
> **Lineitem ingestion** (`appender_lineitem.cpp`): persistent-disk benchmarks that load **1M rows** into a 16-column TPC-H **lineitem**-like table via **`Appender`** and **`DirectAppender`**, with variants for **no PK vs composite PK** and a **`NO_WAL_WRITES`** attach path to separate append cost from WAL/checkpoint/compression work.
> 
> **Compression detection** (`compression_detection.cpp`): benchmarks that pre-append one row group in a transaction and time only **`COMMIT`**, targeting **`DetectBestCompressionMethod`**. Suites cover **16×INTEGER**, **16×DOUBLE**, **16×VARCHAR**, and mixed lineitem schemas, with **`force_compression='auto'`** vs **`uncompressed`** baselines and lineitem runs at **0.5 / 0.25** sample sizes via the new setting.
> 
> **Build**: registers both sources in `benchmark/micro/CMakeLists.txt`. **API**: exposes **`DirectAppender`** on `BaseAppender` (table-targeted flush, no query pipeline). **Config**: documents global **`compression_analyze_sample_size`** (default **1.0**) in `settings.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e65cca7e61d5d42d0573a198b1ae6dd0a261027b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->