### PR TITLE
[WIP] cross col prune

### DIFF
--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -20,6 +20,7 @@ unique_ptr<TableFilterSet> MoveTableFilters(TableFilterSet &table_filters) {
 	for (auto &entry : table_filters) {
 		table_filter_set->SetFilterByColumnIndex(entry.GetIndex(), entry.TakeFilter());
 	}
+	table_filter_set->SetRowGroupFilters(table_filters.TakeRowGroupFilters());
 	return table_filter_set;
 }
 
@@ -87,7 +88,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	optional_ptr<PhysicalOperator> filter;
 	auto &projection_ids = op.projection_ids;
 
-	if (table_filters && op.function.supports_pushdown_type) {
+	if (table_filters && table_filters->FilterCount() > 0 && op.function.supports_pushdown_type) {
 		vector<unique_ptr<Expression>> select_list;
 		unique_ptr<Expression> unsupported_filter;
 		unordered_set<ProjectionIndex> to_remove;

--- a/src/include/duckdb/planner/table_filter_set.hpp
+++ b/src/include/duckdb/planner/table_filter_set.hpp
@@ -16,11 +16,20 @@
 
 namespace duckdb {
 
+struct TableFilterSetMultiColumnFilter {
+	vector<ProjectionIndex> column_indexes;
+	vector<unique_ptr<TableFilter>> filters;
+
+	bool Equals(const TableFilterSetMultiColumnFilter &other) const;
+	TableFilterSetMultiColumnFilter Copy() const;
+};
+
 //! The filters in here are non-composite (only need a single column to be evaluated)
-//! Conditions like `A = 2 OR B = 4` are not pushed into a TableFilterSet.
+//! Cross-column OR conditions can be stored separately for row-group pruning only.
 class TableFilterSet {
 public:
 	void PushFilter(ProjectionIndex col_idx, unique_ptr<TableFilter> filter);
+	void PushRowGroupFilter(vector<ProjectionIndex> column_indexes, vector<unique_ptr<TableFilter>> filters);
 	bool HasFilters() const;
 	idx_t FilterCount() const;
 	bool HasFilter(ProjectionIndex col_idx) const;
@@ -42,6 +51,10 @@ public:
 
 	map<ProjectionIndex, unique_ptr<TableFilter>> GetTableFiltersForSerialization(Serializer &serializer) const;
 	map<ProjectionIndex, unique_ptr<TableFilter>> &GetTableFiltersForDeserialization(Deserializer &deserializer);
+
+	const vector<TableFilterSetMultiColumnFilter> &GetRowGroupFilters() const;
+	vector<TableFilterSetMultiColumnFilter> TakeRowGroupFilters();
+	void SetRowGroupFilters(vector<TableFilterSetMultiColumnFilter> filters);
 
 public:
 	class TableFilterIteratorEntry {
@@ -109,6 +122,7 @@ public:
 
 private:
 	map<ProjectionIndex, unique_ptr<TableFilter>> filters;
+	vector<TableFilterSetMultiColumnFilter> row_group_filters;
 };
 
 class DynamicTableFilterSet {

--- a/src/include/duckdb/planner/table_filter_set.hpp
+++ b/src/include/duckdb/planner/table_filter_set.hpp
@@ -16,9 +16,16 @@
 
 namespace duckdb {
 
+struct TableFilterSetRowGroupFilter {
+	ProjectionIndex column_index;
+	unique_ptr<TableFilter> filter;
+
+	bool Equals(const TableFilterSetRowGroupFilter &other) const;
+	TableFilterSetRowGroupFilter Copy() const;
+};
+
 struct TableFilterSetMultiColumnFilter {
-	vector<ProjectionIndex> column_indexes;
-	vector<unique_ptr<TableFilter>> filters;
+	vector<TableFilterSetRowGroupFilter> filters;
 
 	bool Equals(const TableFilterSetMultiColumnFilter &other) const;
 	TableFilterSetMultiColumnFilter Copy() const;
@@ -29,7 +36,7 @@ struct TableFilterSetMultiColumnFilter {
 class TableFilterSet {
 public:
 	void PushFilter(ProjectionIndex col_idx, unique_ptr<TableFilter> filter);
-	void PushRowGroupFilter(vector<ProjectionIndex> column_indexes, vector<unique_ptr<TableFilter>> filters);
+	void PushRowGroupFilter(vector<TableFilterSetRowGroupFilter> filters);
 	bool HasFilters() const;
 	idx_t FilterCount() const;
 	bool HasFilter(ProjectionIndex col_idx) const;

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -194,6 +194,15 @@ public:
 		return filter_list;
 	}
 
+	optional_ptr<TableFilterSet> GetTableFilters() const {
+		return table_filters;
+	}
+
+	const vector<StorageIndex> &GetColumnIds() const {
+		D_ASSERT(column_ids);
+		return *column_ids;
+	}
+
 	optional_ptr<AdaptiveFilter> GetAdaptiveFilter();
 	AdaptiveFilterState BeginFilter() const;
 	void EndFilter(AdaptiveFilterState state);
@@ -213,6 +222,8 @@ public:
 private:
 	//! The table filters (if any)
 	optional_ptr<TableFilterSet> table_filters;
+	//! The scan column ids
+	optional_ptr<const vector<StorageIndex>> column_ids;
 	//! Adaptive filter info (if any)
 	unique_ptr<AdaptiveFilter> adaptive_filter;
 	//! The set of filters

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -594,8 +594,7 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	auto conj_filter = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
-	vector<ProjectionIndex> row_group_filter_columns;
-	vector<unique_ptr<TableFilter>> row_group_filters;
+	vector<TableFilterSetRowGroupFilter> row_group_filters;
 	if (conj.GetChildren().empty()) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
@@ -658,8 +657,10 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 		if (column_ref->Binding().column_index == proj_id) {
 			conj_filter->GetChildrenMutable().push_back(filter_expression->Copy());
 		}
-		row_group_filter_columns.push_back(column_ref->Binding().column_index);
-		row_group_filters.push_back(make_uniq<ExpressionFilter>(std::move(filter_expression)));
+		TableFilterSetRowGroupFilter row_group_filter;
+		row_group_filter.column_index = column_ref->Binding().column_index;
+		row_group_filter.filter = make_uniq<ExpressionFilter>(std::move(filter_expression));
+		row_group_filters.push_back(std::move(row_group_filter));
 	}
 	if (row_group_filters.empty()) {
 		return FilterPushdownResult::NO_PUSHDOWN;
@@ -667,7 +668,7 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 	if (conj_filter->GetChildren().size() == row_group_filters.size()) {
 		table_filters.PushFilter(proj_id, CreateOptionalExpressionFilter(std::move(conj_filter), col_type));
 	} else {
-		table_filters.PushRowGroupFilter(std::move(row_group_filter_columns), std::move(row_group_filters));
+		table_filters.PushRowGroupFilter(std::move(row_group_filters));
 	}
 	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 }

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -594,6 +594,8 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	auto conj_filter = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
+	vector<ProjectionIndex> row_group_filter_columns;
+	vector<unique_ptr<TableFilter>> row_group_filters;
 	if (conj.GetChildren().empty()) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
@@ -626,23 +628,20 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 		if (!proj_id.IsValid()) {
 			proj_id = column_ref->Binding().column_index;
 			col_type = column_ref->GetReturnType();
-		} else if (proj_id != column_ref->Binding().column_index) {
-			return FilterPushdownResult::NO_PUSHDOWN;
 		}
 
 		auto comparison_type = invert ? FlipComparisonExpression(comp.GetExpressionType()) : comp.GetExpressionType();
+		unique_ptr<Expression> filter_expression;
 		if (const_val->GetValue().IsNull()) {
 			switch (comparison_type) {
 			case ExpressionType::COMPARE_DISTINCT_FROM: {
-				auto null_expr = ExpressionFilter::CreateNullCheckExpression(CreateFilterTargetExpression(*column_ref),
-				                                                             ExpressionType::OPERATOR_IS_NOT_NULL);
-				conj_filter->GetChildrenMutable().push_back(std::move(null_expr));
+				filter_expression = ExpressionFilter::CreateNullCheckExpression(
+				    CreateFilterTargetExpression(*column_ref), ExpressionType::OPERATOR_IS_NOT_NULL);
 				break;
 			}
 			case ExpressionType::COMPARE_NOT_DISTINCT_FROM: {
-				auto null_expr = ExpressionFilter::CreateNullCheckExpression(CreateFilterTargetExpression(*column_ref),
-				                                                             ExpressionType::OPERATOR_IS_NULL);
-				conj_filter->GetChildrenMutable().push_back(std::move(null_expr));
+				filter_expression = ExpressionFilter::CreateNullCheckExpression(
+				    CreateFilterTargetExpression(*column_ref), ExpressionType::OPERATOR_IS_NULL);
 				break;
 			}
 			default:
@@ -651,11 +650,25 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 				break;
 			}
 		} else {
-			conj_filter->GetChildrenMutable().push_back(
-			    CreateComparisonExpression(*column_ref, comparison_type, const_val->GetValue()));
+			filter_expression = CreateComparisonExpression(*column_ref, comparison_type, const_val->GetValue());
 		}
+		if (!filter_expression) {
+			continue;
+		}
+		if (column_ref->Binding().column_index == proj_id) {
+			conj_filter->GetChildrenMutable().push_back(filter_expression->Copy());
+		}
+		row_group_filter_columns.push_back(column_ref->Binding().column_index);
+		row_group_filters.push_back(make_uniq<ExpressionFilter>(std::move(filter_expression)));
 	}
-	table_filters.PushFilter(proj_id, CreateOptionalExpressionFilter(std::move(conj_filter), col_type));
+	if (row_group_filters.empty()) {
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+	if (conj_filter->GetChildren().size() == row_group_filters.size()) {
+		table_filters.PushFilter(proj_id, CreateOptionalExpressionFilter(std::move(conj_filter), col_type));
+	} else {
+		table_filters.PushRowGroupFilter(std::move(row_group_filter_columns), std::move(row_group_filters));
+	}
 	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 }
 

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -866,15 +866,14 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 			remapped_filters.PushFilter(it->second, entry.TakeFilter());
 		}
 		for (auto &row_group_filter : get.table_filters.TakeRowGroupFilters()) {
-			for (auto &column_index : row_group_filter.column_indexes) {
-				auto it = old_to_new_pos.find(column_index);
+			for (auto &filter : row_group_filter.filters) {
+				auto it = old_to_new_pos.find(filter.column_index);
 				if (it == old_to_new_pos.end()) {
 					throw InternalException("RemoveUnusedColumns: removed a row-group filter column");
 				}
-				column_index = it->second;
+				filter.column_index = it->second;
 			}
-			remapped_filters.PushRowGroupFilter(std::move(row_group_filter.column_indexes),
-			                                    std::move(row_group_filter.filters));
+			remapped_filters.PushRowGroupFilter(std::move(row_group_filter.filters));
 		}
 		get.table_filters = std::move(remapped_filters);
 	}

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -865,6 +865,17 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 			}
 			remapped_filters.PushFilter(it->second, entry.TakeFilter());
 		}
+		for (auto &row_group_filter : get.table_filters.TakeRowGroupFilters()) {
+			for (auto &column_index : row_group_filter.column_indexes) {
+				auto it = old_to_new_pos.find(column_index);
+				if (it == old_to_new_pos.end()) {
+					throw InternalException("RemoveUnusedColumns: removed a row-group filter column");
+				}
+				column_index = it->second;
+			}
+			remapped_filters.PushRowGroupFilter(std::move(row_group_filter.column_indexes),
+			                                    std::move(row_group_filter.filters));
+		}
 		get.table_filters = std::move(remapped_filters);
 	}
 

--- a/src/planner/table_filter_set.cpp
+++ b/src/planner/table_filter_set.cpp
@@ -24,12 +24,24 @@
 
 namespace duckdb {
 
+bool TableFilterSetRowGroupFilter::Equals(const TableFilterSetRowGroupFilter &other) const {
+	return column_index == other.column_index &&
+	       filter->Cast<ExpressionFilter>().Equals(other.filter->Cast<ExpressionFilter>());
+}
+
+TableFilterSetRowGroupFilter TableFilterSetRowGroupFilter::Copy() const {
+	TableFilterSetRowGroupFilter result;
+	result.column_index = column_index;
+	result.filter = filter->Cast<ExpressionFilter>().Copy();
+	return result;
+}
+
 bool TableFilterSetMultiColumnFilter::Equals(const TableFilterSetMultiColumnFilter &other) const {
-	if (column_indexes != other.column_indexes || filters.size() != other.filters.size()) {
+	if (filters.size() != other.filters.size()) {
 		return false;
 	}
 	for (idx_t i = 0; i < filters.size(); i++) {
-		if (!filters[i]->Cast<ExpressionFilter>().Equals(other.filters[i]->Cast<ExpressionFilter>())) {
+		if (!filters[i].Equals(other.filters[i])) {
 			return false;
 		}
 	}
@@ -38,9 +50,8 @@ bool TableFilterSetMultiColumnFilter::Equals(const TableFilterSetMultiColumnFilt
 
 TableFilterSetMultiColumnFilter TableFilterSetMultiColumnFilter::Copy() const {
 	TableFilterSetMultiColumnFilter result;
-	result.column_indexes = column_indexes;
 	for (auto &filter : filters) {
-		result.filters.push_back(filter->Cast<ExpressionFilter>().Copy());
+		result.filters.push_back(filter.Copy());
 	}
 	return result;
 }
@@ -479,18 +490,13 @@ void TableFilterSet::PushFilter(ProjectionIndex col_idx, unique_ptr<TableFilter>
 	}
 }
 
-void TableFilterSet::PushRowGroupFilter(vector<ProjectionIndex> column_indexes,
-                                        vector<unique_ptr<TableFilter>> filters) {
-	if (column_indexes.size() != filters.size()) {
-		throw InternalException("Mismatching column and filter count in TableFilterSet::PushRowGroupFilter");
-	}
-	for (auto &col_idx : column_indexes) {
-		if (!col_idx.IsValid()) {
+void TableFilterSet::PushRowGroupFilter(vector<TableFilterSetRowGroupFilter> filters) {
+	for (auto &filter : filters) {
+		if (!filter.column_index.IsValid()) {
 			throw InternalException("Cannot push a row-group filter over an invalid ProjectionIndex");
 		}
 	}
 	TableFilterSetMultiColumnFilter filter;
-	filter.column_indexes = std::move(column_indexes);
 	filter.filters = std::move(filters);
 	row_group_filters.push_back(std::move(filter));
 }
@@ -532,8 +538,7 @@ DynamicTableFilterSet::GetFinalTableFilters(const PhysicalTableScan &scan,
 		}
 		for (auto &row_group_filter : existing_filters->GetRowGroupFilters()) {
 			auto row_group_filter_copy = row_group_filter.Copy();
-			result->PushRowGroupFilter(std::move(row_group_filter_copy.column_indexes),
-			                           std::move(row_group_filter_copy.filters));
+			result->PushRowGroupFilter(std::move(row_group_filter_copy.filters));
 		}
 	}
 	for (auto &entry : filters) {

--- a/src/planner/table_filter_set.cpp
+++ b/src/planner/table_filter_set.cpp
@@ -530,6 +530,11 @@ DynamicTableFilterSet::GetFinalTableFilters(const PhysicalTableScan &scan,
 		for (auto &filter_entry : *existing_filters) {
 			result->PushFilter(filter_entry.GetIndex(), filter_entry.Filter().Cast<ExpressionFilter>().Copy());
 		}
+		for (auto &row_group_filter : existing_filters->GetRowGroupFilters()) {
+			auto row_group_filter_copy = row_group_filter.Copy();
+			result->PushRowGroupFilter(std::move(row_group_filter_copy.column_indexes),
+			                           std::move(row_group_filter_copy.filters));
+		}
 	}
 	for (auto &entry : filters) {
 		for (auto &filter_entry : *entry.second) {

--- a/src/planner/table_filter_set.cpp
+++ b/src/planner/table_filter_set.cpp
@@ -24,6 +24,27 @@
 
 namespace duckdb {
 
+bool TableFilterSetMultiColumnFilter::Equals(const TableFilterSetMultiColumnFilter &other) const {
+	if (column_indexes != other.column_indexes || filters.size() != other.filters.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < filters.size(); i++) {
+		if (!filters[i]->Cast<ExpressionFilter>().Equals(other.filters[i]->Cast<ExpressionFilter>())) {
+			return false;
+		}
+	}
+	return true;
+}
+
+TableFilterSetMultiColumnFilter TableFilterSetMultiColumnFilter::Copy() const {
+	TableFilterSetMultiColumnFilter result;
+	result.column_indexes = column_indexes;
+	for (auto &filter : filters) {
+		result.filters.push_back(filter->Cast<ExpressionFilter>().Copy());
+	}
+	return result;
+}
+
 struct LegacyStructPathEntry {
 	idx_t child_idx;
 	Identifier child_name;
@@ -337,7 +358,7 @@ unique_ptr<TableFilter> TableFilterSet::TableFilterIteratorEntry::TakeFilter() {
 }
 
 bool TableFilterSet::HasFilters() const {
-	return !filters.empty();
+	return !filters.empty() || !row_group_filters.empty();
 }
 idx_t TableFilterSet::FilterCount() const {
 	return filters.size();
@@ -391,6 +412,7 @@ void TableFilterSet::SetFilterByColumnIndex(ProjectionIndex col_idx, unique_ptr<
 
 void TableFilterSet::ClearFilters() {
 	filters.clear();
+	row_group_filters.clear();
 }
 
 bool TableFilterSet::Equals(TableFilterSet &other) {
@@ -403,6 +425,14 @@ bool TableFilterSet::Equals(TableFilterSet &other) {
 			return false;
 		}
 		if (!entry.second->Cast<ExpressionFilter>().Equals(other_entry->second->Cast<ExpressionFilter>())) {
+			return false;
+		}
+	}
+	if (row_group_filters.size() != other.row_group_filters.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < row_group_filters.size(); i++) {
+		if (!row_group_filters[i].Equals(other.row_group_filters[i])) {
 			return false;
 		}
 	}
@@ -424,6 +454,9 @@ unique_ptr<TableFilterSet> TableFilterSet::Copy() const {
 	for (auto &it : filters) {
 		copy->filters.emplace(it.first, it.second->Cast<ExpressionFilter>().Copy());
 	}
+	for (auto &filter : row_group_filters) {
+		copy->row_group_filters.push_back(filter.Copy());
+	}
 	return copy;
 }
 
@@ -444,6 +477,22 @@ void TableFilterSet::PushFilter(ProjectionIndex col_idx, unique_ptr<TableFilter>
 		and_expr->GetChildrenMutable().push_back(std::move(new_filter.expr));
 		filters[col_idx] = make_uniq<ExpressionFilter>(std::move(and_expr));
 	}
+}
+
+void TableFilterSet::PushRowGroupFilter(vector<ProjectionIndex> column_indexes,
+                                        vector<unique_ptr<TableFilter>> filters) {
+	if (column_indexes.size() != filters.size()) {
+		throw InternalException("Mismatching column and filter count in TableFilterSet::PushRowGroupFilter");
+	}
+	for (auto &col_idx : column_indexes) {
+		if (!col_idx.IsValid()) {
+			throw InternalException("Cannot push a row-group filter over an invalid ProjectionIndex");
+		}
+	}
+	TableFilterSetMultiColumnFilter filter;
+	filter.column_indexes = std::move(column_indexes);
+	filter.filters = std::move(filters);
+	row_group_filters.push_back(std::move(filter));
 }
 
 void DynamicTableFilterSet::ClearFilters(const PhysicalOperator &op) {
@@ -513,6 +562,18 @@ TableFilterSet::GetTableFiltersForSerialization(Serializer &serializer) const {
 map<ProjectionIndex, unique_ptr<TableFilter>> &
 TableFilterSet::GetTableFiltersForDeserialization(Deserializer &deserializer) {
 	return filters;
+}
+
+const vector<TableFilterSetMultiColumnFilter> &TableFilterSet::GetRowGroupFilters() const {
+	return row_group_filters;
+}
+
+vector<TableFilterSetMultiColumnFilter> TableFilterSet::TakeRowGroupFilters() {
+	return std::move(row_group_filters);
+}
+
+void TableFilterSet::SetRowGroupFilters(vector<TableFilterSetMultiColumnFilter> filters) {
+	row_group_filters = std::move(filters);
 }
 
 } // namespace duckdb

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
+#include "duckdb/planner/table_filter_set.hpp"
 #include "duckdb/storage/checkpoint/table_data_writer.hpp"
 #include "duckdb/storage/metadata/metadata_reader.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
@@ -734,6 +735,32 @@ bool RowGroup::CheckZonemap(optional_ptr<ClientContext> context, ScanFilterInfo 
 			// filter is always true - no need to check it
 			// label the filter as always true so we don't need to check it anymore
 			filters.SetFilterAlwaysTrue(i);
+		}
+	}
+	auto table_filters = filters.GetTableFilters();
+	if (!table_filters) {
+		return true;
+	}
+	auto &column_ids = filters.GetColumnIds();
+	for (auto &row_group_filter : table_filters->GetRowGroupFilters()) {
+		bool all_filters_are_false = true;
+		for (idx_t i = 0; i < row_group_filter.filters.size(); i++) {
+			auto &filter = *row_group_filter.filters[i];
+			const auto &base_column_index = column_ids[row_group_filter.column_indexes[i]];
+
+			FilterPropagateResult prune_result;
+			if (base_column_index.IsRowIdColumn()) {
+				prune_result = CheckRowIdFilter(filter, row_start, row_start + count);
+			} else {
+				prune_result = GetColumn(base_column_index).CheckZonemap(context, base_column_index, filter);
+			}
+			if (prune_result != FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+				all_filters_are_false = false;
+				break;
+			}
+		}
+		if (all_filters_are_false) {
+			return false;
 		}
 	}
 	return true;

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -744,9 +744,9 @@ bool RowGroup::CheckZonemap(optional_ptr<ClientContext> context, ScanFilterInfo 
 	auto &column_ids = filters.GetColumnIds();
 	for (auto &row_group_filter : table_filters->GetRowGroupFilters()) {
 		bool all_filters_are_false = true;
-		for (idx_t i = 0; i < row_group_filter.filters.size(); i++) {
-			auto &filter = *row_group_filter.filters[i];
-			const auto &base_column_index = column_ids[row_group_filter.column_indexes[i]];
+		for (auto &row_group_entry : row_group_filter.filters) {
+			auto &filter = *row_group_entry.filter;
+			const auto &base_column_index = column_ids[row_group_entry.column_index];
 
 			FilterPropagateResult prune_result;
 			if (base_column_index.IsRowIdColumn()) {

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -82,8 +82,11 @@ void ScanFilterInfo::Initialize(ClientContext &context, TableFilterSet &filters,
                                 const vector<StorageIndex> &column_ids) {
 	D_ASSERT(filters.HasFilters());
 	table_filters = &filters;
-	adaptive_filter = make_uniq<AdaptiveFilter>(filters);
-	adaptive_filter->SetLogger(context.logger);
+	this->column_ids = &column_ids;
+	if (filters.FilterCount() > 0) {
+		adaptive_filter = make_uniq<AdaptiveFilter>(filters);
+		adaptive_filter->SetLogger(context.logger);
+	}
 	filter_list.reserve(filters.FilterCount());
 	for (auto &entry : filters) {
 		filter_list.emplace_back(context, entry.GetIndex(), column_ids, entry.Filter());

--- a/test/sql/optimizer/cross_column_or_row_group_pruning.test
+++ b/test/sql/optimizer/cross_column_or_row_group_pruning.test
@@ -25,3 +25,24 @@ query II
 SELECT count(*), sum(x) FROM t WHERE x < 100 OR s > '00008000';
 ----
 291	1551286
+
+# Dynamic filters should not drop row-group-only OR filters when scan filters are merged.
+# The join dynamic filter includes values in all four row groups, so the 2 / 4 scan
+# relies on the static cross-column OR pruning surviving GetFinalTableFilters().
+
+query II
+EXPLAIN ANALYZE
+SELECT sum(t.x)
+FROM t
+JOIN (VALUES (50::BIGINT), (3000::BIGINT), (5000::BIGINT), (8050::BIGINT)) keys(x) USING (x)
+WHERE t.x < 100 OR t.s > '00008000';
+----
+analyzed_plan	<REGEX>:.*Dynamic Filters:.*x IN.*Row Groups Scanned: 2 / 4.*
+
+query II
+SELECT count(*), sum(t.x)
+FROM t
+JOIN (VALUES (50::BIGINT), (3000::BIGINT), (5000::BIGINT), (8050::BIGINT)) keys(x) USING (x)
+WHERE t.x < 100 OR t.s > '00008000';
+----
+2	8100

--- a/test/sql/optimizer/cross_column_or_row_group_pruning.test
+++ b/test/sql/optimizer/cross_column_or_row_group_pruning.test
@@ -1,0 +1,27 @@
+# name: test/sql/optimizer/cross_column_or_row_group_pruning.test
+# description: Row-group pruning can use simple OR predicates across multiple columns
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/cross_column_or_pruning.duckdb' AS rg (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE rg;
+
+statement ok
+CREATE TABLE t AS
+SELECT range::BIGINT AS x, lpad(range::VARCHAR, 8, '0') AS s
+FROM range(8192);
+
+statement ok
+CHECKPOINT;
+
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE x < 100 OR s > '00008000';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+
+query II
+SELECT count(*), sum(x) FROM t WHERE x < 100 OR s > '00008000';
+----
+291	1551286


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes filter pushdown and row-group skip logic; incorrect zonemap handling could prune valid groups, though the design only skips when all OR branches are always false.
> 
> **Overview**
> Adds **row-group-only** filter storage on `TableFilterSet` so simple `OR` predicates that span multiple columns can still prune row groups without being treated as normal per-column table filters.
> 
> **Filter pushdown** no longer rejects multi-column `OR` in `TryPushdownOrClause`: each `col op const` arm becomes its own entry; same-column `OR` still becomes an optional expression filter, while mixed-column `OR` is stored via `PushRowGroupFilter`.
> 
> **Scan / storage** applies those multi-column `OR` groups during row-group zonemap checks (skip a group only when every disjunct is provably false). `ScanFilterInfo` keeps the full `TableFilterSet` and column ids for that path; adaptive filters are built only when there are regular column filters (`FilterCount() > 0`).
> 
> **Planner plumbing** copies and remaps row-group filters through physical planning, dynamic filter merge, and unused-column removal. A regression test checks `EXPLAIN ANALYZE` row-group counts for `x < 100 OR s > '...'`, including with join dynamic filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6fc44a1ce4c616cee96b1db1939c723c107bfa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->