### PR TITLE
Hjiang/duckdb fix fsst dict filter

### DIFF
--- a/src/include/duckdb/storage/compression/dict_fsst/decompression.hpp
+++ b/src/include/duckdb/storage/compression/dict_fsst/decompression.hpp
@@ -4,6 +4,10 @@
 
 namespace duckdb {
 
+// Forward declarations.
+struct TableFilterState;
+class TableFilter;
+
 namespace dict_fsst {
 
 //===--------------------------------------------------------------------===//
@@ -64,6 +68,9 @@ public:
 	bool all_values_inlined = false;
 
 	unsafe_unique_array<bool> filter_result;
+	bool null_filter_result_initialized = false;
+	unique_ptr<TableFilterState> dictionary_filter_state;
+	unique_ptr<TableFilter> noop_validity_filter;
 };
 
 } // namespace dict_fsst

--- a/src/include/duckdb/storage/compression/dict_fsst/decompression.hpp
+++ b/src/include/duckdb/storage/compression/dict_fsst/decompression.hpp
@@ -6,7 +6,6 @@ namespace duckdb {
 
 // Forward declarations.
 struct TableFilterState;
-class TableFilter;
 
 namespace dict_fsst {
 
@@ -70,7 +69,6 @@ public:
 	unsafe_unique_array<bool> filter_result;
 	bool null_filter_result_initialized = false;
 	unique_ptr<TableFilterState> dictionary_filter_state;
-	unique_ptr<TableFilter> noop_validity_filter;
 };
 
 } // namespace dict_fsst

--- a/src/storage/compression/dict_fsst.cpp
+++ b/src/storage/compression/dict_fsst.cpp
@@ -233,7 +233,7 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 			auto dict_offset = dict_sel.get_index(row_idx);
 			// Evaluate NULL only when slot zero is referenced by an actual row.
 			if (dict_offset == 0 && !scan_state.null_filter_result_initialized) {
-				Vector null_data(scan_state.dictionary->data, /*offset=*/0, /*count=*/1);
+				Vector null_data(scan_state.dictionary->data, /*offset=*/0, /*end=*/1);
 				SelectionVector null_sel;
 				idx_t null_filter_count = 1;
 				ColumnSegment::FilterSelection(null_sel, null_data, dictionary_filter_state, 1, null_filter_count);

--- a/src/storage/compression/dict_fsst.cpp
+++ b/src/storage/compression/dict_fsst.cpp
@@ -4,6 +4,9 @@
 #include "duckdb/storage/compression/dict_fsst/decompression.hpp"
 #include "duckdb/function/compression/compression.hpp"
 #include "duckdb/function/compression_function.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/planner/table_filter_state.hpp"
 
 /*
 Data layout per segment:
@@ -176,10 +179,30 @@ void DictFSSTSelect(ColumnSegment &segment, ColumnScanState &state, idx_t vector
 //===--------------------------------------------------------------------===//
 // Filter
 //===--------------------------------------------------------------------===//
+static void PrepareValidityFilterState(CompressedStringScanState &scan_state, TableFilterState &filter_state) {
+	if (scan_state.noop_validity_filter) {
+		return;
+	}
+	// DICT_FSST already applies the filter to both values and NULLs.
+	auto &expression_state = filter_state.Cast<ExpressionFilterState>();
+	scan_state.noop_validity_filter =
+	    make_uniq<ExpressionFilter>(make_uniq<BoundConstantExpression>(Value::BOOLEAN(true)));
+	auto validity_state = TableFilterState::Initialize(expression_state.GetContext(), *scan_state.noop_validity_filter);
+	auto &validity_expression_state = validity_state->Cast<ExpressionFilterState>();
+	expression_state.executor = std::move(validity_expression_state.executor);
+	expression_state.fast_executor = std::move(validity_expression_state.fast_executor);
+}
+
 static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
                            SelectionVector &sel, idx_t &sel_count, const TableFilter &filter,
                            TableFilterState &filter_state) {
 	auto &scan_state = state.scan_state->Cast<CompressedStringScanState>();
+	if (!scan_state.dictionary_filter_state) {
+		// Validity filtering can evaluate the shared state with a synthetic NULL.
+		auto &expression_state = filter_state.Cast<ExpressionFilterState>();
+		scan_state.dictionary_filter_state = TableFilterState::Initialize(expression_state.GetContext(), filter);
+	}
+	auto &dictionary_filter_state = *scan_state.dictionary_filter_state;
 	auto start = state.GetPositionInSegment();
 	if (scan_state.AllowDictionaryScan(vector_count)) {
 		// only pushdown filters on dictionaries
@@ -188,24 +211,36 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 			// initialize the filter result - setting everything to false
 			scan_state.filter_result = make_unsafe_uniq_array<bool>(scan_state.dict_count);
 
-			// apply the filter
-			auto &dict_data = scan_state.dictionary->data;
+			// Slot zero represents NULL and is not necessarily referenced by any row.
+			idx_t non_null_count = scan_state.dict_count - 1;
+			Vector dict_data(scan_state.dictionary->data, /*offset=*/1, scan_state.dict_count);
 			SelectionVector dict_sel;
