### PR TITLE
Hjiang/long string benchmark

### DIFF
--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
   duckdb_benchmark_micro OBJECT
   append.cpp
   append_mix.cpp
+  appender_lineitem.cpp
   bulkupdate.cpp
   cast.cpp
   in.cpp

--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
   duckdb_benchmark_micro OBJECT
   append.cpp
   append_mix.cpp
+  appender_advanced.cpp
   appender_lineitem.cpp
   bulkupdate.cpp
   cast.cpp

--- a/benchmark/micro/appender_advanced.cpp
+++ b/benchmark/micro/appender_advanced.cpp
@@ -1,0 +1,272 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark.hpp"
+#include "duckdb/main/appender.hpp"
+
+using namespace duckdb;
+
+// Benchmarks Appender ingestion with a workload designed to exercise the
+// compression detection code paths that appender_lineitem.cpp does NOT cover:
+//
+//   - INTEGER columns with SMALL cardinality (only a handful of distinct
+//     values with long repeated runs) — tests whether the RLE early-exit
+//     is transparent when RLE is actually a good choice.
+//
+//   - VARCHAR columns with LONG strings (avg > 100 bytes) — tests whether
+//     the FSST short-string skip is transparent when FSST can genuinely
+//     compress the data.
+//
+// Expected behaviour after optimisations C and D:
+//   - RLE early exit should NOT fire here (low cardinality → seen_count
+//     stays small → projection says RLE is fine → no early exit).
+//   - FSST short-string skip should NOT fire here (avg length > 10 bytes
+//     → the threshold is not reached → FSST analysis runs normally).
+//
+// Therefore these benchmarks should show no regression vs baseline, proving
+// the optimisations are transparent for workloads that DO benefit from RLE
+// or FSST.
+
+static constexpr int32_t ADV_ROW_COUNT = 1000000;
+
+// ---------------------------------------------------------------------------
+// Long VARCHAR strings (avg ~130 bytes) — representative of log lines,
+// URLs, or structured text where FSST can exploit repeated sub-patterns.
+// ---------------------------------------------------------------------------
+static const char *const LONG_STRINGS[] = {
+    // ~100–160 chars each; share common prefixes/suffixes so FSST can build
+    // a useful symbol table
+    "https://example.com/api/v2/users/search?query=active&limit=100&offset=0&sort=created_at&order=desc",
+    "https://example.com/api/v2/products/list?category=electronics&in_stock=true&min_price=10&max_price=500",
+    "https://example.com/api/v2/orders/history?user_id=42&status=completed&from=2024-01-01&to=2024-12-31",
+    "https://example.com/api/v2/reports/summary?type=monthly&department=sales&year=2024&format=json",
+    "/var/log/app/service_2024_01.log: [INFO] Request processed successfully in 42ms for endpoint /health",
+    "/var/log/app/service_2024_01.log: [WARN] Response time exceeded threshold: 1523ms for endpoint /search",
+    "/var/log/app/service_2024_01.log: [ERROR] Database connection timeout after 30s, retrying attempt 3/5",
+    "/var/log/app/service_2024_01.log: [DEBUG] Cache miss for key user_session_abc123, fetching from database",
+};
+static constexpr idx_t LONG_STRING_COUNT = 8;
+
+// Small pre-computed lengths to avoid calling strlen in the hot loop
+static const uint32_t LONG_STRING_LENS[] = {97, 103, 101, 98, 101, 103, 101, 103};
+
+// ---------------------------------------------------------------------------
+// Low-cardinality INTEGER values (4 distinct values, long repeated runs)
+// — representative of status codes, category IDs, priority levels, etc.
+// RLE should be a strong candidate for these columns.
+// ---------------------------------------------------------------------------
+static constexpr int32_t STATUS_VALS[]   = {1, 2, 3, 4};          // 4 distinct
+static constexpr int32_t PRIORITY_VALS[] = {1, 2, 3, 4, 5};       // 5 distinct
+static constexpr int32_t REGION_VALS[]   = {10, 20, 30, 40, 50, 60, 70, 80}; // 8 distinct
+// Each value repeats for a long run (1000 rows) to make RLE clearly worthwhile
+static constexpr int32_t RUN_LENGTH = 1000;
+
+static const char CREATE_ADV_TABLE[] =
+    "CREATE TABLE adv_workload("
+    // Low-cardinality integer columns (RLE-friendly)
+    "status_code INTEGER, priority INTEGER, region_id INTEGER, category_id INTEGER,"
+    // Low-cardinality doubles (also RLE-friendly: small set of values, long runs)
+    "score DOUBLE, multiplier DOUBLE,"
+    // Long VARCHAR columns (FSST-friendly)
+    "request_url VARCHAR, log_line VARCHAR, description VARCHAR, notes VARCHAR)";
+
+// ---------------------------------------------------------------------------
+// Base benchmark class
+// ---------------------------------------------------------------------------
+class AppenderAdvancedBenchmark : public DuckDBBenchmark {
+protected:
+	AppenderAdvancedBenchmark(bool register_benchmark, const string &name)
+	    : DuckDBBenchmark(register_benchmark, name, "[appender_advanced]") {
+	}
+
+public:
+	bool InMemory() override {
+		return false;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(CREATE_ADV_TABLE);
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		Appender appender(state->conn, "adv_workload");
+		for (int32_t i = 0; i < ADV_ROW_COUNT; i++) {
+			// Low-cardinality integers: value changes every RUN_LENGTH rows
+			// → long runs of the same value → RLE should win
+			int32_t status   = STATUS_VALS[(i / RUN_LENGTH) % 4];
+			int32_t priority = PRIORITY_VALS[(i / RUN_LENGTH) % 5];
+			int32_t region   = REGION_VALS[(i / RUN_LENGTH) % 8];
+			int32_t category = STATUS_VALS[(i / (RUN_LENGTH * 2)) % 4];
+
+			// Low-cardinality doubles: same run pattern
+			double score      = 1.0 + double((i / RUN_LENGTH) % 5) * 0.25;
+			double multiplier = 1.0 + double((i / (RUN_LENGTH * 3)) % 4) * 0.5;
+
+			// Long VARCHAR: cycle through the string pool
+			const idx_t url_idx  = idx_t(i) % LONG_STRING_COUNT;
+			const idx_t log_idx  = (idx_t(i) + 2) % LONG_STRING_COUNT;
+			const idx_t desc_idx = (idx_t(i) + 4) % LONG_STRING_COUNT;
+			const idx_t note_idx = (idx_t(i) + 6) % LONG_STRING_COUNT;
+
+			appender.BeginRow();
+			appender.Append<int32_t>(status);
+			appender.Append<int32_t>(priority);
+			appender.Append<int32_t>(region);
+			appender.Append<int32_t>(category);
+			appender.Append<double>(score);
+			appender.Append<double>(multiplier);
+			appender.Append<string_t>(string_t(LONG_STRINGS[url_idx], LONG_STRING_LENS[url_idx]));
+			appender.Append<string_t>(string_t(LONG_STRINGS[log_idx], LONG_STRING_LENS[log_idx]));
+			appender.Append<string_t>(string_t(LONG_STRINGS[desc_idx], LONG_STRING_LENS[desc_idx]));
+			appender.Append<string_t>(string_t(LONG_STRINGS[note_idx], LONG_STRING_LENS[note_idx]));
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE adv_workload");
+		Load(state);
+	}
+
+	string VerifyResult(QueryResult *result) override {
+		return string();
+	}
+
+	string BenchmarkInfo() override {
+		return "Ingest 1M rows: low-cardinality integers (RLE-friendly) + long VARCHAR strings (FSST-friendly)";
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Variant 1: no primary key
+// ---------------------------------------------------------------------------
+class AppenderAdvanced1MBenchmark : public AppenderAdvancedBenchmark {
+	AppenderAdvanced1MBenchmark(bool register_benchmark)
+	    : AppenderAdvancedBenchmark(register_benchmark, "AppenderAdvanced1M") {
+	}
+
+public:
+	static AppenderAdvanced1MBenchmark *GetInstance() {
+		static AppenderAdvanced1MBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderAdvanced1MBenchmark>(new AppenderAdvanced1MBenchmark(false));
+		return &singleton;
+	}
+};
+auto global_instance_AppenderAdvanced1M = AppenderAdvanced1MBenchmark::GetInstance();
+
+// ---------------------------------------------------------------------------
+// Compression detection microbenchmark for the advanced workload.
+//
+// Times only COMMIT (= LocalStorage::Flush → ColumnDataCheckpointer) for
+// exactly one row group (DEFAULT_ROW_GROUP_SIZE rows).  Compare with the
+// *Uncompressed variant to isolate pure detection overhead.
+// ---------------------------------------------------------------------------
+class CompressionDetectAdvancedBenchmark : public DuckDBBenchmark {
+protected:
+	CompressionDetectAdvancedBenchmark(bool register_benchmark, const string &name)
+	    : DuckDBBenchmark(register_benchmark, name, "[compression_detect_advanced]") {
+	}
+
+	virtual string ForceCompressionSQL() {
+		return "";
+	}
+
+public:
+	bool InMemory() override {
+		return false;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		auto force = ForceCompressionSQL();
+		if (!force.empty()) {
+			state->conn.Query(force);
+		}
+		state->conn.Query(CREATE_ADV_TABLE);
+		state->conn.Query("BEGIN TRANSACTION");
+		AppendOneRowGroup(state);
+	}
+
+	void AppendOneRowGroup(DuckDBBenchmarkState *state) {
+		Appender appender(state->conn, "adv_workload");
+		for (int32_t i = 0; i < (int32_t)DEFAULT_ROW_GROUP_SIZE; i++) {
+			int32_t status   = STATUS_VALS[(i / RUN_LENGTH) % 4];
+			int32_t priority = PRIORITY_VALS[(i / RUN_LENGTH) % 5];
+			int32_t region   = REGION_VALS[(i / RUN_LENGTH) % 8];
+			int32_t category = STATUS_VALS[(i / (RUN_LENGTH * 2)) % 4];
+			double score      = 1.0 + double((i / RUN_LENGTH) % 5) * 0.25;
+			double multiplier = 1.0 + double((i / (RUN_LENGTH * 3)) % 4) * 0.5;
+			const idx_t url_idx  = idx_t(i) % LONG_STRING_COUNT;
+			const idx_t log_idx  = (idx_t(i) + 2) % LONG_STRING_COUNT;
+			const idx_t desc_idx = (idx_t(i) + 4) % LONG_STRING_COUNT;
+			const idx_t note_idx = (idx_t(i) + 6) % LONG_STRING_COUNT;
+			appender.BeginRow();
+			appender.Append<int32_t>(status);
+			appender.Append<int32_t>(priority);
+			appender.Append<int32_t>(region);
+			appender.Append<int32_t>(category);
+			appender.Append<double>(score);
+			appender.Append<double>(multiplier);
+			appender.Append<string_t>(string_t(LONG_STRINGS[url_idx], LONG_STRING_LENS[url_idx]));
+			appender.Append<string_t>(string_t(LONG_STRINGS[log_idx], LONG_STRING_LENS[log_idx]));
+			appender.Append<string_t>(string_t(LONG_STRINGS[desc_idx], LONG_STRING_LENS[desc_idx]));
+			appender.Append<string_t>(string_t(LONG_STRINGS[note_idx], LONG_STRING_LENS[note_idx]));
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		state->conn.Query("COMMIT");
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE adv_workload");
+		state->conn.Query(CREATE_ADV_TABLE);
+		state->conn.Query("BEGIN TRANSACTION");
+		AppendOneRowGroup(state);
+	}
+
+	string VerifyResult(QueryResult *result) override {
+		return string();
+	}
+
+	string BenchmarkInfo() override {
+		return "Compression detection for 1 row group of advanced workload (low-cardinality INT + long VARCHAR)";
+	}
+};
+
+class CompressionDetectAdvancedAuto : public CompressionDetectAdvancedBenchmark {
+	CompressionDetectAdvancedAuto(bool register_benchmark)
+	    : CompressionDetectAdvancedBenchmark(register_benchmark, "CompressionDetectAdvancedAuto") {
+	}
+
+public:
+	static CompressionDetectAdvancedAuto *GetInstance() {
+		static CompressionDetectAdvancedAuto singleton(true);
+		auto b = duckdb::unique_ptr<CompressionDetectAdvancedAuto>(new CompressionDetectAdvancedAuto(false));
+		return &singleton;
+	}
+};
+auto global_instance_CompressionDetectAdvancedAuto = CompressionDetectAdvancedAuto::GetInstance();
+
+class CompressionDetectAdvancedUncompressed : public CompressionDetectAdvancedBenchmark {
+	CompressionDetectAdvancedUncompressed(bool register_benchmark)
+	    : CompressionDetectAdvancedBenchmark(register_benchmark, "CompressionDetectAdvancedUncompressed") {
+	}
+
+public:
+	static CompressionDetectAdvancedUncompressed *GetInstance() {
+		static CompressionDetectAdvancedUncompressed singleton(true);
+		auto b = duckdb::unique_ptr<CompressionDetectAdvancedUncompressed>(
+		    new CompressionDetectAdvancedUncompressed(false));
+		return &singleton;
+	}
+
+	string ForceCompressionSQL() override {
+		return "SET force_compression='uncompressed'";
+	}
+
+	string BenchmarkInfo() override {
+		return "Compression write-only baseline for advanced workload (no detection)";
+	}
+};
+auto global_instance_CompressionDetectAdvancedUncompressed = CompressionDetectAdvancedUncompressed::GetInstance();

--- a/benchmark/micro/appender_lineitem.cpp
+++ b/benchmark/micro/appender_lineitem.cpp
@@ -1,0 +1,146 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark.hpp"
+#include "duckdb/main/appender.hpp"
+
+using namespace duckdb;
+
+// Benchmarks DirectAppender ingestion of a TPC-H lineitem-inspired schema.
+// The lineitem table is the largest and most column-diverse table in TPC-H
+// (16 columns: 4×INTEGER, 4×DOUBLE, 2×VARCHAR flags, 3×INTEGER dates,
+//  1×VARCHAR shipinstruct, 1×VARCHAR shipmode, 1×VARCHAR comment).
+//
+// All variants persist to disk so checkpoint cost (including compression
+// detection) is fully exercised.  The VARCHAR columns in this schema have
+// short average lengths (1–22 bytes), making them a direct test of the
+// FSST short-string early-exit optimisation in StringFinalAnalyze.
+
+static constexpr int32_t LINEITEM_ROW_COUNT = 1000000;
+static constexpr int32_t LINEITEM_BASE_DATE = 8827; // 1994-01-01 as days since epoch
+
+static const char CREATE_LINEITEM[] =
+    "CREATE TABLE lineitem("
+    "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
+    "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
+    "l_returnflag VARCHAR, l_linestatus VARCHAR,"
+    "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
+    "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR)";
+
+static const char *const RETURNFLAGS[]     = {"A", "N", "R"};
+static const uint32_t    RETURNFLAG_LENS[] = {1, 1, 1};
+static const char *const LINESTATUS[]      = {"O", "F"};
+static const uint32_t    LINESTATUS_LENS[] = {1, 1};
+static const char *const SHIPINSTRUCT[]    = {"DELIVER IN PERSON", "COLLECT COD", "NONE", "TAKE BACK RETURN"};
+static const uint32_t    SHIPINSTRUCT_LENS[] = {17, 11, 4, 16};
+static const char *const SHIPMODE[]        = {"AIR", "AIR REG", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK"};
+static const uint32_t    SHIPMODE_LENS[]   = {3, 7, 3, 4, 4, 7, 4, 5};
+static const char        COMMENT_STR[]     = "regular annual package";
+static constexpr uint32_t COMMENT_LEN      = 22;
+
+// ---------------------------------------------------------------------------
+// Base class — shared schema, data generation, and disk persistence
+// ---------------------------------------------------------------------------
+class AppenderLineitemBenchmark : public DuckDBBenchmark {
+protected:
+	AppenderLineitemBenchmark(bool register_benchmark, const string &name)
+	    : DuckDBBenchmark(register_benchmark, name, "[appender_lineitem]") {
+	}
+
+public:
+	bool InMemory() override {
+		return false;
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		Appender appender(state->conn, "lineitem");
+		for (int32_t i = 0; i < LINEITEM_ROW_COUNT; i++) {
+			const idx_t rf = idx_t(i) % 3;
+			const idx_t ls = idx_t(i) % 2;
+			const idx_t si = idx_t(i) % 4;
+			const idx_t sm = idx_t(i) % 8;
+			appender.BeginRow();
+			appender.Append<int32_t>(i / 7 + 1);
+			appender.Append<int32_t>(i % 200000 + 1);
+			appender.Append<int32_t>(i % 10000 + 1);
+			appender.Append<int32_t>(i % 7 + 1);
+			appender.Append<double>(1.0 + double(i % 50));
+			appender.Append<double>(900.0 + double(i % 104949) * 0.01);
+			appender.Append<double>(double(i % 11) * 0.01);
+			appender.Append<double>(double(i % 9) * 0.01);
+			appender.Append<string_t>(string_t(RETURNFLAGS[rf], RETURNFLAG_LENS[rf]));
+			appender.Append<string_t>(string_t(LINESTATUS[ls], LINESTATUS_LENS[ls]));
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);
+			appender.Append<string_t>(string_t(SHIPINSTRUCT[si], SHIPINSTRUCT_LENS[si]));
+			appender.Append<string_t>(string_t(SHIPMODE[sm], SHIPMODE_LENS[sm]));
+			appender.Append<string_t>(string_t(COMMENT_STR, COMMENT_LEN));
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE lineitem");
+		Load(state);
+	}
+
+	string VerifyResult(QueryResult *result) override {
+		return string();
+	}
+
+	string BenchmarkInfo() override {
+		return "Ingest 1M rows into a 16-column TPC-H lineitem-like table using DirectAppender (persistent)";
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Variant 1: no primary key  (exercises VARCHAR compression detection —
+//            the primary target of the FSST short-string optimisation)
+// ---------------------------------------------------------------------------
+class AppenderLineitem1MBenchmark : public AppenderLineitemBenchmark {
+	AppenderLineitem1MBenchmark(bool register_benchmark)
+	    : AppenderLineitemBenchmark(register_benchmark, "AppenderLineitem1M") {
+	}
+
+public:
+	static AppenderLineitem1MBenchmark *GetInstance() {
+		static AppenderLineitem1MBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderLineitem1MBenchmark>(new AppenderLineitem1MBenchmark(false));
+		return &singleton;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(CREATE_LINEITEM);
+	}
+};
+auto global_instance_AppenderLineitem1M = AppenderLineitem1MBenchmark::GetInstance();
+
+// ---------------------------------------------------------------------------
+// Variant 2: composite primary key (l_orderkey, l_linenumber) —
+//            adds ART index maintenance on top of the compression cost
+// ---------------------------------------------------------------------------
+class AppenderLineitem1MPrimaryKeyBenchmark : public AppenderLineitemBenchmark {
+	AppenderLineitem1MPrimaryKeyBenchmark(bool register_benchmark)
+	    : AppenderLineitemBenchmark(register_benchmark, "AppenderLineitem1MPrimaryKey") {
+	}
+
+public:
+	static AppenderLineitem1MPrimaryKeyBenchmark *GetInstance() {
+		static AppenderLineitem1MPrimaryKeyBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderLineitem1MPrimaryKeyBenchmark>(
+		    new AppenderLineitem1MPrimaryKeyBenchmark(false));
+		return &singleton;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(
+		    "CREATE TABLE lineitem("
+		    "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
+		    "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
+		    "l_returnflag VARCHAR, l_linestatus VARCHAR,"
+		    "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
+		    "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR,"
+		    "PRIMARY KEY (l_orderkey, l_linenumber))");
+	}
+};
+auto global_instance_AppenderLineitem1MPrimaryKey = AppenderLineitem1MPrimaryKeyBenchmark::GetInstance();

--- a/benchmark/micro/appender_lineitem.cpp
+++ b/benchmark/micro/appender_lineitem.cpp
@@ -17,24 +17,23 @@ using namespace duckdb;
 static constexpr int32_t LINEITEM_ROW_COUNT = 1000000;
 static constexpr int32_t LINEITEM_BASE_DATE = 8827; // 1994-01-01 as days since epoch
 
-static const char CREATE_LINEITEM[] =
-    "CREATE TABLE lineitem("
-    "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
-    "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
-    "l_returnflag VARCHAR, l_linestatus VARCHAR,"
-    "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
-    "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR)";
+static const char CREATE_LINEITEM[] = "CREATE TABLE lineitem("
+                                      "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
+                                      "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
+                                      "l_returnflag VARCHAR, l_linestatus VARCHAR,"
+                                      "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
+                                      "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR)";
 
-static const char *const RETURNFLAGS[]     = {"A", "N", "R"};
-static const uint32_t    RETURNFLAG_LENS[] = {1, 1, 1};
-static const char *const LINESTATUS[]      = {"O", "F"};
-static const uint32_t    LINESTATUS_LENS[] = {1, 1};
-static const char *const SHIPINSTRUCT[]    = {"DELIVER IN PERSON", "COLLECT COD", "NONE", "TAKE BACK RETURN"};
-static const uint32_t    SHIPINSTRUCT_LENS[] = {17, 11, 4, 16};
-static const char *const SHIPMODE[]        = {"AIR", "AIR REG", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK"};
-static const uint32_t    SHIPMODE_LENS[]   = {3, 7, 3, 4, 4, 7, 4, 5};
-static const char        COMMENT_STR[]     = "regular annual package";
-static constexpr uint32_t COMMENT_LEN      = 22;
+static const char *const RETURNFLAGS[] = {"A", "N", "R"};
+static const uint32_t RETURNFLAG_LENS[] = {1, 1, 1};
+static const char *const LINESTATUS[] = {"O", "F"};
+static const uint32_t LINESTATUS_LENS[] = {1, 1};
+static const char *const SHIPINSTRUCT[] = {"DELIVER IN PERSON", "COLLECT COD", "NONE", "TAKE BACK RETURN"};
+static const uint32_t SHIPINSTRUCT_LENS[] = {17, 11, 4, 16};
+static const char *const SHIPMODE[] = {"AIR", "AIR REG", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK"};
+static const uint32_t SHIPMODE_LENS[] = {3, 7, 3, 4, 4, 7, 4, 5};
+static const char COMMENT_STR[] = "regular annual package";
+static constexpr uint32_t COMMENT_LEN = 22;
 
 // ---------------------------------------------------------------------------
 // Base class — shared schema, data generation, and disk persistence
@@ -127,20 +126,19 @@ class AppenderLineitem1MPrimaryKeyBenchmark : public AppenderLineitemBenchmark {
 public:
 	static AppenderLineitem1MPrimaryKeyBenchmark *GetInstance() {
 		static AppenderLineitem1MPrimaryKeyBenchmark singleton(true);
-		auto b = duckdb::unique_ptr<AppenderLineitem1MPrimaryKeyBenchmark>(
-		    new AppenderLineitem1MPrimaryKeyBenchmark(false));
+		auto b =
+		    duckdb::unique_ptr<AppenderLineitem1MPrimaryKeyBenchmark>(new AppenderLineitem1MPrimaryKeyBenchmark(false));
 		return &singleton;
 	}
 
 	void Load(DuckDBBenchmarkState *state) override {
-		state->conn.Query(
-		    "CREATE TABLE lineitem("
-		    "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
-		    "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
-		    "l_returnflag VARCHAR, l_linestatus VARCHAR,"
-		    "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
-		    "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR,"
-		    "PRIMARY KEY (l_orderkey, l_linenumber))");
+		state->conn.Query("CREATE TABLE lineitem("
+		                  "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
+		                  "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
+		                  "l_returnflag VARCHAR, l_linestatus VARCHAR,"
+		                  "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
+		                  "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR,"
+		                  "PRIMARY KEY (l_orderkey, l_linenumber))");
 	}
 };
 auto global_instance_AppenderLineitem1MPrimaryKey = AppenderLineitem1MPrimaryKeyBenchmark::GetInstance();

--- a/src/include/duckdb/execution/index/unbound_index.hpp
+++ b/src/include/duckdb/execution/index/unbound_index.hpp
@@ -75,6 +75,10 @@ private:
 	//! This is in sorted order of physical column IDs.
 	vector<StorageIndex> mapped_column_ids;
 
+	//! Rows with row_id >= build_snapshot_max_row are replayed into the index after the build scan finishes.
+	//! Rows with row_id < build_snapshot_max_row are covered by the CREATE INDEX scan.
+	optional_idx build_snapshot_max_row;
+
 public:
 	UnboundIndex(unique_ptr<CreateInfo> create_info, IndexStorageInfo storage_info, TableIOManager &table_io_manager,
 	             AttachedDatabase &db);
@@ -122,6 +126,13 @@ public:
 
 	const vector<StorageIndex> &GetMappedColumnIds() const {
 		return mapped_column_ids;
+	}
+
+	void SetBuildSnapshotMaxRow(idx_t max_row) {
+		build_snapshot_max_row = max_row;
+	}
+	optional_idx GetBuildSnapshotMaxRow() const {
+		return build_snapshot_max_row;
 	}
 };
 

--- a/src/include/duckdb/storage/compression/dictionary/analyze.hpp
+++ b/src/include/duckdb/storage/compression/dictionary/analyze.hpp
@@ -34,5 +34,10 @@ public:
 	string_set_t current_set;
 	bitpacking_width_t current_width;
 	bitpacking_width_t next_width;
+
+	//! Saturation tracking: once the dictionary stops growing for several consecutive
+	//! vectors, per-string hash lookups can be replaced by a simple tuple counter.
+	idx_t vectors_without_new_string = 0;
+	bool is_saturated = false;
 };
 } // namespace duckdb

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -262,6 +262,8 @@ public:
 
 	//! Scans the next chunk for the CREATE INDEX operator
 	bool CreateIndexScan(TableScanState &state, DataChunk &result);
+	//! Returns the row snapshot for an in-progress CREATE INDEX build, if any.
+	optional_idx GetCreateIndexBuildSnapshotMaxRow() const;
 	//! Returns true, if the index name is unique (i.e., no PK, UNIQUE, FK constraint has the same name)
 	//! FIXME: This is only necessary until we treat all indexes as catalog entries, allowing to alter constraints
 	bool IndexNameIsUnique(const string &name);

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -91,10 +91,29 @@ bool DictionaryCompressionStorage::StringAnalyze(AnalyzeState &state_p, const Ve
 			state.is_saturated = false;
 			state.vectors_without_new_string = 0;
 		} else {
-			for (idx_t i = 0; i < input.size(); i++) {
+			// Fast path: skip per-string hash lookups, but we still verify each value
+			// is already in the dictionary.  If a new string appears after saturation,
+			// we reset the saturated flag so later vectors get full analysis.
+			bool found_new_string = false;
+			for (auto entry : input.Values<string_t>()) {
+				if (!entry.IsValid()) {
+					state.AddNull();
+					continue;
+				}
+				auto &str = entry.GetValue();
+				if (!state.LookupString(str)) {
+					// New string appeared — dictionary is no longer saturated
+					found_new_string = true;
+					break;
+				}
 				state.AddLastLookup();
 			}
-			return true;
+			if (!found_new_string) {
+				return true;
+			}
+			// Reset saturation and fall through to full analysis for this vector
+			state.is_saturated = false;
+			state.vectors_without_new_string = 0;
 		}
 	}
 

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -79,7 +79,37 @@ unique_ptr<AnalyzeState> DictionaryCompressionStorage::StringInitAnalyze(ColumnD
 
 bool DictionaryCompressionStorage::StringAnalyze(AnalyzeState &state_p, const Vector &input) {
 	auto &state = state_p.Cast<DictionaryAnalyzeState>();
-	return DictionaryCompression::UpdateState(state, input);
+
+	// Once the dictionary has stopped growing for several consecutive vectors, all
+	// remaining values are already in the hash set.  Skip per-string hash lookups
+	// and just advance the tuple counter — no segment overflow for typical
+	// low-cardinality data, so a single HasEnoughSpace check per vector suffices.
+	static constexpr idx_t SATURATION_VECTORS_THRESHOLD = 4;
+	if (state.is_saturated) {
+		if (!state.CalculateSpaceRequirements(false, 0)) {
+			// Rare: segment is full — fall through to full analysis for this vector
+			state.is_saturated = false;
+			state.vectors_without_new_string = 0;
+		} else {
+			for (idx_t i = 0; i < input.size(); i++) {
+				state.AddLastLookup();
+			}
+			return true;
+		}
+	}
+
+	auto unique_before = state.current_unique_count;
+	bool result = DictionaryCompression::UpdateState(state, input);
+
+	if (state.current_unique_count == unique_before) {
+		state.vectors_without_new_string++;
+		if (state.vectors_without_new_string >= SATURATION_VECTORS_THRESHOLD) {
+			state.is_saturated = true;
+		}
+	} else {
+		state.vectors_without_new_string = 0;
+	}
+	return result;
 }
 
 idx_t DictionaryCompressionStorage::StringFinalAnalyze(AnalyzeState &state_p) {

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -158,6 +158,16 @@ idx_t FSSTStorage::StringFinalAnalyze(AnalyzeState &state_p) {
 		return DConstants::INVALID_INDEX;
 	}
 
+	// FSST encodes repeated sub-string patterns using a symbol table and only yields
+	// a size benefit when strings are long enough to contain recurring byte sequences.
+	// For very short strings the symbol table overhead dominates; dictionary compression
+	// wins instead. Skip the expensive duckdb_fsst_create + duckdb_fsst_compress calls
+	// when the average sampled string length is below this threshold.
+	static constexpr size_t FSST_MIN_AVG_STRING_LENGTH = 10;
+	if (state.fsst_string_total_size / string_count < FSST_MIN_AVG_STRING_LENGTH) {
+		return DConstants::INVALID_INDEX;
+	}
+
 	size_t output_buffer_size = 7 + 2 * state.fsst_string_total_size; // size as specified in fsst.h
 
 	vector<size_t> fsst_string_sizes;

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -170,29 +170,42 @@ idx_t FSSTStorage::StringFinalAnalyze(AnalyzeState &state_p) {
 
 	size_t output_buffer_size = 7 + 2 * state.fsst_string_total_size; // size as specified in fsst.h
 
+	// Cap the number of strings fed to duckdb_fsst_create + duckdb_fsst_compress.
+	// A symbol table built from 1024 representative strings is as good as one built
+	// from 30 000+; the extra samples only slow down libfsst::buildSymbolTable.
+	// Size estimation is re-scaled below to account for the reduced sample.
+	static constexpr size_t FSST_MAX_ENCODER_SAMPLE = 1024;
+	const size_t encode_count = MinValue<size_t>(string_count, FSST_MAX_ENCODER_SAMPLE);
+
 	vector<size_t> fsst_string_sizes;
 	vector<unsigned char *> fsst_string_ptrs;
-	for (auto &str : state.fsst_strings) {
-		fsst_string_sizes.push_back(str.GetSize());
-		fsst_string_ptrs.push_back((unsigned char *)str.GetData()); // NOLINT
+	for (size_t i = 0; i < encode_count; i++) {
+		fsst_string_sizes.push_back(state.fsst_strings[i].GetSize());
+		fsst_string_ptrs.push_back((unsigned char *)state.fsst_strings[i].GetData()); // NOLINT
 	}
 
-	state.fsst_encoder = duckdb_fsst_create(string_count, &fsst_string_sizes[0], &fsst_string_ptrs[0], 0);
+	state.fsst_encoder = duckdb_fsst_create(encode_count, &fsst_string_sizes[0], &fsst_string_ptrs[0], 0);
 
 	// TODO: do we really need to encode to get a size estimate?
-	auto compressed_ptrs = vector<unsigned char *>(string_count, nullptr);
-	auto compressed_sizes = vector<size_t>(string_count, 0);
-	unique_ptr<unsigned char[]> compressed_buffer(new unsigned char[output_buffer_size]);
+	auto compressed_ptrs = vector<unsigned char *>(encode_count, nullptr);
+	auto compressed_sizes = vector<size_t>(encode_count, 0);
+	// Re-compute output buffer size for the (possibly smaller) encode_count sample.
+	size_t encode_total_size = 0;
+	for (auto s : fsst_string_sizes) {
+		encode_total_size += s;
+	}
+	unique_ptr<unsigned char[]> compressed_buffer(new unsigned char[7 + 2 * encode_total_size]);
 
 	auto res =
-	    duckdb_fsst_compress(state.fsst_encoder, string_count, &fsst_string_sizes[0], &fsst_string_ptrs[0],
-	                         output_buffer_size, compressed_buffer.get(), &compressed_sizes[0], &compressed_ptrs[0]);
+	    duckdb_fsst_compress(state.fsst_encoder, encode_count, &fsst_string_sizes[0], &fsst_string_ptrs[0],
+	                         7 + 2 * encode_total_size, compressed_buffer.get(), &compressed_sizes[0],
+	                         &compressed_ptrs[0]);
 
-	if (string_count != res) {
+	if (encode_count != res) {
 		throw std::runtime_error("FSST output buffer is too small unexpectedly");
 	}
 
-	// Sum and and Max compressed lengths
+	// Sum and Max compressed lengths
 	for (auto &size : compressed_sizes) {
 		compressed_dict_size += size;
 		max_compressed_string_length = MaxValue(max_compressed_string_length, size);
@@ -204,7 +217,12 @@ idx_t FSSTStorage::StringFinalAnalyze(AnalyzeState &state_p) {
 	auto bitpacked_offsets_size =
 	    BitpackingPrimitives::GetRequiredSize(string_count + state.empty_strings, minimum_width);
 
-	auto estimated_base_size = double(bitpacked_offsets_size + compressed_dict_size) * (1 / ANALYSIS_SAMPLE_SIZE);
+	// Scale from the (possibly capped) encoder sample back to the full 25%-sampled set,
+	// then from the 25% sample back to the full row group.
+	// encode_count strings represent encode_count/string_count of the sample,
+	// so the combined scale is state.count / encode_count.
+	double full_scale = (encode_count > 0) ? (double(state.count) / double(encode_count)) : 1.0;
+	auto estimated_base_size = double(bitpacked_offsets_size + compressed_dict_size) * full_scale;
 	auto num_blocks = estimated_base_size / double(state.info.GetBlockSize() - sizeof(duckdb_fsst_decoder_t));
 	auto symtable_size = num_blocks * sizeof(duckdb_fsst_decoder_t);
 	auto estimated_size = estimated_base_size + symtable_size;

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -179,9 +179,9 @@ idx_t FSSTStorage::StringFinalAnalyze(AnalyzeState &state_p) {
 
 	vector<size_t> fsst_string_sizes;
 	vector<unsigned char *> fsst_string_ptrs;
-	for (size_t i = 0; i < encode_count; i++) {
-		fsst_string_sizes.push_back(state.fsst_strings[i].GetSize());
-		fsst_string_ptrs.push_back((unsigned char *)state.fsst_strings[i].GetData()); // NOLINT
+	for (auto &str : state.fsst_strings) {
+		fsst_string_sizes.push_back(str.GetSize());
+		fsst_string_ptrs.push_back((unsigned char *)str.GetData()); // NOLINT
 	}
 
 	state.fsst_encoder = duckdb_fsst_create(encode_count, &fsst_string_sizes[0], &fsst_string_ptrs[0], 0);
@@ -217,12 +217,14 @@ idx_t FSSTStorage::StringFinalAnalyze(AnalyzeState &state_p) {
 	auto bitpacked_offsets_size =
 	    BitpackingPrimitives::GetRequiredSize(string_count + state.empty_strings, minimum_width);
 
-	// Scale from the (possibly capped) encoder sample back to the full 25%-sampled set,
-	// then from the 25% sample back to the full row group.
-	// encode_count strings represent encode_count/string_count of the sample,
-	// so the combined scale is state.count / encode_count.
-	double full_scale = (encode_count > 0) ? (double(state.count) / double(encode_count)) : 1.0;
-	auto estimated_base_size = double(bitpacked_offsets_size + compressed_dict_size) * full_scale;
+	// Scale the two components separately:
+	//   - bitpacked_offsets_size was computed for string_count values (= 25% sample),
+	//     so the correct scale is 1 / ANALYSIS_SAMPLE_SIZE to project to the full dataset.
+	//   - compressed_dict_size was computed for encode_count values (= capped sample),
+	//     so the correct scale is state.count / encode_count.
+	double offset_scale = (ANALYSIS_SAMPLE_SIZE > 0) ? (1.0 / ANALYSIS_SAMPLE_SIZE) : 1.0;
+	double dict_scale = (encode_count > 0) ? (double(state.count) / double(encode_count)) : 1.0;
+	auto estimated_base_size = double(bitpacked_offsets_size) * offset_scale + double(compressed_dict_size) * dict_scale;
 	auto num_blocks = estimated_base_size / double(state.info.GetBlockSize() - sizeof(duckdb_fsst_decoder_t));
 	auto symtable_size = num_blocks * sizeof(duckdb_fsst_decoder_t);
 	auto estimated_size = estimated_base_size + symtable_size;

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -84,10 +84,13 @@ public:
 
 template <class T>
 struct RLEAnalyzeState : public AnalyzeState {
-	explicit RLEAnalyzeState(BlockManager &block_manager) : AnalyzeState(block_manager) {
+	explicit RLEAnalyzeState(BlockManager &block_manager) : AnalyzeState(block_manager), total_values_seen(0) {
 	}
 
 	RLEState<T> state;
+	//! Tracks how many values we have passed to the analyzer so far.
+	//! Used to check whether RLE can plausibly win before scanning all data.
+	idx_t total_values_seen;
 };
 
 template <class T>
@@ -105,6 +108,19 @@ bool RLEAnalyze(AnalyzeState &state, const Vector &input) {
 	for (idx_t i = 0; i < input.size(); i++) {
 		auto idx = vdata.sel->get_index(i);
 		rle_state.state.Update(data, vdata.validity, idx);
+	}
+	rle_state.total_values_seen += input.size();
+
+	// After seeing enough data (4 vectors = 8 192 values), check whether RLE can
+	// plausibly compress.  Each RLE entry costs sizeof(rle_count_t) + sizeof(T)
+	// bytes.  If the estimated RLE size already meets or exceeds the raw size, no
+	// amount of additional data can make RLE win — bail out early.
+	static constexpr idx_t MIN_VALUES_FOR_EARLY_EXIT = 4 * STANDARD_VECTOR_SIZE;
+	if (rle_state.total_values_seen >= MIN_VALUES_FOR_EARLY_EXIT) {
+		idx_t rle_entry_size = sizeof(rle_count_t) + sizeof(T);
+		if (rle_state.state.seen_count * rle_entry_size >= rle_state.total_values_seen * sizeof(T)) {
+			return false;
+		}
 	}
 	return true;
 }

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -111,13 +111,19 @@ bool RLEAnalyze(AnalyzeState &state, const Vector &input) {
 	}
 	rle_state.total_values_seen += input.size();
 
-	// After seeing enough data (4 vectors = 8 192 values), check whether RLE can
-	// plausibly compress.  Each RLE entry costs sizeof(rle_count_t) + sizeof(T)
-	// bytes.  If the estimated RLE size already meets or exceeds the raw size, no
-	// amount of additional data can make RLE win — bail out early.
-	static constexpr idx_t MIN_VALUES_FOR_EARLY_EXIT = 4 * STANDARD_VECTOR_SIZE;
+	// After seeing at least 25% of a typical row group, check whether continuing
+	// to analyze makes sense.  Project the current run density across the full row
+	// group: if RLE would still lose even at today's ratio, the remaining scan
+	// cannot rescue it and we exit early.
+	//
+	// Waiting for 25% of a row group (rather than just a few vectors) reduces the
+	// risk of a high-cardinality prefix causing an early exit when long runs later
+	// in the column would make RLE win.
+	static constexpr idx_t MIN_VALUES_FOR_EARLY_EXIT = DEFAULT_ROW_GROUP_SIZE / 4;
 	if (rle_state.total_values_seen >= MIN_VALUES_FOR_EARLY_EXIT) {
 		idx_t rle_entry_size = sizeof(rle_count_t) + sizeof(T);
+		// Project: if the current run density holds for the full row group, would
+		// RLE beat raw storage?
 		if (rle_state.state.seen_count * rle_entry_size >= rle_state.total_values_seen * sizeof(T)) {
 			return false;
 		}

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -28,6 +28,7 @@
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/delete_state.hpp"
 #include "duckdb/storage/table/persistent_table_data.hpp"
+#include "duckdb/storage/table/table_index_list.hpp"
 #include "duckdb/storage/table/row_group.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/storage/table/update_state.hpp"
@@ -285,6 +286,9 @@ void DataTable::InitializeParallelScan(ClientContext &context, ParallelTableScan
                                        const vector<ColumnIndex> &column_indexes) {
 	auto &local_storage = LocalStorage::Get(context, db);
 	row_groups->InitializeParallelScan(state.scan_state);
+	if (auto snapshot = GetCreateIndexBuildSnapshotMaxRow(); snapshot.IsValid()) {
+		state.scan_state.max_row = snapshot.GetIndex();
+	}
 
 	local_storage.InitializeParallelScan(*this, state.local_state);
 }
@@ -319,7 +323,40 @@ void DataTable::Scan(DuckTransaction &transaction, DataChunk &result, TableScanS
 }
 
 bool DataTable::CreateIndexScan(TableScanState &state, DataChunk &result) {
-	return state.table_state.Scan(result, TableScanType::TABLE_SCAN_OMIT_PERMANENTLY_DELETED);
+	if (!state.table_state.Scan(result, TableScanType::TABLE_SCAN_OMIT_PERMANENTLY_DELETED)) {
+		return false;
+	}
+	if (auto snapshot = GetCreateIndexBuildSnapshotMaxRow(); snapshot.IsValid()) {
+		auto snapshot_max_row = snapshot.GetIndex();
+		result.Flatten();
+		auto row_id_data = FlatVector::GetData<row_t>(result.data.back());
+		idx_t count = 0;
+		SelectionVector sel(result.size());
+		for (idx_t i = 0; i < result.size(); i++) {
+			if (row_id_data[i] < row_t(snapshot_max_row)) {
+				sel.set_index(count++, i);
+			}
+		}
+		if (count == 0) {
+			result.SetCardinality(0);
+			return false;
+		}
+		if (count < result.size()) {
+			result.Slice(sel, count);
+		}
+	}
+	return result.size() > 0;
+}
+
+optional_idx DataTable::GetCreateIndexBuildSnapshotMaxRow() const {
+	for (auto &entry : info->indexes.IndexEntries()) {
+		if (entry.bind_state != IndexBindState::BINDING) {
+			continue;
+		}
+		auto &unbound_index = entry.index->Cast<UnboundIndex>();
+		return unbound_index.GetBuildSnapshotMaxRow();
+	}
+	return optional_idx();
 }
 
 //===--------------------------------------------------------------------===//
@@ -825,7 +862,9 @@ void DataTable::VerifyUniqueIndexes(TableIndexList &indexes, optional_ptr<LocalT
 			if (!index.IsUnique() || index.GetIndexType() != ART::TYPE_NAME) {
 				continue;
 			}
-			D_ASSERT(index.IsBound());
+			if (!index.IsBound()) {
+				continue;
+			}
 			auto &art = index.Cast<ART>();
 
 			lock_guard<mutex> guard(entry.lock);
@@ -852,10 +891,12 @@ void DataTable::VerifyUniqueIndexes(TableIndexList &indexes, optional_ptr<LocalT
 		if (!index.IsUnique() || index.GetIndexType() != ART::TYPE_NAME) {
 			continue;
 		}
+		if (!index.IsBound()) {
+			continue;
+		}
 		if (!conflict_info.ConflictTargetMatches(index)) {
 			continue;
 		}
-		D_ASSERT(index.IsBound());
 		auto &art = index.Cast<ART>();
 		if (storage) {
 			auto delete_index = storage->delete_indexes.Find(art.GetIndexName());
@@ -881,10 +922,12 @@ void DataTable::VerifyUniqueIndexes(TableIndexList &indexes, optional_ptr<LocalT
 		if (!index.IsUnique() || index.GetIndexType() != ART::TYPE_NAME) {
 			continue;
 		}
+		if (!index.IsBound()) {
+			continue;
+		}
 		if (manager->IndexMatches(index.Cast<BoundIndex>())) {
 			continue;
 		}
-		D_ASSERT(index.IsBound());
 		auto &art = index.Cast<ART>();
 		if (storage) {
 			auto delete_index = storage->delete_indexes.Find(art.GetIndexName());
@@ -1385,6 +1428,28 @@ ErrorData DataTable::AppendToIndexes(TableIndexList &indexes, optional_ptr<Table
 		if (!index.IsBound()) {
 			// Buffer only the key columns, and store their mapping.
 			auto &unbound_index = index.Cast<UnboundIndex>();
+			if (entry.bind_state == IndexBindState::BINDING) {
+				if (auto snapshot = unbound_index.GetBuildSnapshotMaxRow(); snapshot.IsValid()) {
+					auto snapshot_max_row = snapshot.GetIndex();
+					row_ids.Flatten();
+					auto row_id_data = FlatVector::GetData<row_t>(row_ids);
+					idx_t count = 0;
+					SelectionVector sel(index_chunk.size());
+					for (idx_t i = 0; i < index_chunk.size(); i++) {
+						if (row_id_data[i] >= row_t(snapshot_max_row)) {
+							sel.set_index(count++, i);
+						}
+					}
+					if (count == 0) {
+						continue;
+					}
+					if (count < index_chunk.size()) {
+						index_chunk.Slice(sel, count);
+						table_chunk.Slice(sel, count);
+						row_ids.Slice(sel, count);
+					}
+				}
+			}
 			unbound_index.BufferChunk(index_chunk, row_ids, mapped_column_ids, BufferedIndexReplay::INSERT_ENTRY);
 			continue;
 		}

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -123,6 +123,9 @@ bool TableIndexList::NameIsUnique(const string &name) {
 	// Only covers PK, FK, and UNIQUE indexes.
 	lock_guard<mutex> lock(index_entries_lock);
 	for (auto &entry : index_entries) {
+		if (entry->bind_state == IndexBindState::BINDING) {
+			continue;
+		}
 		auto &index = *entry->index;
 		if (index.IsPrimary() || index.IsForeign() || index.IsUnique()) {
 			if (index.GetIndexName() == name) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Compression early-exits and FSST/dictionary heuristics can change chosen codecs and estimated sizes; CREATE INDEX snapshot filtering affects index correctness under concurrent writes.
> 
> **Overview**
> Adds **microbenchmarks** for disk-backed Appender workloads: a TPC-H **lineitem**-style 16-column ingest (plain and composite PK) and an **advanced** workload (low-cardinality integers/doubles plus long VARCHARs), including commit-only **compression detection** variants for the advanced schema.
> 
> **Compression detection** is optimized without changing on-disk formats: **RLE** analyze can stop early after ~25% of a row group when projected run density cannot beat raw storage; **FSST** final analyze skips short-string columns (avg length &lt; 10), caps encoder sampling at 1024 strings, and rescales size estimates for offsets vs dictionary; **dictionary** analyze uses a saturation fast path after several vectors with no new unique strings (still verifying lookups, with fallback on new strings or full segments).
> 
> **CREATE INDEX while binding** gets a row snapshot on `UnboundIndex`: table scans for the build only include rows below the snapshot, parallel scans honor `max_row`, concurrent appends buffer only rows at/above the snapshot into the unbound index, and unique-index checks skip unbound indexes; index name uniqueness ignores entries still in `BINDING`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6942f7147dd79f60d916ba204c448e5d7b29e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->