### PR TITLE
FSST and RLE early exit

### DIFF
--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
   duckdb_benchmark_micro OBJECT
   append.cpp
   append_mix.cpp
+  appender_lineitem.cpp
   bulkupdate.cpp
   cast.cpp
   in.cpp

--- a/benchmark/micro/appender_lineitem.cpp
+++ b/benchmark/micro/appender_lineitem.cpp
@@ -1,0 +1,146 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark.hpp"
+#include "duckdb/main/appender.hpp"
+
+using namespace duckdb;
+
+// Benchmarks DirectAppender ingestion of a TPC-H lineitem-inspired schema.
+// The lineitem table is the largest and most column-diverse table in TPC-H
+// (16 columns: 4×INTEGER, 4×DOUBLE, 2×VARCHAR flags, 3×INTEGER dates,
+//  1×VARCHAR shipinstruct, 1×VARCHAR shipmode, 1×VARCHAR comment).
+//
+// All variants persist to disk so checkpoint cost (including compression
+// detection) is fully exercised.  The VARCHAR columns in this schema have
+// short average lengths (1–22 bytes), making them a direct test of the
+// FSST short-string early-exit optimisation in StringFinalAnalyze.
+
+static constexpr int32_t LINEITEM_ROW_COUNT = 1000000;
+static constexpr int32_t LINEITEM_BASE_DATE = 8827; // 1994-01-01 as days since epoch
+
+static const char CREATE_LINEITEM[] =
+    "CREATE TABLE lineitem("
+    "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
+    "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
+    "l_returnflag VARCHAR, l_linestatus VARCHAR,"
+    "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
+    "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR)";
+
+static const char *const RETURNFLAGS[]     = {"A", "N", "R"};
+static const uint32_t    RETURNFLAG_LENS[] = {1, 1, 1};
+static const char *const LINESTATUS[]      = {"O", "F"};
+static const uint32_t    LINESTATUS_LENS[] = {1, 1};
+static const char *const SHIPINSTRUCT[]    = {"DELIVER IN PERSON", "COLLECT COD", "NONE", "TAKE BACK RETURN"};
+static const uint32_t    SHIPINSTRUCT_LENS[] = {17, 11, 4, 16};
+static const char *const SHIPMODE[]        = {"AIR", "AIR REG", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK"};
+static const uint32_t    SHIPMODE_LENS[]   = {3, 7, 3, 4, 4, 7, 4, 5};
+static const char        COMMENT_STR[]     = "regular annual package";
+static constexpr uint32_t COMMENT_LEN      = 22;
+
+// ---------------------------------------------------------------------------
+// Base class — shared schema, data generation, and disk persistence
+// ---------------------------------------------------------------------------
+class AppenderLineitemBenchmark : public DuckDBBenchmark {
+protected:
+	AppenderLineitemBenchmark(bool register_benchmark, const string &name)
+	    : DuckDBBenchmark(register_benchmark, name, "[appender_lineitem]") {
+	}
+
+public:
+	bool InMemory() override {
+		return false;
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		Appender appender(state->conn, "lineitem");
+		for (int32_t i = 0; i < LINEITEM_ROW_COUNT; i++) {
+			const idx_t rf = idx_t(i) % 3;
+			const idx_t ls = idx_t(i) % 2;
+			const idx_t si = idx_t(i) % 4;
+			const idx_t sm = idx_t(i) % 8;
+			appender.BeginRow();
+			appender.Append<int32_t>(i / 7 + 1);
+			appender.Append<int32_t>(i % 200000 + 1);
+			appender.Append<int32_t>(i % 10000 + 1);
+			appender.Append<int32_t>(i % 7 + 1);
+			appender.Append<double>(1.0 + double(i % 50));
+			appender.Append<double>(900.0 + double(i % 104949) * 0.01);
+			appender.Append<double>(double(i % 11) * 0.01);
+			appender.Append<double>(double(i % 9) * 0.01);
+			appender.Append<string_t>(string_t(RETURNFLAGS[rf], RETURNFLAG_LENS[rf]));
+			appender.Append<string_t>(string_t(LINESTATUS[ls], LINESTATUS_LENS[ls]));
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);
+			appender.Append<string_t>(string_t(SHIPINSTRUCT[si], SHIPINSTRUCT_LENS[si]));
+			appender.Append<string_t>(string_t(SHIPMODE[sm], SHIPMODE_LENS[sm]));
+			appender.Append<string_t>(string_t(COMMENT_STR, COMMENT_LEN));
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE lineitem");
+		Load(state);
+	}
+
+	string VerifyResult(QueryResult *result) override {
+		return string();
+	}
+
+	string BenchmarkInfo() override {
+		return "Ingest 1M rows into a 16-column TPC-H lineitem-like table using DirectAppender (persistent)";
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Variant 1: no primary key  (exercises VARCHAR compression detection —
+//            the primary target of the FSST short-string optimisation)
+// ---------------------------------------------------------------------------
+class AppenderLineitem1MBenchmark : public AppenderLineitemBenchmark {
+	AppenderLineitem1MBenchmark(bool register_benchmark)
+	    : AppenderLineitemBenchmark(register_benchmark, "AppenderLineitem1M") {
+	}
+
+public:
+	static AppenderLineitem1MBenchmark *GetInstance() {
+		static AppenderLineitem1MBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderLineitem1MBenchmark>(new AppenderLineitem1MBenchmark(false));
+		return &singleton;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(CREATE_LINEITEM);
+	}
+};
+auto global_instance_AppenderLineitem1M = AppenderLineitem1MBenchmark::GetInstance();
+
+// ---------------------------------------------------------------------------
+// Variant 2: composite primary key (l_orderkey, l_linenumber) —
+//            adds ART index maintenance on top of the compression cost
+// ---------------------------------------------------------------------------
+class AppenderLineitem1MPrimaryKeyBenchmark : public AppenderLineitemBenchmark {
+	AppenderLineitem1MPrimaryKeyBenchmark(bool register_benchmark)
+	    : AppenderLineitemBenchmark(register_benchmark, "AppenderLineitem1MPrimaryKey") {
+	}
+
+public:
+	static AppenderLineitem1MPrimaryKeyBenchmark *GetInstance() {
+		static AppenderLineitem1MPrimaryKeyBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderLineitem1MPrimaryKeyBenchmark>(
+		    new AppenderLineitem1MPrimaryKeyBenchmark(false));
+		return &singleton;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(
+		    "CREATE TABLE lineitem("
+		    "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
+		    "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
+		    "l_returnflag VARCHAR, l_linestatus VARCHAR,"
+		    "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
+		    "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR,"
+		    "PRIMARY KEY (l_orderkey, l_linenumber))");
+	}
+};
+auto global_instance_AppenderLineitem1MPrimaryKey = AppenderLineitem1MPrimaryKeyBenchmark::GetInstance();

--- a/benchmark/micro/appender_lineitem.cpp
+++ b/benchmark/micro/appender_lineitem.cpp
@@ -17,24 +17,23 @@ using namespace duckdb;
 static constexpr int32_t LINEITEM_ROW_COUNT = 1000000;
 static constexpr int32_t LINEITEM_BASE_DATE = 8827; // 1994-01-01 as days since epoch
 
-static const char CREATE_LINEITEM[] =
-    "CREATE TABLE lineitem("
-    "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
-    "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
-    "l_returnflag VARCHAR, l_linestatus VARCHAR,"
-    "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
-    "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR)";
+static const char CREATE_LINEITEM[] = "CREATE TABLE lineitem("
+                                      "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
+                                      "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
+                                      "l_returnflag VARCHAR, l_linestatus VARCHAR,"
+                                      "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
+                                      "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR)";
 
-static const char *const RETURNFLAGS[]     = {"A", "N", "R"};
-static const uint32_t    RETURNFLAG_LENS[] = {1, 1, 1};
-static const char *const LINESTATUS[]      = {"O", "F"};
-static const uint32_t    LINESTATUS_LENS[] = {1, 1};
-static const char *const SHIPINSTRUCT[]    = {"DELIVER IN PERSON", "COLLECT COD", "NONE", "TAKE BACK RETURN"};
-static const uint32_t    SHIPINSTRUCT_LENS[] = {17, 11, 4, 16};
-static const char *const SHIPMODE[]        = {"AIR", "AIR REG", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK"};
-static const uint32_t    SHIPMODE_LENS[]   = {3, 7, 3, 4, 4, 7, 4, 5};
-static const char        COMMENT_STR[]     = "regular annual package";
-static constexpr uint32_t COMMENT_LEN      = 22;
+static const char *const RETURNFLAGS[] = {"A", "N", "R"};
+static const uint32_t RETURNFLAG_LENS[] = {1, 1, 1};
+static const char *const LINESTATUS[] = {"O", "F"};
+static const uint32_t LINESTATUS_LENS[] = {1, 1};
+static const char *const SHIPINSTRUCT[] = {"DELIVER IN PERSON", "COLLECT COD", "NONE", "TAKE BACK RETURN"};
+static const uint32_t SHIPINSTRUCT_LENS[] = {17, 11, 4, 16};
+static const char *const SHIPMODE[] = {"AIR", "AIR REG", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK"};
+static const uint32_t SHIPMODE_LENS[] = {3, 7, 3, 4, 4, 7, 4, 5};
+static const char COMMENT_STR[] = "regular annual package";
+static constexpr uint32_t COMMENT_LEN = 22;
 
 // ---------------------------------------------------------------------------
 // Base class — shared schema, data generation, and disk persistence
@@ -127,20 +126,19 @@ class AppenderLineitem1MPrimaryKeyBenchmark : public AppenderLineitemBenchmark {
 public:
 	static AppenderLineitem1MPrimaryKeyBenchmark *GetInstance() {
 		static AppenderLineitem1MPrimaryKeyBenchmark singleton(true);
-		auto b = duckdb::unique_ptr<AppenderLineitem1MPrimaryKeyBenchmark>(
-		    new AppenderLineitem1MPrimaryKeyBenchmark(false));
+		auto b =
+		    duckdb::unique_ptr<AppenderLineitem1MPrimaryKeyBenchmark>(new AppenderLineitem1MPrimaryKeyBenchmark(false));
 		return &singleton;
 	}
 
 	void Load(DuckDBBenchmarkState *state) override {
-		state->conn.Query(
-		    "CREATE TABLE lineitem("
-		    "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
-		    "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
-		    "l_returnflag VARCHAR, l_linestatus VARCHAR,"
-		    "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
-		    "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR,"
-		    "PRIMARY KEY (l_orderkey, l_linenumber))");
+		state->conn.Query("CREATE TABLE lineitem("
+		                  "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
+		                  "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
+		                  "l_returnflag VARCHAR, l_linestatus VARCHAR,"
+		                  "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
+		                  "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR,"
+		                  "PRIMARY KEY (l_orderkey, l_linenumber))");
 	}
 };
 auto global_instance_AppenderLineitem1MPrimaryKey = AppenderLineitem1MPrimaryKeyBenchmark::GetInstance();

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -158,6 +158,16 @@ idx_t FSSTStorage::StringFinalAnalyze(AnalyzeState &state_p) {
 		return DConstants::INVALID_INDEX;
 	}
 
+	// FSST encodes repeated sub-string patterns using a symbol table and only yields
+	// a size benefit when strings are long enough to contain recurring byte sequences.
+	// For very short strings the symbol table overhead dominates; dictionary compression
+	// wins instead. Skip the expensive duckdb_fsst_create + duckdb_fsst_compress calls
+	// when the average sampled string length is below this threshold.
+	static constexpr size_t FSST_MIN_AVG_STRING_LENGTH = 10;
+	if (state.fsst_string_total_size / string_count < FSST_MIN_AVG_STRING_LENGTH) {
+		return DConstants::INVALID_INDEX;
+	}
+
 	size_t output_buffer_size = 7 + 2 * state.fsst_string_total_size; // size as specified in fsst.h
 
 	vector<size_t> fsst_string_sizes;

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -84,10 +84,13 @@ public:
 
 template <class T>
 struct RLEAnalyzeState : public AnalyzeState {
-	explicit RLEAnalyzeState(BlockManager &block_manager) : AnalyzeState(block_manager) {
+	explicit RLEAnalyzeState(BlockManager &block_manager) : AnalyzeState(block_manager), total_values_seen(0) {
 	}
 
 	RLEState<T> state;
+	//! Tracks how many values we have passed to the analyzer so far.
+	//! Used to check whether RLE can plausibly win before scanning all data.
+	idx_t total_values_seen;
 };
 
 template <class T>
@@ -105,6 +108,19 @@ bool RLEAnalyze(AnalyzeState &state, const Vector &input) {
 	for (idx_t i = 0; i < input.size(); i++) {
 		auto idx = vdata.sel->get_index(i);
 		rle_state.state.Update(data, vdata.validity, idx);
+	}
+	rle_state.total_values_seen += input.size();
+
+	// After seeing enough data (4 vectors = 8 192 values), check whether RLE can
+	// plausibly compress.  Each RLE entry costs sizeof(rle_count_t) + sizeof(T)
+	// bytes.  If the estimated RLE size already meets or exceeds the raw size, no
+	// amount of additional data can make RLE win — bail out early.
+	static constexpr idx_t MIN_VALUES_FOR_EARLY_EXIT = 4 * STANDARD_VECTOR_SIZE;
+	if (rle_state.total_values_seen >= MIN_VALUES_FOR_EARLY_EXIT) {
+		idx_t rle_entry_size = sizeof(rle_count_t) + sizeof(T);
+		if (rle_state.state.seen_count * rle_entry_size >= rle_state.total_values_seen * sizeof(T)) {
+			return false;
+		}
 	}
 	return true;
 }

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -111,13 +111,19 @@ bool RLEAnalyze(AnalyzeState &state, const Vector &input) {
 	}
 	rle_state.total_values_seen += input.size();
 
-	// After seeing enough data (4 vectors = 8 192 values), check whether RLE can
-	// plausibly compress.  Each RLE entry costs sizeof(rle_count_t) + sizeof(T)
-	// bytes.  If the estimated RLE size already meets or exceeds the raw size, no
-	// amount of additional data can make RLE win — bail out early.
-	static constexpr idx_t MIN_VALUES_FOR_EARLY_EXIT = 4 * STANDARD_VECTOR_SIZE;
+	// After seeing at least 25% of a typical row group, check whether continuing
+	// to analyze makes sense.  Project the current run density across the full row
+	// group: if RLE would still lose even at today's ratio, the remaining scan
+	// cannot rescue it and we exit early.
+	//
+	// Waiting for 25% of a row group (rather than just a few vectors) reduces the
+	// risk of a high-cardinality prefix causing an early exit when long runs later
+	// in the column would make RLE win.
+	static constexpr idx_t MIN_VALUES_FOR_EARLY_EXIT = DEFAULT_ROW_GROUP_SIZE / 4;
 	if (rle_state.total_values_seen >= MIN_VALUES_FOR_EARLY_EXIT) {
 		idx_t rle_entry_size = sizeof(rle_count_t) + sizeof(T);
+		// Project: if the current run density holds for the full row group, would
+		// RLE beat raw storage?
 		if (rle_state.state.seen_count * rle_entry_size >= rle_state.total_values_seen * sizeof(T)) {
 			return false;
 		}


### PR DESCRIPTION
TLDR:
- On-chip profiling shows best compression detection takes 27% CPU
- With early exit for FSST and RLE detection (>30 LOC), we could improve 6% latency under our benchmark setup

Benchmark setup
- Principle
  + Contains both string, floating point, and integer type
  + Different dataset shape (i.e., high vs low cardinality, long vs short string, floating point variance) likely display different hotspots
- For our setup, integer values are of high cardinality, which means RLE doesn't apply well
- For our setup, string values are relatively short (<30 bytes), which means FSST is expensive and likely less useful

On-chip flamegraph
<img width="3020" height="1318" alt="image" src="https://github.com/user-attachments/assets/8794b4db-225b-4ff7-ab34-95122e0361a6" />

which clearly shows compression detection is a bottleneck

In this PR, I made two changes:
- Early exit FSST if the string is too short (<10 chars); for such input, dictionary encoding is more suitable
- Early exit RLE detection when 25% of the row doesn't show advantage (i.e., for high cardinality dataset)
- These two changes achieve 6% latency improvement


| Variant | Baseline | After change | Total gain |
| --- | ---: | ---: | ---: |
| AppenderLineitem1M | 0.645s | 0.605s | −6.2% |
| AppenderLineitem1MPrimaryKey | 0.917s | 0.879s | −4.1% |
