### PR TITLE
ingestion benchmarks

### DIFF
--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -3,6 +3,9 @@ add_library(
   duckdb_benchmark_micro OBJECT
   append.cpp
   append_mix.cpp
+  appender_advanced.cpp
+  appender_int.cpp
+  appender_lineitem.cpp
   bulkupdate.cpp
   cast.cpp
   in.cpp

--- a/benchmark/micro/appender_advanced.cpp
+++ b/benchmark/micro/appender_advanced.cpp
@@ -1,0 +1,82 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark.hpp"
+#include "duckdb/main/appender.hpp"
+
+using namespace duckdb;
+
+// Advanced workload: low-cardinality integers + long VARCHAR strings.
+// Tests that FSST early-exit and RLE early-exit are transparent for
+// workloads that actually benefit from those codecs.
+
+static constexpr int32_t ADV_ROW_COUNT  = 1000000;
+static constexpr int32_t ADV_RUN_LENGTH = 1000;
+
+static const char CREATE_ADV_TABLE[] =
+    "CREATE TABLE adv_workload("
+    "status_code INTEGER, priority INTEGER, region_id INTEGER, category_id INTEGER,"
+    "score DOUBLE, multiplier DOUBLE,"
+    "request_url VARCHAR, log_line VARCHAR, description VARCHAR, notes VARCHAR)";
+
+static const char *const ADV_LONG_STRINGS[] = {
+    "https://example.com/api/v2/users/search?query=active&limit=100&offset=0&sort=created_at&order=desc",
+    "https://example.com/api/v2/products/list?category=electronics&in_stock=true&min_price=10&max_price=500",
+    "https://example.com/api/v2/orders/history?user_id=42&status=completed&from=2024-01-01&to=2024-12-31",
+    "https://example.com/api/v2/reports/summary?type=monthly&department=sales&year=2024&format=json",
+    "/var/log/app/service_2024_01.log: [INFO] Request processed successfully in 42ms for endpoint /health",
+    "/var/log/app/service_2024_01.log: [WARN] Response time exceeded threshold: 1523ms for endpoint /search",
+    "/var/log/app/service_2024_01.log: [ERROR] Database connection timeout after 30s, retrying attempt 3/5",
+    "/var/log/app/service_2024_01.log: [DEBUG] Cache miss for key user_session_abc123, fetching from database",
+};
+static const uint32_t ADV_LONG_STRING_LENS[] = {97, 103, 101, 98, 101, 103, 101, 103};
+static constexpr idx_t ADV_LONG_STRING_COUNT  = 8;
+
+static const int32_t ADV_STATUS[]   = {1, 2, 3, 4};
+static const int32_t ADV_PRIORITY[] = {1, 2, 3, 4, 5};
+static const int32_t ADV_REGION[]   = {10, 20, 30, 40, 50, 60, 70, 80};
+
+class AppenderAdvancedBenchmark : public DuckDBBenchmark {
+	AppenderAdvancedBenchmark(bool r) : DuckDBBenchmark(r, "AppenderAdvanced1M", "[appender_advanced]") {}
+public:
+	static AppenderAdvancedBenchmark *GetInstance() {
+		static AppenderAdvancedBenchmark s(true);
+		auto b = duckdb::unique_ptr<AppenderAdvancedBenchmark>(new AppenderAdvancedBenchmark(false));
+		return &s;
+	}
+	bool InMemory() override { return false; }
+	size_t NRuns() override  { return 250; }
+
+	void Load(DuckDBBenchmarkState *state) override { state->conn.Query(CREATE_ADV_TABLE); }
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		Appender appender(state->conn, "adv_workload");
+		for (int32_t i = 0; i < ADV_ROW_COUNT; i++) {
+			const idx_t url_idx = idx_t(i)      % ADV_LONG_STRING_COUNT;
+			const idx_t log_idx = (idx_t(i) + 2) % ADV_LONG_STRING_COUNT;
+			const idx_t dsc_idx = (idx_t(i) + 4) % ADV_LONG_STRING_COUNT;
+			const idx_t not_idx = (idx_t(i) + 6) % ADV_LONG_STRING_COUNT;
+			appender.BeginRow();
+			appender.Append<int32_t>(ADV_STATUS[(i / ADV_RUN_LENGTH) % 4]);
+			appender.Append<int32_t>(ADV_PRIORITY[(i / ADV_RUN_LENGTH) % 5]);
+			appender.Append<int32_t>(ADV_REGION[(i / ADV_RUN_LENGTH) % 8]);
+			appender.Append<int32_t>(ADV_STATUS[(i / (ADV_RUN_LENGTH * 2)) % 4]);
+			appender.Append<double>(1.0 + double((i / ADV_RUN_LENGTH) % 5) * 0.25);
+			appender.Append<double>(1.0 + double((i / (ADV_RUN_LENGTH * 3)) % 4) * 0.5);
+			appender.Append<string_t>(string_t(ADV_LONG_STRINGS[url_idx], ADV_LONG_STRING_LENS[url_idx]));
+			appender.Append<string_t>(string_t(ADV_LONG_STRINGS[log_idx], ADV_LONG_STRING_LENS[log_idx]));
+			appender.Append<string_t>(string_t(ADV_LONG_STRINGS[dsc_idx], ADV_LONG_STRING_LENS[dsc_idx]));
+			appender.Append<string_t>(string_t(ADV_LONG_STRINGS[not_idx], ADV_LONG_STRING_LENS[not_idx]));
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE adv_workload");
+		Load(state);
+	}
+	string VerifyResult(QueryResult *result) override { return string(); }
+	string BenchmarkInfo() override {
+		return "1M rows: low-cardinality INT (runs 1000) + long VARCHAR (~100 chars)";
+	}
+};
+auto global_instance_AppenderAdvanced1M = AppenderAdvancedBenchmark::GetInstance();

--- a/benchmark/micro/appender_int.cpp
+++ b/benchmark/micro/appender_int.cpp
@@ -1,0 +1,90 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark.hpp"
+#include "duckdb/main/appender.hpp"
+
+using namespace duckdb;
+
+// Integer-only benchmarks targeting RLE compression behaviour.
+//   HighCard — high-cardinality sequential values: RLE early exit fires
+//   LowCard  — low-cardinality runs of 1000:       RLE wins, no early exit
+
+static constexpr int32_t INT_ROW_COUNT  = 1000000;
+static constexpr int32_t INT_RUN_LENGTH = 1000;
+
+static const char CREATE_INT_BENCH[] =
+    "CREATE TABLE int_bench("
+    "c0 INTEGER, c1 INTEGER, c2 INTEGER, c3 INTEGER,"
+    "c4 INTEGER, c5 INTEGER, c6 INTEGER, c7 INTEGER)";
+
+class AppenderIntBenchmark : public DuckDBBenchmark {
+protected:
+	AppenderIntBenchmark(bool r, const string &name)
+	    : DuckDBBenchmark(r, name, "[appender_int]") {}
+public:
+	bool InMemory() override { return false; }
+	size_t NRuns() override  { return 250; }
+	void Load(DuckDBBenchmarkState *state) override { state->conn.Query(CREATE_INT_BENCH); }
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE int_bench");
+		Load(state);
+	}
+	string VerifyResult(QueryResult *result) override { return string(); }
+};
+
+// High-cardinality: all-distinct sequential values → RLE cannot win
+class AppenderIntHighCardBenchmark : public AppenderIntBenchmark {
+	AppenderIntHighCardBenchmark(bool r) : AppenderIntBenchmark(r, "AppenderIntHighCard") {}
+public:
+	static AppenderIntHighCardBenchmark *GetInstance() {
+		static AppenderIntHighCardBenchmark s(true);
+		auto b = duckdb::unique_ptr<AppenderIntHighCardBenchmark>(new AppenderIntHighCardBenchmark(false));
+		return &s;
+	}
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		Appender appender(state->conn, "int_bench");
+		for (int32_t i = 0; i < INT_ROW_COUNT; i++) {
+			appender.BeginRow();
+			appender.Append<int32_t>(i);
+			appender.Append<int32_t>(i * 7 + 1);
+			appender.Append<int32_t>(i % 200000 + 1);
+			appender.Append<int32_t>(i % 100000 + 1);
+			appender.Append<int32_t>(i / 7 + 1);
+			appender.Append<int32_t>(i % 10000 + 1);
+			appender.Append<int32_t>(i % 50000 + 1);
+			appender.Append<int32_t>(i % 7 + 1);
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+	string BenchmarkInfo() override { return "1M rows 8×INTEGER high-cardinality — RLE early exit fires"; }
+};
+auto global_instance_AppenderIntHighCard = AppenderIntHighCardBenchmark::GetInstance();
+
+// Low-cardinality: runs of 1000 → RLE wins, early exit must NOT fire
+class AppenderIntLowCardBenchmark : public AppenderIntBenchmark {
+	AppenderIntLowCardBenchmark(bool r) : AppenderIntBenchmark(r, "AppenderIntLowCard") {}
+public:
+	static AppenderIntLowCardBenchmark *GetInstance() {
+		static AppenderIntLowCardBenchmark s(true);
+		auto b = duckdb::unique_ptr<AppenderIntLowCardBenchmark>(new AppenderIntLowCardBenchmark(false));
+		return &s;
+	}
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		Appender appender(state->conn, "int_bench");
+		for (int32_t i = 0; i < INT_ROW_COUNT; i++) {
+			appender.BeginRow();
+			appender.Append<int32_t>((i / INT_RUN_LENGTH) % 4 + 1);
+			appender.Append<int32_t>((i / INT_RUN_LENGTH) % 5 + 1);
+			appender.Append<int32_t>((i / INT_RUN_LENGTH) % 8 + 1);
+			appender.Append<int32_t>((i / INT_RUN_LENGTH) % 3 + 1);
+			appender.Append<int32_t>((i / INT_RUN_LENGTH) % 6 + 1);
+			appender.Append<int32_t>((i / INT_RUN_LENGTH) % 4 + 10);
+			appender.Append<int32_t>((i / (INT_RUN_LENGTH * 2)) % 5 + 1);
+			appender.Append<int32_t>((i / (INT_RUN_LENGTH * 3)) % 4 + 1);
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+	string BenchmarkInfo() override { return "1M rows 8×INTEGER low-cardinality runs of 1000 — RLE wins"; }
+};
+auto global_instance_AppenderIntLowCard = AppenderIntLowCardBenchmark::GetInstance();

--- a/benchmark/micro/appender_lineitem.cpp
+++ b/benchmark/micro/appender_lineitem.cpp
@@ -1,0 +1,140 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark.hpp"
+#include "duckdb/main/appender.hpp"
+
+using namespace duckdb;
+
+// TPC-H lineitem-inspired 16-column benchmark for compression analysis.
+// All variants use file-based persistent storage (InMemory=false) and
+// run 250 hot iterations for stable medians.
+//
+// AppenderLineitem1M               — auto compression detection (baseline)
+// AppenderLineitem1MForcedCompression — USING COMPRESSION per column
+
+static constexpr int32_t LINEITEM_ROW_COUNT = 1000000;
+static constexpr int32_t LINEITEM_BASE_DATE = 8827; // 1994-01-01 as days since epoch
+
+static const char CREATE_LINEITEM_AUTO[] =
+    "CREATE TABLE lineitem("
+    "l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,"
+    "l_quantity DOUBLE, l_extendedprice DOUBLE, l_discount DOUBLE, l_tax DOUBLE,"
+    "l_returnflag VARCHAR, l_linestatus VARCHAR,"
+    "l_shipdate INTEGER, l_commitdate INTEGER, l_receiptdate INTEGER,"
+    "l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR)";
+
+static const char CREATE_LINEITEM_FORCED[] =
+    "CREATE TABLE lineitem("
+    "l_orderkey    INTEGER  USING COMPRESSION BITPACKING,"
+    "l_partkey     INTEGER  USING COMPRESSION BITPACKING,"
+    "l_suppkey     INTEGER  USING COMPRESSION BITPACKING,"
+    "l_linenumber  INTEGER  USING COMPRESSION BITPACKING,"
+    "l_quantity    DOUBLE   USING COMPRESSION ALP,"
+    "l_extendedprice DOUBLE USING COMPRESSION ALP,"
+    "l_discount    DOUBLE   USING COMPRESSION ALP,"
+    "l_tax         DOUBLE   USING COMPRESSION ALP,"
+    "l_returnflag  VARCHAR  USING COMPRESSION DICTIONARY,"
+    "l_linestatus  VARCHAR  USING COMPRESSION DICTIONARY,"
+    "l_shipdate    INTEGER  USING COMPRESSION BITPACKING,"
+    "l_commitdate  INTEGER  USING COMPRESSION BITPACKING,"
+    "l_receiptdate INTEGER  USING COMPRESSION BITPACKING,"
+    "l_shipinstruct VARCHAR USING COMPRESSION DICTIONARY,"
+    "l_shipmode    VARCHAR  USING COMPRESSION DICTIONARY,"
+    "l_comment     VARCHAR  USING COMPRESSION DICTIONARY)";
+
+static const char *const RETURNFLAGS[]     = {"A", "N", "R"};
+static const uint32_t    RETURNFLAG_LENS[] = {1, 1, 1};
+static const char *const LINESTATUS[]      = {"O", "F"};
+static const uint32_t    LINESTATUS_LENS[] = {1, 1};
+static const char *const SHIPINSTRUCT[]    = {"DELIVER IN PERSON", "COLLECT COD", "NONE", "TAKE BACK RETURN"};
+static const uint32_t    SHIPINSTRUCT_LENS[] = {17, 11, 4, 16};
+static const char *const SHIPMODE[]        = {"AIR", "AIR REG", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK"};
+static const uint32_t    SHIPMODE_LENS[]   = {3, 7, 3, 4, 4, 7, 4, 5};
+static const char        COMMENT_STR[]     = "regular annual package";
+static constexpr uint32_t COMMENT_LEN      = 22;
+
+// ---------------------------------------------------------------------------
+// Shared base class
+// ---------------------------------------------------------------------------
+class AppenderLineitemBenchmark : public DuckDBBenchmark {
+protected:
+	AppenderLineitemBenchmark(bool register_benchmark, const string &name)
+	    : DuckDBBenchmark(register_benchmark, name, "[appender_lineitem]") {
+	}
+
+public:
+	bool InMemory() override { return false; }
+	size_t NRuns() override  { return 250; }
+
+	void RunBenchmark(DuckDBBenchmarkState *state) override {
+		Appender appender(state->conn, "lineitem");
+		for (int32_t i = 0; i < LINEITEM_ROW_COUNT; i++) {
+			const idx_t rf = idx_t(i) % 3;
+			const idx_t ls = idx_t(i) % 2;
+			const idx_t si = idx_t(i) % 4;
+			const idx_t sm = idx_t(i) % 8;
+			appender.BeginRow();
+			appender.Append<int32_t>(i / 7 + 1);
+			appender.Append<int32_t>(i % 200000 + 1);
+			appender.Append<int32_t>(i % 10000 + 1);
+			appender.Append<int32_t>(i % 7 + 1);
+			appender.Append<double>(1.0 + double(i % 50));
+			appender.Append<double>(900.0 + double(i % 104949) * 0.01);
+			appender.Append<double>(double(i % 11) * 0.01);
+			appender.Append<double>(double(i % 9) * 0.01);
+			appender.Append<string_t>(string_t(RETURNFLAGS[rf], RETURNFLAG_LENS[rf]));
+			appender.Append<string_t>(string_t(LINESTATUS[ls], LINESTATUS_LENS[ls]));
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);
+			appender.Append<int32_t>(LINEITEM_BASE_DATE + i % 2557);
+			appender.Append<string_t>(string_t(SHIPINSTRUCT[si], SHIPINSTRUCT_LENS[si]));
+			appender.Append<string_t>(string_t(SHIPMODE[sm], SHIPMODE_LENS[sm]));
+			appender.Append<string_t>(string_t(COMMENT_STR, COMMENT_LEN));
+			appender.EndRow();
+		}
+		appender.Close();
+	}
+
+	void Cleanup(DuckDBBenchmarkState *state) override {
+		state->conn.Query("DROP TABLE lineitem");
+		Load(state);
+	}
+
+	string VerifyResult(QueryResult *result) override { return string(); }
+};
+
+// ---------------------------------------------------------------------------
+// Variant 1: auto compression detection (baseline)
+// ---------------------------------------------------------------------------
+class AppenderLineitem1MBenchmark : public AppenderLineitemBenchmark {
+	AppenderLineitem1MBenchmark(bool r) : AppenderLineitemBenchmark(r, "AppenderLineitem1M") {}
+public:
+	static AppenderLineitem1MBenchmark *GetInstance() {
+		static AppenderLineitem1MBenchmark s(true);
+		auto b = duckdb::unique_ptr<AppenderLineitem1MBenchmark>(new AppenderLineitem1MBenchmark(false));
+		return &s;
+	}
+	void Load(DuckDBBenchmarkState *state) override { state->conn.Query(CREATE_LINEITEM_AUTO); }
+	string BenchmarkInfo() override { return "1M lineitem rows — auto compression detection"; }
+};
+auto global_instance_AppenderLineitem1M = AppenderLineitem1MBenchmark::GetInstance();
+
+// ---------------------------------------------------------------------------
+// Variant 2: hard-coded per-column compression (no detect scan when fixed)
+// ---------------------------------------------------------------------------
+class AppenderLineitem1MForcedCompressionBenchmark : public AppenderLineitemBenchmark {
+	AppenderLineitem1MForcedCompressionBenchmark(bool r)
+	    : AppenderLineitemBenchmark(r, "AppenderLineitem1MForcedCompression") {}
+public:
+	static AppenderLineitem1MForcedCompressionBenchmark *GetInstance() {
+		static AppenderLineitem1MForcedCompressionBenchmark s(true);
+		auto b = duckdb::unique_ptr<AppenderLineitem1MForcedCompressionBenchmark>(
+		    new AppenderLineitem1MForcedCompressionBenchmark(false));
+		return &s;
+	}
+	void Load(DuckDBBenchmarkState *state) override { state->conn.Query(CREATE_LINEITEM_FORCED); }
+	string BenchmarkInfo() override {
+		return "1M lineitem rows — USING COMPRESSION per column (Bitpacking/ALP/Dictionary)";
+	}
+};
+auto global_instance_AppenderLineitem1MForcedCompression =
+    AppenderLineitem1MForcedCompressionBenchmark::GetInstance();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Benchmark-only additions with no changes to engine, storage, or runtime behavior.
> 
> **Overview**
> Adds **five new micro benchmarks** under `benchmark/micro/` that measure **1M-row `Appender` ingestion** on disk-backed storage (250 runs each), aimed at **compression codec behavior** (RLE/FSST early-exit, auto-detect vs forced codecs).
> 
> **Integer RLE** (`appender_int.cpp`): `AppenderIntHighCard` vs `AppenderIntLowCard` on eight integer columns—high-cardinality sequential values vs 1000-row low-cardinality runs.
> 
> **Mixed workload** (`appender_advanced.cpp`): `AppenderAdvanced1M` with low-cardinality integer runs plus ~100-char repeating VARCHARs (URLs/log lines).
> 
> **Lineitem-style** (`appender_lineitem.cpp`): shared 16-column TPC-H-like data; `AppenderLineitem1M` uses default compression detection, `AppenderLineitem1MForcedCompression` pins **BITPACKING / ALP / DICTIONARY** per column via `USING COMPRESSION`.
> 
> `CMakeLists.txt` registers the three new `.cpp` objects in `duckdb_benchmark_micro`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ddab96bb164ead583611abae3ad29a74646fbd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->