### PR TITLE
Fix DICT_FSST filter

### DIFF
--- a/src/include/duckdb/storage/compression/dict_fsst/decompression.hpp
+++ b/src/include/duckdb/storage/compression/dict_fsst/decompression.hpp
@@ -4,6 +4,10 @@
 
 namespace duckdb {
 
+// Forward declarations.
+struct TableFilterState;
+class TableFilter;
+
 namespace dict_fsst {
 
 //===--------------------------------------------------------------------===//
@@ -64,6 +68,9 @@ public:
 	bool all_values_inlined = false;
 
 	unsafe_unique_array<bool> filter_result;
+	bool null_filter_result_initialized = false;
+	unique_ptr<TableFilterState> dictionary_filter_state;
+	unique_ptr<TableFilter> noop_validity_filter;
 };
 
 } // namespace dict_fsst

--- a/src/storage/compression/dict_fsst.cpp
+++ b/src/storage/compression/dict_fsst.cpp
@@ -233,7 +233,7 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 			auto dict_offset = dict_sel.get_index(row_idx);
 			// Evaluate NULL only when slot zero is referenced by an actual row.
 			if (dict_offset == 0 && !scan_state.null_filter_result_initialized) {
-				Vector null_data(scan_state.dictionary->data, /*offset=*/0, /*count=*/1);
+				Vector null_data(scan_state.dictionary->data, /*offset=*/0, /*end=*/1);
 				SelectionVector null_sel;
 				idx_t null_filter_count = 1;
 				ColumnSegment::FilterSelection(null_sel, null_data, dictionary_filter_state, 1, null_filter_count);

--- a/src/storage/compression/dict_fsst.cpp
+++ b/src/storage/compression/dict_fsst.cpp
@@ -4,6 +4,9 @@
 #include "duckdb/storage/compression/dict_fsst/decompression.hpp"
 #include "duckdb/function/compression/compression.hpp"
 #include "duckdb/function/compression_function.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/planner/table_filter_state.hpp"
 
 /*
 Data layout per segment:
@@ -176,10 +179,30 @@ void DictFSSTSelect(ColumnSegment &segment, ColumnScanState &state, idx_t vector
 //===--------------------------------------------------------------------===//
 // Filter
 //===--------------------------------------------------------------------===//
+static void PrepareValidityFilterState(CompressedStringScanState &scan_state, TableFilterState &filter_state) {
+	if (scan_state.noop_validity_filter) {
+		return;
+	}
+	// DICT_FSST already applies the filter to both values and NULLs.
+	auto &expression_state = filter_state.Cast<ExpressionFilterState>();
+	scan_state.noop_validity_filter =
+	    make_uniq<ExpressionFilter>(make_uniq<BoundConstantExpression>(Value::BOOLEAN(true)));
+	auto validity_state = TableFilterState::Initialize(expression_state.GetContext(), *scan_state.noop_validity_filter);
+	auto &validity_expression_state = validity_state->Cast<ExpressionFilterState>();
+	expression_state.executor = std::move(validity_expression_state.executor);
+	expression_state.fast_executor = std::move(validity_expression_state.fast_executor);
+}
+
 static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
                            SelectionVector &sel, idx_t &sel_count, const TableFilter &filter,
                            TableFilterState &filter_state) {
 	auto &scan_state = state.scan_state->Cast<CompressedStringScanState>();
+	if (!scan_state.dictionary_filter_state) {
+		// Validity filtering can evaluate the shared state with a synthetic NULL.
+		auto &expression_state = filter_state.Cast<ExpressionFilterState>();
+		scan_state.dictionary_filter_state = TableFilterState::Initialize(expression_state.GetContext(), filter);
+	}
+	auto &dictionary_filter_state = *scan_state.dictionary_filter_state;
 	auto start = state.GetPositionInSegment();
 	if (scan_state.AllowDictionaryScan(vector_count)) {
 		// only pushdown filters on dictionaries
@@ -188,24 +211,36 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 			// initialize the filter result - setting everything to false
 			scan_state.filter_result = make_unsafe_uniq_array<bool>(scan_state.dict_count);
 
-			// apply the filter
-			auto &dict_data = scan_state.dictionary->data;
+			// Slot zero represents NULL and is not necessarily referenced by any row.
+			idx_t non_null_count = scan_state.dict_count - 1;
+			Vector dict_data(scan_state.dictionary->data, /*offset=*/1, scan_state.dict_count);
 			SelectionVector dict_sel;
-			idx_t filter_count = scan_state.dict_count;
-			ColumnSegment::FilterSelection(dict_sel, dict_data, filter_state, scan_state.dict_count, filter_count);
+			ColumnSegment::FilterSelection(dict_sel, dict_data, dictionary_filter_state, non_null_count,
+			                               non_null_count);
 
 			// now set all matching tuples to true