-			idx_t filter_count = scan_state.dict_count;
-			ColumnSegment::FilterSelection(dict_sel, dict_data, filter_state, scan_state.dict_count, filter_count);
+			ColumnSegment::FilterSelection(dict_sel, dict_data, dictionary_filter_state, non_null_count,
+			                               non_null_count);
 
 			// now set all matching tuples to true
-			for (idx_t i = 0; i < filter_count; i++) {
-				auto idx = dict_sel.get_index(i);
+			for (idx_t i = 0; i < non_null_count; i++) {
+				auto idx = dict_sel.get_index(i) + 1;
 				scan_state.filter_result[idx] = true;
 			}
 		}
+		// Till now, we have a filter result for all non-NULL values.
 		auto &dict_sel = scan_state.GetSelVec(start, vector_count);
 		SelectionVector new_sel(sel_count);
 		idx_t approved_tuple_count = 0;
 		for (idx_t idx = 0; idx < sel_count; idx++) {
 			auto row_idx = sel.get_index(idx);
 			auto dict_offset = dict_sel.get_index(row_idx);
+			// Evaluate NULL only when slot zero is referenced by an actual row.
+			if (dict_offset == 0 && !scan_state.null_filter_result_initialized) {
+				Vector null_data(scan_state.dictionary->data, /*offset=*/0, /*count=*/1);
+				SelectionVector null_sel;
+				idx_t null_filter_count = 1;
+				ColumnSegment::FilterSelection(null_sel, null_data, dictionary_filter_state, 1, null_filter_count);
+				scan_state.filter_result[0] = null_filter_count == 1;
+				scan_state.null_filter_result_initialized = true;
+			}
+			// Check filter result for the value at the offset and assign selection vector.
 			if (!scan_state.filter_result[dict_offset]) {
 				// does not pass the filter
 				continue;
@@ -218,11 +253,13 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 		sel_count = approved_tuple_count;
 
 		result.Dictionary(scan_state.dictionary, dict_sel, vector_count);
+		PrepareValidityFilterState(scan_state, filter_state);
 		return;
 	}
 	// fallback: scan + filter
 	DictFSSTCompressionStorage::StringScan(segment, state, vector_count, result);
-	ColumnSegment::FilterSelection(sel, result, filter_state, vector_count, sel_count);
+	ColumnSegment::FilterSelection(sel, result, dictionary_filter_state, vector_count, sel_count);
+	PrepareValidityFilterState(scan_state, filter_state);
 }
 
 } // namespace dict_fsst

--- a/src/storage/compression/dict_fsst.cpp
+++ b/src/storage/compression/dict_fsst.cpp
@@ -4,8 +4,6 @@
 #include "duckdb/storage/compression/dict_fsst/decompression.hpp"
 #include "duckdb/function/compression/compression.hpp"
 #include "duckdb/function/compression_function.hpp"
