### PR TITLE
[demo] lru change

### DIFF
--- a/src/include/duckdb/common/lru_cache.hpp
+++ b/src/include/duckdb/common/lru_cache.hpp
@@ -36,9 +36,13 @@ public:
 	using mapped_type = shared_ptr<Val>;
 	using hasher = KeyHash;
 	using key_equal = KeyEqual;
+	using EntryCallback = std::function<void(const Key &, const shared_ptr<Val> &)>;
 
 	// @param max_total_weight_p: Maximum total weight (in relevant unit) of entries. 0 means unlimited.
-	explicit SharedLruCache(idx_t max_total_weight_p) : max_total_weight(max_total_weight_p), current_total_weight(0) {
+	explicit SharedLruCache(idx_t max_total_weight_p, EntryCallback insert_callback_p = nullptr,
+	                        EntryCallback delete_callback_p = nullptr)
+	    : max_total_weight(max_total_weight_p), current_total_weight(0),
+	      insert_callback(std::move(insert_callback_p)), delete_callback(std::move(delete_callback_p)) {
 	}
 
 	// Disable copy and move
@@ -72,8 +76,9 @@ public:
 		new_entry.payload = std::move(payload);
 		new_entry.payload_weight = payload_weight;
 
-		entry_map[std::move(key)] = std::move(new_entry);
+		auto entry = entry_map.emplace(std::move(key), std::move(new_entry));
 		current_total_weight += payload_weight;
+		OnEntryInserted(entry.first);
 	}
 
 	// Delete the entry with key `key`.
@@ -101,9 +106,12 @@ public:
 
 	// Clear the whole cache.
 	void Clear() {
-		entry_map.clear();
-		lru_list.clear();
-		current_total_weight = 0;
+		while (!lru_list.empty()) {
+			const auto &stale_key = lru_list.back();
+			auto stale_it = entry_map.find(stale_key);
+			D_ASSERT(stale_it != entry_map.end());
+			DeleteImpl(stale_it);
+		}
 	}
 
 	// Evict entries based on their access, until we've freed at least the target number of bytes or there's no entries
@@ -145,7 +153,20 @@ private:
 
 	using EntryMap = unordered_map<Key, Entry, KeyHash, KeyEqual>;
 
+	void OnEntryInserted(typename EntryMap::iterator iter) {
+		if (insert_callback) {
+			insert_callback(iter->first, iter->second.value);
+		}
+	}
+
+	void OnEntryDeleted(typename EntryMap::iterator iter) {
+		if (delete_callback) {
+			delete_callback(iter->first, iter->second.value);
+		}
+	}
+
 	void DeleteImpl(typename EntryMap::iterator iter) {
+		OnEntryDeleted(iter);
 		current_total_weight -= iter->second.payload_weight;
 		lru_list.erase(iter->second.lru_iterator);
 		entry_map.erase(iter);
@@ -173,6 +194,8 @@ private:
 	idx_t current_total_weight;
 	EntryMap entry_map;
 	list<Key> lru_list;
+	EntryCallback insert_callback;
+	EntryCallback delete_callback;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -111,8 +111,7 @@ private:
 	atomic<bool> enable;
 	//! Generation counter, incremented whenever cache enablement changes.
 	atomic<idx_t> generation;
-	//! Paths of the cached files tracked in the ObjectCache.
-	//! Entries should only be inserted at `GetOrCreateCachedFile` and deleted at object cache entry deletion.
+	//! Paths of cached files currently tracked in the ObjectCache.
 	unordered_set<string> cached_file_keys DUCKDB_GUARDED_BY(lock);
 	//! Lock for accessing cached_file_keys.
 	mutable annotated_mutex lock;

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -46,6 +46,12 @@ public:
 	//! Get the rough cache memory usage in bytes for this entry.
 	//! Used for eviction decisions. Return invalid index to prevent eviction.
 	virtual optional_idx GetEstimatedCacheMemory() const = 0;
+
+	virtual void OnLRUCacheInsert(const string &) {
+	}
+
+	virtual void OnLRUCacheDelete(const string &) {
+	}
 };
 
 struct CleanupBufferPool {
@@ -63,7 +69,15 @@ public:
 	explicit ObjectCache(BufferPool &buffer_pool_p) : ObjectCache(DEFAULT_MAX_MEMORY, buffer_pool_p) {
 	}
 
-	ObjectCache(idx_t max_memory, BufferPool &buffer_pool_p) : lru_cache(max_memory), buffer_pool(buffer_pool_p) {
+	ObjectCache(idx_t max_memory, BufferPool &buffer_pool_p)
+	    : lru_cache(max_memory,
+	                [](const string &key, const shared_ptr<ObjectCacheEntry> &value) {
+		                value->OnLRUCacheInsert(key);
+	                },
+	                [](const string &key, const shared_ptr<ObjectCacheEntry> &value) {
+		                value->OnLRUCacheDelete(key);
+	                }),
+	      buffer_pool(buffer_pool_p) {
 	}
 
 	shared_ptr<ObjectCacheEntry> GetObject(const string &key) {

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -18,12 +18,9 @@ class ExternalFileCache::ExternalFileCacheObjectCacheEntry : public ObjectCacheE
 public:
 	ExternalFileCacheObjectCacheEntry(ExternalFileCache &cache_p, string path_p, idx_t generation_p)
 	    : cache(cache_p), cached_file(make_shared_ptr<CachedFile>(std::move(path_p), generation_p)) {
-		cache.InsertCachedFileKey(cached_file->path);
 	}
 
-	~ExternalFileCacheObjectCacheEntry() override {
-		cache.EraseCachedFileKey(cached_file->path);
-	}
+	~ExternalFileCacheObjectCacheEntry() override = default;
 
 	static string ObjectType() {
 		return "external_file_cache";
@@ -31,6 +28,14 @@ public:
 
 	string GetObjectType() override {
 		return ObjectType();
+	}
+
+	void OnLRUCacheInsert(const string &) override {
+		cache.InsertCachedFileKey(cached_file->path);
+	}
+
+	void OnLRUCacheDelete(const string &) override {
+		cache.EraseCachedFileKey(cached_file->path);
 	}
 
 	optional_idx GetEstimatedCacheMemory() const override {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared LRU and ObjectCache eviction paths; incorrect callback ordering could desync external file cache bookkeeping, though scope is limited and other entries use default no-op hooks.
> 
> **Overview**
> **`SharedLruCache`** now accepts optional **insert** and **delete** callbacks and invokes them whenever entries are added or removed through **`Put`**, **`Delete`**, eviction, or **`Clear`**. **`Clear`** no longer wipes internal maps directly; it evicts entries one-by-one via **`DeleteImpl`** so delete callbacks run consistently.
> 
> **`ObjectCache`** registers those callbacks to call **`OnLRUCacheInsert`** / **`OnLRUCacheDelete`** on **`ObjectCacheEntry`** (default no-ops). **External file cache** moves **`cached_file_keys`** registration off the object-cache entry constructor/destructor and into those hooks, so the tracked path set stays aligned with LRU presence (including eviction and cache clears), not only when the entry object is destroyed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a5ebc5972fbc02364811ac7c793c746960dc25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->