-			for (idx_t i = 0; i < filter_count; i++) {
-				auto idx = dict_sel.get_index(i);
+			for (idx_t i = 0; i < non_null_count; i++) {
+				auto idx = dict_sel.get_index(i) + 1;
 				scan_state.filter_result[idx] = true;
 			}
 		}
+		// Till now, we have a filter result for all non-NULL values.
 		auto &dict_sel = scan_state.GetSelVec(start, vector_count);
 		SelectionVector new_sel(sel_count);
 		idx_t approved_tuple_count = 0;
 		for (idx_t idx = 0; idx < sel_count; idx++) {
 			auto row_idx = sel.get_index(idx);
 			auto dict_offset = dict_sel.get_index(row_idx);
+			// Evaluate NULL only when slot zero is referenced by an actual row.
+			if (dict_offset == 0 && !scan_state.null_filter_result_initialized) {
+				Vector null_data(scan_state.dictionary->data, /*offset=*/0, /*count=*/1);
+				SelectionVector null_sel;
+				idx_t null_filter_count = 1;
+				ColumnSegment::FilterSelection(null_sel, null_data, dictionary_filter_state, 1, null_filter_count);
+				scan_state.filter_result[0] = null_filter_count == 1;
+				scan_state.null_filter_result_initialized = true;
+			}
+			// Check filter result for the value at the offset and assign selection vector.
 			if (!scan_state.filter_result[dict_offset]) {
 				// does not pass the filter
 				continue;
@@ -218,11 +253,13 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 		sel_count = approved_tuple_count;
 
 		result.Dictionary(scan_state.dictionary, dict_sel, vector_count);
+		PrepareValidityFilterState(scan_state, filter_state);
 		return;
 	}
 	// fallback: scan + filter
 	DictFSSTCompressionStorage::StringScan(segment, state, vector_count, result);
-	ColumnSegment::FilterSelection(sel, result, filter_state, vector_count, sel_count);
+	ColumnSegment::FilterSelection(sel, result, dictionary_filter_state, vector_count, sel_count);
+	PrepareValidityFilterState(scan_state, filter_state);
 }
 
 } // namespace dict_fsst

