### PR TITLE
Fix list conversion

### DIFF
--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -225,16 +225,12 @@ static bool ListToArrayCast(Vector &source, Vector &result, idx_t count, CastPar
 		// We can just cast the child vector directly
 		// Note: Its worth doing a CheckAllValid here, the slow path is significantly more expensive
 		if (FlatVector::ValidityMutable(result).CheckAllValid(count)) {
-			Vector payload_vector(result_cc.GetType(), child_count);
-
-			bool ok = cast_data.child_cast_info.Cast(source_cc, payload_vector, child_count, child_parameters);
+			Vector sliced_source(source_cc, child_sel, child_count);
+			bool ok = cast_data.child_cast_info.Cast(sliced_source, result_cc, child_count, child_parameters);
 			if (all_ok && !ok) {
 				all_ok = false;
 				HandleCastError::AssignError(*child_parameters.error_message, parameters);
 			}
-			// Now do the actual copy onto the result vector, making sure to slice properly in case the lists are out of
-			// order
-			VectorOperations::Copy(payload_vector, result_cc, child_sel, child_count, 0, 0);
 			return all_ok;
 		}
 

--- a/test/sql/types/nested/array/array_cast.test
+++ b/test/sql/types/nested/array/array_cast.test
@@ -170,3 +170,19 @@ query I
 SELECT TRY_CAST(l AS INTEGER[][3]) FROM VALUES (['foo']) as v(l);
 ----
 NULL
+
+# Sliced lists keep child offsets into the original list child vector. LIST -> ARRAY casts should only cast selected
+# child values, not a prefix of the original child vector.
+query II
+WITH t(l) AS (VALUES (['bad','1','2']), (['bad','3','4']))
+SELECT list_slice(l, 2, 3), TRY_CAST(list_slice(l, 2, 3) AS INTEGER[2])
+FROM t
+----
+[1, 2]	[1, 2]
+[3, 4]	[3, 4]
+
+query I
+SELECT CAST(list_slice(l, 2, 3) AS INTEGER[2])
+FROM (VALUES (['bad','1','2'])) t(l)
+----
+[1, 2]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches nested-type cast fast path used by LIST→ARRAY; behavior change is localized but affects correctness for sliced lists and multi-row batches.
> 
> **Overview**
> Fixes incorrect **LIST → ARRAY** casts when list values are **sliced** (e.g. `list_slice`), where child elements still point at offsets in the original list child vector.
> 
> In `ListToArrayCast`’s all-valid fast path, the cast no longer runs on a prefix of the full child vector and copies with `child_sel`. It builds a **selection-sliced** child view (`Vector sliced_source` + `child_sel`) and casts straight into the array child vector, so only the intended elements are converted.
> 
> Adds SQL tests covering `TRY_CAST`/`CAST` of sliced lists to fixed-size integer arrays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd075dc589bb8f99f8e51fcaaaad854d36a74f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->