### PR TITLE
Implement MoveUnaryMinusRule

### DIFF
--- a/src/include/duckdb/optimizer/rule/move_constants.hpp
+++ b/src/include/duckdb/optimizer/rule/move_constants.hpp
@@ -22,4 +22,13 @@ public:
 	                             bool is_root) override;
 };
 
+// The MoveUnaryMinusRule moves constants across a unary minus, e.g. -x < -5 becomes x > 5.
+class MoveUnaryMinusRule : public Rule {
+public:
+	explicit MoveUnaryMinusRule(ExpressionRewriter &rewriter);
+
+	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &changes_made,
+	                             bool is_root) override;
+};
+
 } // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -72,6 +72,7 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 	rewriter.rules.push_back(make_uniq<InEnumSimplificationRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<EqualOrNullSimplification>(rewriter));
 	rewriter.rules.push_back(make_uniq<MoveConstantsRule>(rewriter));
+	rewriter.rules.push_back(make_uniq<MoveUnaryMinusRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<LikeOptimizationRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<OrderedAggregateOptimizer>(rewriter));
 	rewriter.rules.push_back(make_uniq<DistinctAggregateOptimizer>(rewriter));

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/optimizer/rule/move_constants.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/value_operations/value_operations.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
@@ -223,7 +224,25 @@ unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<ref
 		}
 		auto width = DecimalType::GetWidth(constant_type);
 		auto scale = DecimalType::GetScale(constant_type);
-		outer_constant.GetValueMutable() = Value::DECIMAL(negated_value, width, scale);
+		switch (constant_type.InternalType()) {
+		case PhysicalType::INT16:
+			outer_constant.GetValueMutable() =
+			    Value::DECIMAL(Cast::Operation<hugeint_t, int16_t>(negated_value), width, scale);
+			break;
+		case PhysicalType::INT32:
+			outer_constant.GetValueMutable() =
+			    Value::DECIMAL(Cast::Operation<hugeint_t, int32_t>(negated_value), width, scale);
+			break;
+		case PhysicalType::INT64:
+			outer_constant.GetValueMutable() =
+			    Value::DECIMAL(Cast::Operation<hugeint_t, int64_t>(negated_value), width, scale);
+			break;
+		case PhysicalType::INT128:
+			outer_constant.GetValueMutable() = Value::DECIMAL(negated_value, width, scale);
+			break;
+		default:
+			throw InternalException("Unknown DECIMAL physical type");
+		}
 	} else {
 		// integer path
 		hugeint_t negated_value;

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -167,4 +167,83 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 	return nullptr;
 }
 
