### PR TITLE
only rle

### DIFF
--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -3,6 +3,9 @@ add_library(
   duckdb_benchmark_micro OBJECT
   append.cpp
   append_mix.cpp
+  appender_advanced.cpp
+  appender_int.cpp
+  appender_lineitem.cpp
   bulkupdate.cpp
   cast.cpp
   in.cpp

--- a/benchmark/micro/appender_advanced.cpp
+++ b/benchmark/micro/appender_advanced.cpp
@@ -1,0 +1,330 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark.hpp"
+#include "duckdb/main/appender.hpp"
+
+using namespace duckdb;
+
+// Benchmarks Appender ingestion with a workload designed to exercise the
+// compression detection code paths that appender_lineitem.cpp does NOT cover:
+//
+//   - INTEGER columns with SMALL cardinality (only a handful of distinct
+//     values with long repeated runs) — tests whether the RLE early-exit
+//     is transparent when RLE is actually a good choice.
+//
+//   - VARCHAR columns with LONG strings (avg > 100 bytes) — tests whether
+//     the FSST short-string skip is transparent when FSST can genuinely
+//     compress the data.
+//
+// Expected behaviour after optimisations C and D:
+//   - RLE early exit should NOT fire here (low cardinality → seen_count
+//     stays small → projection says RLE is fine → no early exit).
+//   - FSST short-string skip should NOT fire here (avg length > 10 bytes
+//     → the threshold is not reached → FSST analysis runs normally).
+//
+// Therefore these benchmarks should show no regression vs baseline, proving
+// the optimisations are transparent for workloads that DO benefit from RLE
+// or FSST.
+
+static constexpr int32_t ADV_ROW_COUNT = 1000000;
+
+// ---------------------------------------------------------------------------
+// Long VARCHAR strings (avg ~130 bytes) — representative of log lines,
+// URLs, or structured text where FSST can exploit repeated sub-patterns.
+// ---------------------------------------------------------------------------
+static const char *const LONG_STRINGS[] = {
+    // ~100–160 chars each; share common prefixes/suffixes so FSST can build
+    // a useful symbol table
+    "https://example.com/api/v2/users/search?query=active&limit=100&offset=0&sort=created_at&order=desc",
+    "https://example.com/api/v2/products/list?category=electronics&in_stock=true&min_price=10&max_price=500",
+    "https://example.com/api/v2/orders/history?user_id=42&status=completed&from=2024-01-01&to=2024-12-31",
+    "https://example.com/api/v2/reports/summary?type=monthly&department=sales&year=2024&format=json",
+    "/var/log/app/service_2024_01.log: [INFO] Request processed successfully in 42ms for endpoint /health",
+    "/var/log/app/service_2024_01.log: [WARN] Response time exceeded threshold: 1523ms for endpoint /search",
+    "/var/log/app/service_2024_01.log: [ERROR] Database connection timeout after 30s, retrying attempt 3/5",
+    "/var/log/app/service_2024_01.log: [DEBUG] Cache miss for key user_session_abc123, fetching from database",
+};
+static constexpr idx_t LONG_STRING_COUNT = 8;
+
+// Small pre-computed lengths to avoid calling strlen in the hot loop
+static const uint32_t LONG_STRING_LENS[] = {97, 103, 101, 98, 101, 103, 101, 103};
+
+// ---------------------------------------------------------------------------
+// Low-cardinality INTEGER values (4 distinct values, long repeated runs)
+// — representative of status codes, category IDs, priority levels, etc.
+// RLE should be a strong candidate for these columns.
+// ---------------------------------------------------------------------------
+static constexpr int32_t STATUS_VALS[]   = {1, 2, 3, 4};          // 4 distinct
+static constexpr int32_t PRIORITY_VALS[] = {1, 2, 3, 4, 5};       // 5 distinct
+static constexpr int32_t REGION_VALS[]   = {10, 20, 30, 40, 50, 60, 70, 80}; // 8 distinct
+// Each value repeats for a long run (1000 rows) to make RLE clearly worthwhile
+static constexpr int32_t RUN_LENGTH = 1000;
+
+static const char CREATE_ADV_TABLE[] =
+    "CREATE TABLE adv_workload("
+    // Low-cardinality integer columns (RLE-friendly)
+    "status_code INTEGER, priority INTEGER, region_id INTEGER, category_id INTEGER,"
+    // Low-cardinality doubles (also RLE-friendly: small set of values, long runs)
+    "score DOUBLE, multiplier DOUBLE,"
+    // Long VARCHAR columns (FSST-friendly)
+    "request_url VARCHAR, log_line VARCHAR, description VARCHAR, notes VARCHAR)";
+
+// ---------------------------------------------------------------------------
+// Base benchmark class
+// ---------------------------------------------------------------------------
+class AppenderAdvancedBenchmark : public DuckDBBenchmark {
+protected:
+	AppenderAdvancedBenchmark(bool register_benchmark, const string &name)
+	    : DuckDBBenchmark(register_benchmark, name, "[appender_advanced]") {
+	}
+
+public:
+	bool InMemory() override {
+		return false;
+	}
+
+	size_t NRuns() override {
+		return 80;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(CREATE_ADV_TABLE);
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		Appender appender(state->conn, "adv_workload");
+		for (int32_t i = 0; i < ADV_ROW_COUNT; i++) {
+			// Low-cardinality integers: value changes every RUN_LENGTH rows
+			// → long runs of the same value → RLE should win
+			int32_t status   = STATUS_VALS[(i / RUN_LENGTH) % 4];
+			int32_t priority = PRIORITY_VALS[(i / RUN_LENGTH) % 5];
+			int32_t region   = REGION_VALS[(i / RUN_LENGTH) % 8];
+			int32_t category = STATUS_VALS[(i / (RUN_LENGTH * 2)) % 4];
+
+			// Low-cardinality doubles: same run pattern
+			double score      = 1.0 + double((i / RUN_LENGTH) % 5) * 0.25;
+			double multiplier = 1.0 + double((i / (RUN_LENGTH * 3)) % 4) * 0.5;
+
+			// Long VARCHAR: cycle through the string pool
+			const idx_t url_idx  = idx_t(i) % LONG_STRING_COUNT;
+			const idx_t log_idx  = (idx_t(i) + 2) % LONG_STRING_COUNT;
+			const idx_t desc_idx = (idx_t(i) + 4) % LONG_STRING_COUNT;
+			const idx_t note_idx = (idx_t(i) + 6) % LONG_STRING_COUNT;
+
+			appender.BeginRow();
+			appender.Append<int32_t>(status);
+			appender.Append<int32_t>(priority);
+			appender.Append<int32_t>(region);
+			appender.Append<int32_t>(category);
+			appender.Append<double>(score);
+			appender.Append<double>(multiplier);
+			appender.Append<string_t>(string_t(LONG_STRINGS[url_idx], LONG_STRING_LENS[url_idx]));
+			appender.Append<string_t>(string_t(LONG_STRINGS[log_idx], LONG_STRING_LENS[log_idx]));
+			appender.Append<string_t>(string_t(LONG_STRINGS[desc_idx], LONG_STRING_LENS[desc_idx]));
+			appender.Append<string_t>(string_t(LONG_STRINGS[note_idx], LONG_STRING_LENS[note_idx]));
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE adv_workload");
+		Load(state);
+	}
+
+	string VerifyResult(QueryResult *result) override {
+		return string();
+	}
+
+	string BenchmarkInfo() override {
+		return "Ingest 1M rows: low-cardinality integers (RLE-friendly) + long VARCHAR strings (FSST-friendly)";
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Variant 1: no primary key
+// ---------------------------------------------------------------------------
+class AppenderAdvanced1MBenchmark : public AppenderAdvancedBenchmark {
+	AppenderAdvanced1MBenchmark(bool register_benchmark)
+	    : AppenderAdvancedBenchmark(register_benchmark, "AppenderAdvanced1M") {
+	}
+
+public:
+	static AppenderAdvanced1MBenchmark *GetInstance() {
+		static AppenderAdvanced1MBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderAdvanced1MBenchmark>(new AppenderAdvanced1MBenchmark(false));
+		return &singleton;
+	}
+};
+auto global_instance_AppenderAdvanced1M = AppenderAdvanced1MBenchmark::GetInstance();
+
+// ---------------------------------------------------------------------------
+// Storage verification benchmark for the advanced workload.
+// INTEGER columns have low cardinality (4-8 distinct values, runs of 1000
+// rows) so RLE SHOULD win.  Verifies the early exit does NOT fire here.
+// ---------------------------------------------------------------------------
+class AppenderAdvancedStorageCheckBenchmark : public AppenderAdvancedBenchmark {
+	AppenderAdvancedStorageCheckBenchmark(bool register_benchmark)
+	    : AppenderAdvancedBenchmark(register_benchmark, "AppenderAdvancedStorageCheck") {
+	}
+
+public:
+	static AppenderAdvancedStorageCheckBenchmark *GetInstance() {
+		static AppenderAdvancedStorageCheckBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderAdvancedStorageCheckBenchmark>(
+		    new AppenderAdvancedStorageCheckBenchmark(false));
+		return &singleton;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(CREATE_ADV_TABLE);
+		RunBenchmark(state);
+		state->conn.Query("CHECKPOINT");
+	}
+
+	string GetQuery() override {
+		return "SELECT compression, COUNT(*) AS cnt "
+		       "FROM pragma_storage_info('adv_workload') "
+		       "WHERE segment_type = 'INTEGER' "
+		       "GROUP BY compression ORDER BY cnt DESC";
+	}
+
+	string VerifyResult(QueryResult *result) override {
+		if (!result || result->HasError()) {
+			return "storage info query failed";
+		}
+		auto chunk = result->Fetch();
+		if (!chunk || chunk->size() == 0) {
+			return "no INTEGER segments found";
+		}
+		// Low-cardinality integers (runs of 1000) — RLE must be the top compressor
+		auto compression = chunk->data[0].GetValue(0).ToString();
+		if (compression != "RLE") {
+			return "INTEGER columns are not using RLE (got: " + compression + ") — "
+			       "RLE early exit may have fired incorrectly for low-cardinality data";
+		}
+		return string();
+	}
+
+	string BenchmarkInfo() override {
+		return "Verify INTEGER compression types after 1M-row advanced workload ingestion";
+	}
+};
+auto global_instance_AppenderAdvancedStorageCheck = AppenderAdvancedStorageCheckBenchmark::GetInstance();
+
+// ---------------------------------------------------------------------------
+// Compression detection microbenchmark for the advanced workload.
+//
+// Times only COMMIT (= LocalStorage::Flush → ColumnDataCheckpointer) for
+// exactly one row group (DEFAULT_ROW_GROUP_SIZE rows).  Compare with the
+// *Uncompressed variant to isolate pure detection overhead.
+// ---------------------------------------------------------------------------
+class CompressionDetectAdvancedBenchmark : public DuckDBBenchmark {
+protected:
+	CompressionDetectAdvancedBenchmark(bool register_benchmark, const string &name)
+	    : DuckDBBenchmark(register_benchmark, name, "[compression_detect_advanced]") {
+	}
+
+	virtual string ForceCompressionSQL() {
+		return "";
+	}
+
+public:
+	bool InMemory() override {
+		return false;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		auto force = ForceCompressionSQL();
+		if (!force.empty()) {
+			state->conn.Query(force);
+		}
+		state->conn.Query(CREATE_ADV_TABLE);
+		state->conn.Query("BEGIN TRANSACTION");
+		AppendOneRowGroup(state);
+	}
+
+	void AppendOneRowGroup(DuckDBBenchmarkState *state) {
+		Appender appender(state->conn, "adv_workload");
+		for (int32_t i = 0; i < (int32_t)DEFAULT_ROW_GROUP_SIZE; i++) {
+			int32_t status   = STATUS_VALS[(i / RUN_LENGTH) % 4];
+			int32_t priority = PRIORITY_VALS[(i / RUN_LENGTH) % 5];
+			int32_t region   = REGION_VALS[(i / RUN_LENGTH) % 8];
+			int32_t category = STATUS_VALS[(i / (RUN_LENGTH * 2)) % 4];
+			double score      = 1.0 + double((i / RUN_LENGTH) % 5) * 0.25;
+			double multiplier = 1.0 + double((i / (RUN_LENGTH * 3)) % 4) * 0.5;
+			const idx_t url_idx  = idx_t(i) % LONG_STRING_COUNT;
+			const idx_t log_idx  = (idx_t(i) + 2) % LONG_STRING_COUNT;
+			const idx_t desc_idx = (idx_t(i) + 4) % LONG_STRING_COUNT;
+			const idx_t note_idx = (idx_t(i) + 6) % LONG_STRING_COUNT;
+			appender.BeginRow();
+			appender.Append<int32_t>(status);
+			appender.Append<int32_t>(priority);
+			appender.Append<int32_t>(region);
+			appender.Append<int32_t>(category);
+			appender.Append<double>(score);
+			appender.Append<double>(multiplier);
+			appender.Append<string_t>(string_t(LONG_STRINGS[url_idx], LONG_STRING_LENS[url_idx]));
+			appender.Append<string_t>(string_t(LONG_STRINGS[log_idx], LONG_STRING_LENS[log_idx]));
+			appender.Append<string_t>(string_t(LONG_STRINGS[desc_idx], LONG_STRING_LENS[desc_idx]));
+			appender.Append<string_t>(string_t(LONG_STRINGS[note_idx], LONG_STRING_LENS[note_idx]));
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		state->conn.Query("COMMIT");
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE adv_workload");
+		state->conn.Query(CREATE_ADV_TABLE);
+		state->conn.Query("BEGIN TRANSACTION");
+		AppendOneRowGroup(state);
+	}
+
+	string VerifyResult(QueryResult *result) override {
+		return string();
+	}
+
+	string BenchmarkInfo() override {
+		return "Compression detection for 1 row group of advanced workload (low-cardinality INT + long VARCHAR)";
+	}
+};
+
+class CompressionDetectAdvancedAuto : public CompressionDetectAdvancedBenchmark {
+	CompressionDetectAdvancedAuto(bool register_benchmark)
+	    : CompressionDetectAdvancedBenchmark(register_benchmark, "CompressionDetectAdvancedAuto") {
+	}
+
+public:
+	static CompressionDetectAdvancedAuto *GetInstance() {
+		static CompressionDetectAdvancedAuto singleton(true);
+		auto b = duckdb::unique_ptr<CompressionDetectAdvancedAuto>(new CompressionDetectAdvancedAuto(false));
+		return &singleton;
+	}
+};
+auto global_instance_CompressionDetectAdvancedAuto = CompressionDetectAdvancedAuto::GetInstance();
+
+class CompressionDetectAdvancedUncompressed : public CompressionDetectAdvancedBenchmark {
+	CompressionDetectAdvancedUncompressed(bool register_benchmark)
+	    : CompressionDetectAdvancedBenchmark(register_benchmark, "CompressionDetectAdvancedUncompressed") {
+	}
+
+public:
+	static CompressionDetectAdvancedUncompressed *GetInstance() {
+		static CompressionDetectAdvancedUncompressed singleton(true);
+		auto b = duckdb::unique_ptr<CompressionDetectAdvancedUncompressed>(
+		    new CompressionDetectAdvancedUncompressed(false));
+		return &singleton;
+	}
+
+	string ForceCompressionSQL() override {
+		return "SET force_compression='uncompressed'";
+	}
+
+	string BenchmarkInfo() override {
+		return "Compression write-only baseline for advanced workload (no detection)";
+	}
+};
+auto global_instance_CompressionDetectAdvancedUncompressed = CompressionDetectAdvancedUncompressed::GetInstance();

--- a/benchmark/micro/appender_int.cpp
+++ b/benchmark/micro/appender_int.cpp
@@ -1,0 +1,146 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark.hpp"
+#include "duckdb/main/appender.hpp"
+
+using namespace duckdb;
+
+// Integer-only ingestion benchmarks targeting RLE compression behaviour.
+//
+// HighCardinality  — 8 INTEGER columns filled with sequential / pseudo-random
+//                   values (every row is distinct).  RLE cannot compress this
+//                   data at all; the early-exit optimisation should fire after
+//                   25 % of the row group and skip the remainder of the scan.
+//
+// LowCardinality   — 8 INTEGER columns filled with 4–8 distinct values in
+//                   long runs (RUN_LENGTH rows each).  RLE IS the best choice;
+//                   the early-exit projection should say "RLE wins" and NOT
+//                   fire, so compression quality is unchanged.
+//
+// Both variants persist to disk (InMemory() = false) and run 80 hot runs each
+// so the median is stable within a 3-minute wall-clock budget.
+
+static constexpr int32_t INT_ROW_COUNT   = 1000000;
+static constexpr int32_t INT_RUN_LENGTH  = 1000; // distinct value every N rows (low-cardinality)
+
+static const char CREATE_HIGH_CARD[] =
+    "CREATE TABLE int_bench("
+    "c0 INTEGER, c1 INTEGER, c2 INTEGER, c3 INTEGER,"
+    "c4 INTEGER, c5 INTEGER, c6 INTEGER, c7 INTEGER)";
+
+static const char CREATE_LOW_CARD[] =
+    "CREATE TABLE int_bench("
+    "c0 INTEGER, c1 INTEGER, c2 INTEGER, c3 INTEGER,"
+    "c4 INTEGER, c5 INTEGER, c6 INTEGER, c7 INTEGER)";
+
+// ---------------------------------------------------------------------------
+// Shared base
+// ---------------------------------------------------------------------------
+class AppenderIntBenchmark : public DuckDBBenchmark {
+protected:
+	AppenderIntBenchmark(bool register_benchmark, const string &name)
+	    : DuckDBBenchmark(register_benchmark, name, "[appender_int]") {
+	}
+
+public:
+	bool InMemory() override {
+		return false;
+	}
+
+	size_t NRuns() override {
+		return 80;
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE int_bench");
+		Load(state);
+	}
+
+	string VerifyResult(QueryResult *result) override {
+		return string();
+	}
+};
+
+// ---------------------------------------------------------------------------
+// High-cardinality: every value is unique → RLE early exit should fire
+// ---------------------------------------------------------------------------
+class AppenderIntHighCardBenchmark : public AppenderIntBenchmark {
+	AppenderIntHighCardBenchmark(bool register_benchmark)
+	    : AppenderIntBenchmark(register_benchmark, "AppenderIntHighCard") {
+	}
+
+public:
+	static AppenderIntHighCardBenchmark *GetInstance() {
+		static AppenderIntHighCardBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderIntHighCardBenchmark>(new AppenderIntHighCardBenchmark(false));
+		return &singleton;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(CREATE_HIGH_CARD);
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		Appender appender(state->conn, "int_bench");
+		for (int32_t i = 0; i < INT_ROW_COUNT; i++) {
+			appender.BeginRow();
+			appender.Append<int32_t>(i);                        // sequential — all distinct
+			appender.Append<int32_t>(i * 7 + 1);               // different stride
+			appender.Append<int32_t>(i % 200000 + 1);          // cycling but high-cardinality
+			appender.Append<int32_t>(i % 100000 + 1);
+			appender.Append<int32_t>(i / 7 + 1);               // slowly increasing
+			appender.Append<int32_t>(i % 10000 + 1);
+			appender.Append<int32_t>(i % 50000 + 1);
+			appender.Append<int32_t>(i % 7 + 1);               // low-cardinality cycling (7 values)
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	string BenchmarkInfo() override {
+		return "Ingest 1M rows of 8 high-cardinality INTEGER columns — RLE early exit should fire";
+	}
+};
+auto global_instance_AppenderIntHighCard = AppenderIntHighCardBenchmark::GetInstance();
+
+// ---------------------------------------------------------------------------
+// Low-cardinality: long repeated runs → RLE should win, early exit must NOT fire
+// ---------------------------------------------------------------------------
+class AppenderIntLowCardBenchmark : public AppenderIntBenchmark {
+	AppenderIntLowCardBenchmark(bool register_benchmark)
+	    : AppenderIntBenchmark(register_benchmark, "AppenderIntLowCard") {
+	}
+
+public:
+	static AppenderIntLowCardBenchmark *GetInstance() {
+		static AppenderIntLowCardBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderIntLowCardBenchmark>(new AppenderIntLowCardBenchmark(false));
+		return &singleton;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(CREATE_LOW_CARD);
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		Appender appender(state->conn, "int_bench");
+		for (int32_t i = 0; i < INT_ROW_COUNT; i++) {
+			// Each column cycles through a small set with runs of INT_RUN_LENGTH rows
+			appender.BeginRow();
+			appender.Append<int32_t>((i / INT_RUN_LENGTH) % 4 + 1);
+			appender.Append<int32_t>((i / INT_RUN_LENGTH) % 5 + 1);
+			appender.Append<int32_t>((i / INT_RUN_LENGTH) % 8 + 1);
+			appender.Append<int32_t>((i / INT_RUN_LENGTH) % 3 + 1);
+			appender.Append<int32_t>((i / INT_RUN_LENGTH) % 6 + 1);
+			appender.Append<int32_t>((i / INT_RUN_LENGTH) % 4 + 10);
+			appender.Append<int32_t>((i / (INT_RUN_LENGTH * 2)) % 5 + 1);
+			appender.Append<int32_t>((i / (INT_RUN_LENGTH * 3)) % 4 + 1);
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	string BenchmarkInfo() override {
+		return "Ingest 1M rows of 8 low-cardinality INTEGER columns (runs of 1000) — RLE should win";
+	}
+};
+auto global_instance_AppenderIntLowCard = AppenderIntLowCardBenchmark::GetInstance();

--- a/benchmark/micro/appender_lineitem.cpp
+++ b/benchmark/micro/appender_lineitem.cpp
@@ -1,0 +1,181 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark.hpp"
+#include "duckdb/main/appender.hpp"
+
+using namespace duckdb;
+
+// Two variants of the TPC-H lineitem-inspired 16-column schema targeting the
+// RLE early-exit optimisation in RLEAnalyze.
+//
+// HighCardInt — integer columns hold sequential / high-cardinality values
+//               (distinct per row or cycling with a large period).  RLE
+//               cannot compress them; the early-exit should fire and skip
+//               the rest of the analyze scan.
+//
+// LowCardInt  — integer columns hold low-cardinality values in long runs
+//               (RUN_LENGTH consecutive rows share the same value).  RLE IS
+//               the best choice; the projection should say "RLE wins" so the
+//               early-exit must NOT fire, preserving compression quality.
+//
+// Both variants share the same VARCHAR / DOUBLE columns so the only variable
+// is the integer cardinality.  Both use file-based storage and run 80 hot
+// runs (≈ 2 min wall-clock each).
+
+static constexpr int32_t LINEITEM_ROW_COUNT = 1000000;
+static constexpr int32_t LINEITEM_BASE_DATE = 8827; // 1994-01-01 as days since epoch
+static constexpr int32_t RUN_LENGTH         = 1000; // rows per run for low-cardinality variant
+
+static const char CREATE_LINEITEM[] =
+    "CREATE TABLE lineitem("
+    "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
+    "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
+    "l_returnflag VARCHAR, l_linestatus VARCHAR,"
+    "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
+    "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR)";
+
+static const char *const RETURNFLAGS[]     = {"A", "N", "R"};
+static const uint32_t    RETURNFLAG_LENS[] = {1, 1, 1};
+static const char *const LINESTATUS[]      = {"O", "F"};
+static const uint32_t    LINESTATUS_LENS[] = {1, 1};
+static const char *const SHIPINSTRUCT[]    = {"DELIVER IN PERSON", "COLLECT COD", "NONE", "TAKE BACK RETURN"};
+static const uint32_t    SHIPINSTRUCT_LENS[] = {17, 11, 4, 16};
+static const char *const SHIPMODE[]        = {"AIR", "AIR REG", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK"};
+static const uint32_t    SHIPMODE_LENS[]   = {3, 7, 3, 4, 4, 7, 4, 5};
+static const char        COMMENT_STR[]     = "regular annual package";
+static constexpr uint32_t COMMENT_LEN      = 22;
+
+// ---------------------------------------------------------------------------
+// Shared base — VARCHAR and DOUBLE columns are the same for both variants
+// ---------------------------------------------------------------------------
+class AppenderLineitemBenchmark : public DuckDBBenchmark {
+protected:
+	AppenderLineitemBenchmark(bool register_benchmark, const string &name)
+	    : DuckDBBenchmark(register_benchmark, name, "[appender_lineitem]") {
+	}
+
+	// Subclasses supply the 4 integer values per row (orderkey, partkey,
+	// suppkey, linenumber) plus the 3 date integers.
+	virtual void AppendIntColumns(Appender &appender, int32_t i) = 0;
+
+public:
+	bool InMemory() override {
+		return false;
+	}
+
+	size_t NRuns() override {
+		return 80;
+	}
+
+	void Load(DuckDBBenchmarkState *state) override {
+		state->conn.Query(CREATE_LINEITEM);
+	}
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		Appender appender(state->conn, "lineitem");
+		for (int32_t i = 0; i < LINEITEM_ROW_COUNT; i++) {
+			const idx_t rf = idx_t(i) % 3;
+			const idx_t ls = idx_t(i) % 2;
+			const idx_t si = idx_t(i) % 4;
+			const idx_t sm = idx_t(i) % 8;
+			appender.BeginRow();
+			AppendIntColumns(appender, i);
+			appender.Append<double>(1.0 + double(i % 50));
+			appender.Append<double>(900.0 + double(i % 104949) * 0.01);
+			appender.Append<double>(double(i % 11) * 0.01);
+			appender.Append<double>(double(i % 9) * 0.01);
+			appender.Append<string_t>(string_t(RETURNFLAGS[rf], RETURNFLAG_LENS[rf]));
+			appender.Append<string_t>(string_t(LINESTATUS[ls], LINESTATUS_LENS[ls]));
+			AppendDateColumns(appender, i);
+			appender.Append<string_t>(string_t(SHIPINSTRUCT[si], SHIPINSTRUCT_LENS[si]));
+			appender.Append<string_t>(string_t(SHIPMODE[sm], SHIPMODE_LENS[sm]));
+			appender.Append<string_t>(string_t(COMMENT_STR, COMMENT_LEN));
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE lineitem");
+		Load(state);
+	}
+
+	string VerifyResult(QueryResult *result) override {
+		return string();
+	}
+
+	string BenchmarkInfo() override {
+		return "Ingest 1M rows of TPC-H lineitem schema into persistent storage";
+	}
+
+private:
+	void AppendDateColumns(Appender &appender, int32_t i) {
+		// Dates are derived from i — high-cardinality regardless of variant
+		appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);
+		appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);
+		appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Variant 1: HIGH-CARDINALITY integers
+// l_orderkey, l_partkey, l_suppkey, l_linenumber span large ranges.
+// RLE early-exit should fire — Bitpacking becomes the compressor.
+// ---------------------------------------------------------------------------
+class AppenderLineitemHighCardIntBenchmark : public AppenderLineitemBenchmark {
+	AppenderLineitemHighCardIntBenchmark(bool register_benchmark)
+	    : AppenderLineitemBenchmark(register_benchmark, "AppenderLineitemHighCardInt") {
+	}
+
+	void AppendIntColumns(Appender &appender, int32_t i) override {
+		appender.Append<int32_t>(i / 7 + 1);          // slowly increases — long period
+		appender.Append<int32_t>(i % 200000 + 1);     // 200 000 distinct values
+		appender.Append<int32_t>(i % 10000 + 1);      // 10 000 distinct values
+		appender.Append<int32_t>(i % 7 + 1);          // 7 distinct but cycling per-row
+	}
+
+public:
+	static AppenderLineitemHighCardIntBenchmark *GetInstance() {
+		static AppenderLineitemHighCardIntBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderLineitemHighCardIntBenchmark>(
+		    new AppenderLineitemHighCardIntBenchmark(false));
+		return &singleton;
+	}
+
+	string BenchmarkInfo() override {
+		return "Lineitem 1M rows — high-cardinality INT cols: RLE early exit fires, Bitpacking chosen";
+	}
+};
+auto global_instance_AppenderLineitemHighCardInt = AppenderLineitemHighCardIntBenchmark::GetInstance();
+
+// ---------------------------------------------------------------------------
+// Variant 2: LOW-CARDINALITY integers
+// Integer columns cycle through a small value set with long runs.
+// RLE projection says "RLE wins" — early exit must NOT fire.
+// Compression quality should be identical to the no-fix baseline.
+// ---------------------------------------------------------------------------
+class AppenderLineitemLowCardIntBenchmark : public AppenderLineitemBenchmark {
+	AppenderLineitemLowCardIntBenchmark(bool register_benchmark)
+	    : AppenderLineitemBenchmark(register_benchmark, "AppenderLineitemLowCardInt") {
+	}
+
+	void AppendIntColumns(Appender &appender, int32_t i) override {
+		// Each value repeats for RUN_LENGTH consecutive rows → long RLE runs
+		appender.Append<int32_t>((i / RUN_LENGTH) % 4 + 1);
+		appender.Append<int32_t>((i / RUN_LENGTH) % 8 + 1);
+		appender.Append<int32_t>((i / RUN_LENGTH) % 5 + 1);
+		appender.Append<int32_t>((i / (RUN_LENGTH * 2)) % 4 + 1);
+	}
+
+public:
+	static AppenderLineitemLowCardIntBenchmark *GetInstance() {
+		static AppenderLineitemLowCardIntBenchmark singleton(true);
+		auto b = duckdb::unique_ptr<AppenderLineitemLowCardIntBenchmark>(
+		    new AppenderLineitemLowCardIntBenchmark(false));
+		return &singleton;
+	}
+
+	string BenchmarkInfo() override {
+		return "Lineitem 1M rows — low-cardinality INT cols (runs of 1000): RLE wins, early exit silent";
+	}
+};
+auto global_instance_AppenderLineitemLowCardInt = AppenderLineitemLowCardIntBenchmark::GetInstance();

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -84,10 +84,13 @@ public:
 
 template <class T>
 struct RLEAnalyzeState : public AnalyzeState {
-	explicit RLEAnalyzeState(BlockManager &block_manager) : AnalyzeState(block_manager) {
+	explicit RLEAnalyzeState(BlockManager &block_manager) : AnalyzeState(block_manager), total_values_seen(0) {
 	}
 
 	RLEState<T> state;
+	//! Tracks how many values we have passed to the analyzer so far.
+	//! Used to check whether RLE can plausibly win before scanning all data.
+	idx_t total_values_seen;
 };
 
 template <class T>
@@ -105,6 +108,25 @@ bool RLEAnalyze(AnalyzeState &state, const Vector &input) {
 	for (idx_t i = 0; i < input.size(); i++) {
 		auto idx = vdata.sel->get_index(i);
 		rle_state.state.Update(data, vdata.validity, idx);
+	}
+	rle_state.total_values_seen += input.size();
+
+	// After seeing at least 25% of a typical row group, check whether continuing
+	// to analyze makes sense.  Project the current run density across the full row
+	// group: if RLE would still lose even at today's ratio, the remaining scan
+	// cannot rescue it and we exit early.
+	//
+	// Waiting for 25% of a row group (rather than just a few vectors) reduces the
+	// risk of a high-cardinality prefix causing an early exit when long runs later
+	// in the column would make RLE win.
+	static constexpr idx_t MIN_VALUES_FOR_EARLY_EXIT = DEFAULT_ROW_GROUP_SIZE / 4;
+	if (rle_state.total_values_seen >= MIN_VALUES_FOR_EARLY_EXIT) {
+		idx_t rle_entry_size = sizeof(rle_count_t) + sizeof(T);
+		// Project: if the current run density holds for the full row group, would
+		// RLE beat raw storage?
+		if (rle_state.state.seen_count * rle_entry_size >= rle_state.total_values_seen * sizeof(T)) {
+			return false;
+		}
 	}
 	return true;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes compression codec selection during checkpoint; incorrect early exit could skip RLE on columns that would benefit, though the 25% threshold and projection logic aim to avoid that.
> 
> **Overview**
> Adds an **early exit** during RLE compression analysis in `RLEAnalyze`: after at least **25% of a row group** (`DEFAULT_ROW_GROUP_SIZE / 4`), it projects whether RLE could beat raw storage from current run density; if not, analysis stops (`return false`) so checkpointing skips the rest of the RLE scan on high-cardinality columns.
> 
> Registers three new **microbenchmark** sources in `benchmark/micro`—`appender_int`, `appender_lineitem`, and `appender_advanced`—with high- vs low-cardinality integer workloads (and mixed long-VARCHAR / low-card INT in the advanced suite). Includes ingestion timing benchmarks, a storage check that asserts **RLE** on low-card INTEGER segments, and commit-time compression-detection benchmarks (auto vs forced uncompressed) for one row group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8094da9458722982ab0343bcc3fdf319084b419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->