### PR TITLE
Pushdown prefix predicate

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -421,7 +421,8 @@ FilterPushdownResult FilterCombiner::TryPushdownPrefixFilter(TableFilterSet &tab
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	auto &func = expr.Cast<BoundFunctionExpression>();
-	if (func.Function().GetName() != "prefix") {
+	auto &function_name = func.Function().GetName();
+	if (function_name != "prefix" && function_name != "starts_with" && function_name != "^@") {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	if (func.GetChildren()[0]->GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF ||

--- a/test/optimizer/pushdown/starts_with_pushdown.test
+++ b/test/optimizer/pushdown/starts_with_pushdown.test
@@ -1,0 +1,24 @@
+# name: test/optimizer/pushdown/starts_with_pushdown.test
+# description: Test that starts_with/^@/prefix filters are pushed down as range filters
+# group: [pushdown]
+
+statement ok
+CREATE TABLE t AS SELECT lpad(i::VARCHAR, 9, '0') AS s FROM range(500000) tbl(i);
+
+# starts_with is pushed down as a range filter
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE starts_with(s, '00049999')
+----
+analyzed_plan	<REGEX>:(?s).*s >= '00049999'.*s < '0004999:'.*
+
+# the ^@ operator as well
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE s ^@ '00049999'
+----
+analyzed_plan	<REGEX>:(?s).*s >= '00049999'.*s < '0004999:'.*
+
+# and the prefix function
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE prefix(s, '00049999')
+----
+analyzed_plan	<REGEX>:(?s).*s >= '00049999'.*s < '0004999:'.*

--- a/test/optimizer/pushdown/starts_with_pushdown.test
+++ b/test/optimizer/pushdown/starts_with_pushdown.test
@@ -5,20 +5,17 @@
 statement ok
 CREATE TABLE t AS SELECT lpad(i::VARCHAR, 9, '0') AS s FROM range(500000) tbl(i);
 
-# starts_with is pushed down as a range filter
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM t WHERE starts_with(s, '00049999')
 ----
-analyzed_plan	<REGEX>:(?s).*s >= '00049999'.*s < '0004999:'.*
+analyzed_plan	<REGEX>:(?s).*s >= '00049999'.*s < '0004999:'.*Row Groups Scanned: 1 / 5.*
 
-# the ^@ operator as well
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM t WHERE s ^@ '00049999'
 ----
-analyzed_plan	<REGEX>:(?s).*s >= '00049999'.*s < '0004999:'.*
+analyzed_plan	<REGEX>:(?s).*s >= '00049999'.*s < '0004999:'.*Row Groups Scanned: 1 / 5.*
 
-# and the prefix function
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM t WHERE prefix(s, '00049999')
 ----
-analyzed_plan	<REGEX>:(?s).*s >= '00049999'.*s < '0004999:'.*
+analyzed_plan	<REGEX>:(?s).*s >= '00049999'.*s < '0004999:'.*Row Groups Scanned: 1 / 5.*


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow optimizer change: aliases more function names into existing prefix-to-range pushdown; tests lock in scan pruning behavior.
> 
> **Overview**
> Extends **prefix-style filter pushdown** so predicates written as `starts_with(col, 'literal')` or `col ^@ 'literal'` use the same optimizer path as `prefix(col, 'literal')`.
> 
> When the shape is a column plus a non-empty string constant, those filters are still rewritten to **varchar range bounds** (`>=` prefix and `<` next lexicographic string) on the scan, enabling row-group pruning on large tables.
> 
> Adds regression tests that `EXPLAIN ANALYZE` shows the range filters and **1 / 5** row groups scanned for all three spellings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39076671bc3324009772abcf86cd4605a8cd7e6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->