+MoveUnaryMinusRule::MoveUnaryMinusRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	auto op = make_uniq<ComparisonExpressionMatcher>();
+	op->matchers.push_back(make_uniq<ConstantExpressionMatcher>());
+	op->policy = SetMatcher::Policy::UNORDERED;
+
+	// match a unary minus over a numeric expression, e.g. [-x = -5] or [-x < -3.14]
+	auto negation = make_uniq<FunctionExpressionMatcher>();
+	negation->function = make_uniq<SpecificFunctionMatcher>("-");
+	negation->type = make_uniq<NumericTypeMatcher>();
+	negation->matchers.push_back(make_uniq<ExpressionMatcher>());
+	// ORDERED policy requires an exact child count: this only matches the unary minus
+	negation->policy = SetMatcher::Policy::ORDERED;
+	op->matchers.push_back(std::move(negation));
+	root = std::move(op);
+}
+
+unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
+                                                 bool &changes_made, bool is_root) {
+	auto &comparison = bindings[0].get().Cast<BoundFunctionExpression>();
+	auto &outer_constant = bindings[1].get().Cast<BoundConstantExpression>();
+	auto &negation = bindings[2].get().Cast<BoundFunctionExpression>();
+	if (negation.GetReturnType().IsUnsigned()) {
+		// negating an unsigned value is only valid for 0 - don't try to rewrite
+		return nullptr;
+	}
+	if (outer_constant.GetValue().IsNull()) {
+		if (comparison.GetExpressionType() == ExpressionType::COMPARE_DISTINCT_FROM ||
+		    comparison.GetExpressionType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+			return nullptr;
+		}
+		return make_uniq<BoundConstantExpression>(Value(comparison.GetReturnType()));
+	}
+	auto &constant_type = outer_constant.GetReturnType();
+	if (constant_type.IsFloating()) {
+		// IEEE 754 negation is exact (sign-bit flip), safe for FLOAT and DOUBLE
+		double val = DoubleValue::Get(outer_constant.GetValue());
+		auto result_value = Value::DOUBLE(-val);
+		if (!result_value.DefaultTryCastAs(constant_type)) {
+			return nullptr;
+		}
+		outer_constant.GetValueMutable() = std::move(result_value);
+	} else if (constant_type.id() == LogicalTypeId::DECIMAL) {
+		// negate the unscaled integer and reconstruct with the same width/scale
+		hugeint_t negated_value;
+		if (!Hugeint::TryNegate(IntegralValue::Get(outer_constant.GetValue()), negated_value)) {
+			return nullptr;
+		}
+		auto width = DecimalType::GetWidth(constant_type);
+		auto scale = DecimalType::GetScale(constant_type);
+		outer_constant.GetValueMutable() = Value::DECIMAL(negated_value, width, scale);
+	} else {
+		// integer path
+		hugeint_t negated_value;
+		if (!Hugeint::TryNegate(IntegralValue::Get(outer_constant.GetValue()), negated_value)) {
+			return nullptr;
+		}
+		auto result_value = Value::HUGEINT(negated_value);
+		if (!result_value.DefaultTryCastAs(constant_type)) {
+			if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+				return nullptr;
+			}
+			// the negated constant is out of range, e.g. [-x = -128] for TINYINT: the comparison can never be true
+			return ExpressionRewriter::ConstantOrNull(std::move(negation.GetChildrenMutable()[0]),
+			                                          Value::BOOLEAN(false));
+		}
+		outer_constant.GetValueMutable() = std::move(result_value);
+	}
+	// [-x COMP c] => [x FLIPPED_COMP -c]
+	auto inner_expr = std::move(negation.GetChildrenMutable()[0]);
+	if (RefersToSameObject(BoundComparisonExpression::Left(comparison), negation)) {
+		BoundComparisonExpression::LeftMutable(comparison) = std::move(inner_expr);
+	} else {
+		BoundComparisonExpression::RightMutable(comparison) = std::move(inner_expr);
+	}
+	BoundComparisonExpression::FlipType(comparison);
+	changes_made = true;
+	return nullptr;
+}
+
 } // namespace duckdb

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -187,10 +187,13 @@ unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<ref
 	auto &comparison = bindings[0].get().Cast<BoundFunctionExpression>();
 	auto &outer_constant = bindings[1].get().Cast<BoundConstantExpression>();
 	auto &negation = bindings[2].get().Cast<BoundFunctionExpression>();
+
+	// Unsigned values cannot be negated
 	if (negation.GetReturnType().IsUnsigned()) {
-		// negating an unsigned value is only valid for 0 - don't try to rewrite
 		return nullptr;
 	}
+
+	// Handle NULL values
 	if (outer_constant.GetValue().IsNull()) {
 		if (comparison.GetExpressionType() == ExpressionType::COMPARE_DISTINCT_FROM ||
 		    comparison.GetExpressionType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
@@ -198,6 +201,7 @@ unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<ref
 		}
 		return make_uniq<BoundConstantExpression>(Value(comparison.GetReturnType()));
 	}