--- a/src/storage/compression/dict_fsst.cpp
+++ b/src/storage/compression/dict_fsst.cpp
@@ -179,7 +179,11 @@ void DictFSSTSelect(ColumnSegment &segment, ColumnScanState &state, idx_t vector
 //===--------------------------------------------------------------------===//
 // Filter
 //===--------------------------------------------------------------------===//
-static void PrepareValidityFilterState(CompressedStringScanState &scan_state, TableFilterState &filter_state) {
+// DICT_FSST applies the real filter inside DictFSSTFilter so it can filter on dictionary entries and handle
+// the synthetic NULL dictionary slot. Afterwards, StandardColumnData::Filter can still pass the same filter
+// state to the validity column filter, so replace that state with a constant-true expression once the real
+// filter has been applied.
+static void ReplaceValidityFilterWithNoop(CompressedStringScanState &scan_state, TableFilterState &filter_state) {
 	if (scan_state.noop_validity_filter) {
 		return;
 	}
@@ -198,7 +202,7 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
                            TableFilterState &filter_state) {
 	auto &scan_state = state.scan_state->Cast<CompressedStringScanState>();
 	if (!scan_state.dictionary_filter_state) {
-		// Validity filtering can evaluate the shared state with a synthetic NULL.
+		// Keep the real filter state before replacing the original with a noop.
 		auto &expression_state = filter_state.Cast<ExpressionFilterState>();
 		scan_state.dictionary_filter_state = TableFilterState::Initialize(expression_state.GetContext(), filter);
 	}
@@ -215,11 +219,11 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 			idx_t non_null_count = scan_state.dict_count - 1;
 			Vector dict_data(scan_state.dictionary->data, /*offset=*/1, scan_state.dict_count);
 			SelectionVector dict_sel;
-			ColumnSegment::FilterSelection(dict_sel, dict_data, dictionary_filter_state, non_null_count,
-			                               non_null_count);
+			idx_t filter_count = non_null_count;
+			ColumnSegment::FilterSelection(dict_sel, dict_data, dictionary_filter_state, non_null_count, filter_count);
 
 			// now set all matching tuples to true
-			for (idx_t i = 0; i < non_null_count; i++) {
+			for (idx_t i = 0; i < filter_count; i++) {
 				auto idx = dict_sel.get_index(i) + 1;
 				scan_state.filter_result[idx] = true;
 			}
@@ -253,13 +257,13 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 		sel_count = approved_tuple_count;
 
 		result.Dictionary(scan_state.dictionary, dict_sel, vector_count);
-		PrepareValidityFilterState(scan_state, filter_state);
+		ReplaceValidityFilterWithNoop(scan_state, filter_state);
 		return;
 	}
 	// fallback: scan + filter
 	DictFSSTCompressionStorage::StringScan(segment, state, vector_count, result);
 	ColumnSegment::FilterSelection(sel, result, dictionary_filter_state, vector_count, sel_count);
-	PrepareValidityFilterState(scan_state, filter_state);
+	ReplaceValidityFilterWithNoop(scan_state, filter_state);
 }
 
 } // namespace dict_fsst

--- a/test/sql/storage/compression/dict_fsst/dict_fsst_expression_filter.test
+++ b/test/sql/storage/compression/dict_fsst/dict_fsst_expression_filter.test
@@ -43,6 +43,12 @@ WHERE split_part(task_id, '/', 2)::INTEGER >= 10
 ----
 154
 
+query I
+SELECT count(*) FROM partial_segment
+WHERE split_part(task_id, '/', 2)::INTEGER >= 10000
+----
+0
+
 statement ok
 DELETE FROM partial_segment
 WHERE split_part(task_id, '/', 2)::INTEGER >= 10
@@ -57,6 +63,12 @@ SELECT count(*) FROM full_vector
 WHERE split_part(task_id, '/', 2)::INTEGER >= 10
 ----
 2038
+
+query I
+SELECT count(*) FROM full_vector
+WHERE split_part(task_id, '/', 2)::INTEGER >= 10000
+----
+0
 
 statement ok
 DELETE FROM full_vector

--- a/test/sql/storage/compression/dict_fsst/dict_fsst_expression_filter.test
+++ b/test/sql/storage/compression/dict_fsst/dict_fsst_expression_filter.test
@@ -1,0 +1,68 @@
+# name: test/sql/storage/compression/dict_fsst/dict_fsst_expression_filter.test
+# description: Test expression filters over DICT_FSST strings
+# group: [dict_fsst]
+
+require vector_size 2048
+
+load {TEST_DIR}/dict_fsst_expression_filter.db readwrite v2.0.0
+
+statement ok
+CREATE TABLE partial_segment AS
+SELECT concat('HumanEval/', i::VARCHAR) AS task_id
+FROM range(0, 164) tbl(i)
+
+statement ok
+CREATE TABLE full_vector AS
+SELECT concat('HumanEval/', i::VARCHAR) AS task_id
+FROM range(0, 2048) tbl(i)
+
+statement ok
+CHECKPOINT
+
+restart
+
+query I
+SELECT count(*) FROM pragma_storage_info('partial_segment')
+WHERE column_name = 'task_id'
+  AND segment_type = 'VARCHAR'
+  AND compression = 'DICT_FSST'
+----
+1
+
+query I
+SELECT count(*) FROM pragma_storage_info('full_vector')
+WHERE column_name = 'task_id'
+  AND segment_type = 'VARCHAR'
+  AND compression = 'DICT_FSST'
+----
+1
+
+query I
+SELECT count(*) FROM partial_segment
+WHERE split_part(task_id, '/', 2)::INTEGER >= 10
+----
+154
+
+statement ok
+DELETE FROM partial_segment
+WHERE split_part(task_id, '/', 2)::INTEGER >= 10
+
+query I
+SELECT count(*) FROM partial_segment
+----
+10
+
+query I
+SELECT count(*) FROM full_vector
+WHERE split_part(task_id, '/', 2)::INTEGER >= 10
+----
+2038
+
+statement ok
+DELETE FROM full_vector
+WHERE split_part(task_id, '/', 2)::INTEGER >= 10
+
+query I
+SELECT count(*) FROM full_vector
+----
+10


### PR DESCRIPTION
DICT_FSST applies filters once to each dictionary value and then checks the cached result for each row.
Dictionary slot 0 is a synthetic NULL sentinel, but the old implementation included all dict_count slots in dictionary filtering.
The validity filter then evaluated the expression again using a synthetic NULL, causing the ''::INTEGER conversion error.
The fix filters only dictionary slots 1 through N and evaluates slot 0 only when a real row references NULL.
It preserves dictionary filtering and makes the redundant validity-filter pass a no-op. 


https://github.com/duckdb/duckdb/issues/23741


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compressed-column scan filter pushdown and shared filter-state behavior for expression predicates; incorrect handling could affect query results or performance on DICT_FSST VARCHAR columns.
> 
> **Overview**
> Fixes **DICT_FSST** filter pushdown when predicates are **expression filters** (e.g. `split_part(...)::INTEGER >= 10`), including cases that previously failed with conversion errors on synthetic NULLs.
> 
> **Dictionary filtering** now runs on slots **1..N** only (real string values), with **slot 0** (NULL sentinel) evaluated **lazily** only if a scanned row references it. Filter evaluation uses a **cached `dictionary_filter_state`** instead of the shared filter state passed through column filtering.
> 
> After the segment applies the real predicate, **`ReplaceValidityFilterWithNoop`** swaps the filter state’s executors for a constant-**true** expression so the follow-up **validity-column** filter does not re-run the same expression on NULL.
> 
> Adds **SQL logic tests** for expression filters and deletes on both partial-segment and full-vector **DICT_FSST** tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89471b02c11c091da3d4438d40c338ae64f88de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->