-#include "duckdb/planner/expression/bound_constant_expression.hpp"
-#include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/table_filter_state.hpp"
 
 /*
@@ -179,20 +177,6 @@ void DictFSSTSelect(ColumnSegment &segment, ColumnScanState &state, idx_t vector
 //===--------------------------------------------------------------------===//
 // Filter
 //===--------------------------------------------------------------------===//
-static void PrepareValidityFilterState(CompressedStringScanState &scan_state, TableFilterState &filter_state) {
-	if (scan_state.noop_validity_filter) {
-		return;
-	}
-	// DICT_FSST already applies the filter to both values and NULLs.
-	auto &expression_state = filter_state.Cast<ExpressionFilterState>();
-	scan_state.noop_validity_filter =
-	    make_uniq<ExpressionFilter>(make_uniq<BoundConstantExpression>(Value::BOOLEAN(true)));
-	auto validity_state = TableFilterState::Initialize(expression_state.GetContext(), *scan_state.noop_validity_filter);
-	auto &validity_expression_state = validity_state->Cast<ExpressionFilterState>();
-	expression_state.executor = std::move(validity_expression_state.executor);
-	expression_state.fast_executor = std::move(validity_expression_state.fast_executor);
-}
-
 static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
                            SelectionVector &sel, idx_t &sel_count, const TableFilter &filter,
                            TableFilterState &filter_state) {
@@ -213,14 +197,17 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 
 			// Slot zero represents NULL and is not necessarily referenced by any row.
 			idx_t non_null_count = scan_state.dict_count - 1;
-			Vector dict_data(scan_state.dictionary->data, /*offset=*/1, scan_state.dict_count);
-			SelectionVector dict_sel;
-			ColumnSegment::FilterSelection(dict_sel, dict_data, dictionary_filter_state, non_null_count,
+			auto &dict_data = scan_state.dictionary->data;
+			SelectionVector dict_sel(non_null_count);
+			for (idx_t i = 0; i < non_null_count; i++) {
+				dict_sel.set_index(i, i + 1);
+			}
+			ColumnSegment::FilterSelection(dict_sel, dict_data, dictionary_filter_state, scan_state.dict_count,
 			                               non_null_count);
 
 			// now set all matching tuples to true
 			for (idx_t i = 0; i < non_null_count; i++) {
-				auto idx = dict_sel.get_index(i) + 1;
+				auto idx = dict_sel.get_index(i);
 				scan_state.filter_result[idx] = true;
 			}
 		}
@@ -253,13 +240,11 @@ static void DictFSSTFilter(ColumnSegment &segment, ColumnScanState &state, idx_t
 		sel_count = approved_tuple_count;
 
 		result.Dictionary(scan_state.dictionary, dict_sel, vector_count);
-		PrepareValidityFilterState(scan_state, filter_state);
 		return;
 	}
 	// fallback: scan + filter
 	DictFSSTCompressionStorage::StringScan(segment, state, vector_count, result);
 	ColumnSegment::FilterSelection(sel, result, dictionary_filter_state, vector_count, sel_count);
-	PrepareValidityFilterState(scan_state, filter_state);
 }
 
 } // namespace dict_fsst