+
 	auto &constant_type = outer_constant.GetReturnType();
 	if (constant_type.IsFloating()) {
 		double val = 0.0;

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -177,7 +177,6 @@ MoveUnaryMinusRule::MoveUnaryMinusRule(ExpressionRewriter &rewriter) : Rule(rewr
 	negation->function = make_uniq<SpecificFunctionMatcher>("-");
 	negation->type = make_uniq<NumericTypeMatcher>();
 	negation->matchers.push_back(make_uniq<ExpressionMatcher>());
-	// ORDERED policy requires an exact child count: this only matches the unary minus
 	negation->policy = SetMatcher::Policy::ORDERED;
 	op->matchers.push_back(std::move(negation));
 	root = std::move(op);
@@ -201,8 +200,12 @@ unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<ref
 	}
 	auto &constant_type = outer_constant.GetReturnType();
 	if (constant_type.IsFloating()) {
-		// IEEE 754 negation is exact (sign-bit flip), safe for FLOAT and DOUBLE
-		double val = DoubleValue::Get(outer_constant.GetValue());
+		double val = 0.0;
+		if (constant_type.id() == LogicalTypeId::FLOAT) {
+			val = static_cast<double>(FloatValue::Get(outer_constant.GetValue()));
+		} else {
+			val = DoubleValue::Get(outer_constant.GetValue());
+		}
 		auto result_value = Value::DOUBLE(-val);
 		if (!result_value.DefaultTryCastAs(constant_type)) {
 			return nullptr;

--- a/test/optimizer/move_constants.test
+++ b/test/optimizer/move_constants.test
@@ -106,9 +106,6 @@ query I nosort mult_left_negative_flip
 EXPLAIN SELECT X>5 FROM test
 ----
 
-mode skip instable
-
-# FIXME
 # negation
 query I nosort negation
 EXPLAIN SELECT -X=-5 FROM test
@@ -125,3 +122,134 @@ EXPLAIN SELECT -X<-5 FROM test
 query I nosort negation_flip
 EXPLAIN SELECT X>5 FROM test
 ----
+
+# negation with the constant on the left
+query I nosort negation_flip_left
+EXPLAIN SELECT -5>-X FROM test
+----
+
+query I nosort negation_flip_left
+EXPLAIN SELECT 5<X FROM test
+----
+
+# negated constant out of range: equality can never be true
+statement ok
+CREATE TABLE tiny(x TINYINT);
+
+statement ok
+INSERT INTO tiny VALUES (-127), (-1), (0), (5), (127), (NULL);
+
+query I
+SELECT count(*) FROM tiny WHERE -x = -128
+----
+0
+
+query I
+SELECT count(*) FROM tiny WHERE -x = 127
+----
+1
+
+# NULL constant
+query I
+SELECT count(*) FROM tiny WHERE -x = NULL::TINYINT
+----
+0
+
+# nested negation
+query I
+SELECT count(*) FROM tiny WHERE -(-x) = 5
+----
+1
+
+query I
+SELECT count(*) FROM tiny WHERE -x > -2
+----
+3
+
+# floating-point negation
+statement ok
+CREATE TABLE floats(x DOUBLE);
+
+statement ok
+INSERT INTO floats VALUES (-3.14), (-1.0), (0.0), (2.5), (7.7), (NULL);
+
+query I nosort float_neg_eq
+EXPLAIN SELECT -x = -2.5 FROM floats
+----
+
+query I nosort float_neg_eq
+EXPLAIN SELECT x = 2.5 FROM floats
+----
+
+query I nosort float_neg_lt
+EXPLAIN SELECT -x < -2.5 FROM floats
+----
+
+query I nosort float_neg_lt
+EXPLAIN SELECT x > 2.5 FROM floats
+----
+
+query I nosort float_neg_left
+EXPLAIN SELECT -2.5 > -x FROM floats
+----
+
+query I nosort float_neg_left
+EXPLAIN SELECT 2.5 < x FROM floats
+----
+
+query I
+SELECT count(*) FROM floats WHERE -x = -2.5
+----
+1
+
+query I
+SELECT count(*) FROM floats WHERE -x < -2.5
+----
+1
+
+query I
+SELECT count(*) FROM floats WHERE -x > 1.0
+----
+1
+
+# FLOAT type
+statement ok
+CREATE TABLE floats32(x FLOAT);
+
+statement ok
+INSERT INTO floats32 VALUES (-1.0), (0.0), (3.5), (NULL);
+
+query I
+SELECT count(*) FROM floats32 WHERE -x = -3.5
+----
+1
+
+query I
+SELECT count(*) FROM floats32 WHERE -x < 0.0
+----
+1
+
+# DECIMAL negation
+statement ok
+CREATE TABLE decimals(x DECIMAL(9,2));
+
+statement ok
+INSERT INTO decimals VALUES (-10.50), (0.00), (5.25), (99.99), (NULL);
+
+query I nosort decimal_neg
+EXPLAIN SELECT -x = -5.25 FROM decimals
+----
+
+query I nosort decimal_neg
+EXPLAIN SELECT x = 5.25 FROM decimals
+----
+
+query I
+SELECT count(*) FROM decimals WHERE -x = -5.25
+----
+1
+
+query I
+SELECT count(*) FROM decimals WHERE -x < -5.25
+----
+1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes filter predicate shapes in the query optimizer; incorrect rewrites could affect correctness of WHERE clauses, though behavior is heavily tested and scoped to unary minus comparisons.
> 
> **Overview**
> Adds **`MoveUnaryMinusRule`** to the expression rewriter so predicates like `-x = -5` or `-x < -3.14` rewrite to `x = 5` and `x > 5` (constant negated, comparison flipped). The rule is registered in the optimizer immediately after `MoveConstantsRule`.
> 
> **Apply** handles numeric types (integers, float/double, decimal), skips unsigned negation, folds NULL comparisons (except `IS DISTINCT FROM` / `IS NOT DISTINCT FROM`), and when negating the constant would overflow the type on equality (e.g. `-x = -128` on `TINYINT`), rewrites to `ConstantOrNull(..., false)`.
> 
> **Tests:** Removes the unstable skip around negation `EXPLAIN` checks and adds coverage for left-hand constants, out-of-range equality, NULL, nested `-(-x)`, and float/`FLOAT`/decimal execution and plans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c931e39f561a4ffa4420694ed61e3fbd18c9e5f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->