### PR TITLE
fix bound index

### DIFF
--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -1212,9 +1212,18 @@ void WriteAheadLogDeserializer::ReplayRowGroupData() {
 		for (auto &col : state.current_table->GetColumns().Physical()) {
 			column_ids.emplace_back(col.StorageOid());
 		}
+		DataChunk index_chunk;
+		vector<StorageIndex> mapped_column_ids;
+		const auto has_unbound_indexes = indexes.HasUnbound();
+		if (has_unbound_indexes) {
+			TableIndexList::InitializeIndexChunk(index_chunk, storage.GetTypes(), mapped_column_ids, *table_info);
+		}
 		Vector row_id_vector(LogicalType::ROW_TYPE, STANDARD_VECTOR_SIZE);
 		auto current_row_id = storage.GetNextRowId();
 		for (auto &chunk : new_row_groups.Chunks(transaction, column_ids)) {
+			if (has_unbound_indexes) {
+				TableIndexList::ReferenceIndexChunk(chunk, index_chunk, mapped_column_ids);
+			}
 			auto row_id_writer = FlatVector::Writer<row_t>(row_id_vector, chunk.size());
 			for (idx_t r = 0; r < chunk.size(); r++) {
 				row_id_writer.WriteValue(NumericCast<row_t>(current_row_id + r));
@@ -1223,7 +1232,8 @@ void WriteAheadLogDeserializer::ReplayRowGroupData() {
 			for (auto &index : indexes.Indexes()) {
 				if (!index.IsBound()) {
 					auto &unbound_index = index.Cast<UnboundIndex>();
-					unbound_index.BufferChunk(chunk, row_id_vector, column_ids, BufferedIndexReplay::INSERT_ENTRY);
+					unbound_index.BufferChunk(index_chunk, row_id_vector, mapped_column_ids,
+					                          BufferedIndexReplay::INSERT_ENTRY);
 					continue;
 				}
 				auto &bound_index = index.Cast<BoundIndex>();

--- a/test/sql/index/art/storage/test_art_wal_replay_full_row_group_append.test
+++ b/test/sql/index/art/storage/test_art_wal_replay_full_row_group_append.test
@@ -1,0 +1,76 @@
+# name: test/sql/index/art/storage/test_art_wal_replay_full_row_group_append.test
+# description: WAL replay of delete plus full-row-group append should bind unique ART indexes
+# group: [storage]
+
+require noforcestorage
+
+require no_alternative_verify
+
+load {TEST_DIR}/test_art_wal_replay_full_row_group_append_main.db
+
+statement ok
+SET wal_autocheckpoint = '1TB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+SET checkpoint_on_detach = 'DISABLED';
+
+statement ok
+ATTACH '{TEST_DIR}/test_art_wal_replay_full_row_group_append_data.db' AS idxdb (ROW_GROUP_SIZE 2048);
+
+statement ok
+CREATE TABLE idxdb.t AS
+	SELECT i::INTEGER AS i, (i * 10)::BIGINT AS v
+	FROM range(0, 10000) tbl(i);
+
+statement ok
+CREATE UNIQUE INDEX idx_t_i ON idxdb.t(i);
+
+statement ok
+CHECKPOINT idxdb;
+
+statement ok
+DELETE FROM idxdb.t WHERE i % 7 = 0;
+
+statement ok
+INSERT INTO idxdb.t
+	SELECT i::INTEGER AS i, (i * 10)::BIGINT AS v
+	FROM range(10000, 12048) tbl(i);
+
+query III
+SELECT count(*), sum(i), sum(v) FROM idxdb.t
+----
+10619	65428986	654289860
+
+statement ok
+DETACH idxdb;
+
+query I
+SELECT count(*) FROM glob('{TEST_DIR}/test_art_wal_replay_full_row_group_append_data.db.wal')
+----
+1
+
+restart
+
+statement ok
+ATTACH '{TEST_DIR}/test_art_wal_replay_full_row_group_append_data.db' AS idxdb;
+
+query II
+SELECT count(*), COALESCE(sum(v), -1) FROM idxdb.t WHERE i = 10000;
+----
+1	100000
+
+query II
+SELECT count(*), COALESCE(sum(v), -1) FROM idxdb.t WHERE i = 7;
+----
+0	-1
+
+query II
+SELECT count(*), COALESCE(sum(v), -1) FROM idxdb.t WHERE i = 8;
+----
+1	80
+
+statement ok
+CHECKPOINT idxdb;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches WAL replay index update logic on recovery paths; wrong column mapping could affect index correctness, but change mirrors existing append code and is covered by a targeted test.
> 
> **Overview**
> Fixes incorrect **unbound index** buffering when replaying **ROW_GROUP_DATA** WAL entries so unique ART indexes can bind correctly after restart.
> 
> During row-group merge replay, **unbound** indexes now receive an **index-only** `DataChunk` and **mapped column IDs** (via `TableIndexList::InitializeIndexChunk` / `ReferenceIndexChunk`), matching normal append paths. Previously the full physical table chunk was passed to `BufferChunk`, which could corrupt buffered replay data when deletes and large appends left only WAL state.
> 
> Adds a regression test: checkpoint, delete, full row-group insert, detach with WAL, restart/attach, and queries that depend on the unique index and delete visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad91cd4374f262ef75cfff3df95855a6fd33bbd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->