--- a/test/sql/storage/compression/dict_fsst/dict_fsst_expression_filter.test
+++ b/test/sql/storage/compression/dict_fsst/dict_fsst_expression_filter.test
@@ -1,0 +1,68 @@
+# name: test/sql/storage/compression/dict_fsst/dict_fsst_expression_filter.test
+# description: Test expression filters over DICT_FSST strings
+# group: [dict_fsst]
+
+require vector_size 2048
+
+load {TEST_DIR}/dict_fsst_expression_filter.db readwrite v2.0.0
+
+statement ok
+CREATE TABLE partial_segment AS
+SELECT concat('HumanEval/', i::VARCHAR) AS task_id
+FROM range(0, 164) tbl(i)
+
+statement ok
+CREATE TABLE full_vector AS
+SELECT concat('HumanEval/', i::VARCHAR) AS task_id
+FROM range(0, 2048) tbl(i)
+
+statement ok
+CHECKPOINT
+
+restart
+
+query I
+SELECT count(*) FROM pragma_storage_info('partial_segment')
+WHERE column_name = 'task_id'
+  AND segment_type = 'VARCHAR'
+  AND compression = 'DICT_FSST'
+----
+1
+
+query I
+SELECT count(*) FROM pragma_storage_info('full_vector')
+WHERE column_name = 'task_id'
+  AND segment_type = 'VARCHAR'
+  AND compression = 'DICT_FSST'
+----
+1
+
+query I
+SELECT count(*) FROM partial_segment
+WHERE split_part(task_id, '/', 2)::INTEGER >= 10
+----
+154
+
+statement ok
+DELETE FROM partial_segment
+WHERE split_part(task_id, '/', 2)::INTEGER >= 10
+
+query I
+SELECT count(*) FROM partial_segment
+----
+10
+
+query I
+SELECT count(*) FROM full_vector
+WHERE split_part(task_id, '/', 2)::INTEGER >= 10
+----
+2038
+
+statement ok
+DELETE FROM full_vector
+WHERE split_part(task_id, '/', 2)::INTEGER >= 10
+
+query I
+SELECT count(*) FROM full_vector
+----
+10

--- a/test/sql/storage/compression/dict_fsst/dict_fsst_expression_filter.test
+++ b/test/sql/storage/compression/dict_fsst/dict_fsst_expression_filter.test
@@ -17,9 +17,24 @@ SELECT concat('HumanEval/', i::VARCHAR) AS task_id
 FROM range(0, 2048) tbl(i)
 
 statement ok
+CREATE TABLE with_nulls AS
+SELECT CASE WHEN i % 11 = 0 THEN NULL ELSE concat('HumanEval/', i::VARCHAR) END AS task_id
+FROM range(0, 164) tbl(i)
+
+statement ok
+CREATE TABLE appended_after_checkpoint AS
+SELECT concat('HumanEval/', i::VARCHAR) AS task_id
+FROM range(0, 164) tbl(i)
+
+statement ok
 CHECKPOINT
 
 restart
+
+statement ok
+INSERT INTO appended_after_checkpoint
+SELECT concat('HumanEval/', i::VARCHAR) AS task_id
+FROM range(0, 10) tbl(i)
 
 query I
 SELECT count(*) FROM pragma_storage_info('partial_segment')
@@ -57,6 +72,18 @@ SELECT count(*) FROM full_vector
 WHERE split_part(task_id, '/', 2)::INTEGER >= 10
 ----
 2038
+
+query I
+SELECT count(*) FROM with_nulls
+WHERE split_part(task_id, '/', 2)::INTEGER >= 10
+----
+140
+
+query I
+SELECT count(*) FROM appended_after_checkpoint
+WHERE split_part(task_id, '/', 2)::INTEGER >= 10
+----
+154
 
 statement ok
 DELETE FROM full_vector


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core column scan filter pushdown for DICT_FSST compressed VARCHAR data; incorrect logic would silently drop or keep wrong rows, though scope is limited to this codec’s filter path.
> 
> **Overview**
> Fixes **dictionary filter pushdown** on `DICT_FSST` string segments so expression predicates (e.g. `split_part(...)::INTEGER >= 10`) and **NULL** handling match scan results.
> 
> `DictFSSTFilter` now keeps a **segment-scan `dictionary_filter_state`** (initialized from the expression filter context) and uses it for all `FilterSelection` calls instead of the incoming per-vector `filter_state`. Bulk dictionary evaluation **skips dictionary slot 0** (reserved for NULL) and only filters indices `1..dict_count-1`; when a row references slot 0, NULL is evaluated once via a synthetic single-element vector and cached in `filter_result[0]`.
> 
> Adds **`dict_fsst_expression_filter.test`** covering partial vs full vectors, nullable columns, segments appended after checkpoint/restart, and `DELETE` with the same expression filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd2f3a33bbce8be2505ffde07deb282f19afc0ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->