### PR TITLE
[WIP] Hjiang/interval stats

### DIFF
--- a/extension/core_functions/scalar/date/epoch.cpp
+++ b/extension/core_functions/scalar/date/epoch.cpp
@@ -61,7 +61,9 @@ ScalarFunction ToTimestampFun::GetFunction() {
 }
 
 ScalarFunction NormalizedIntervalFun::GetFunction() {
-	return ScalarFunction({LogicalType::INTERVAL}, LogicalType::INTERVAL, NormalizedIntervalFunction);
+	ScalarFunction function({LogicalType::INTERVAL}, LogicalType::INTERVAL, NormalizedIntervalFunction);
+	function.SetUnaryArgProperties(ArgProperties().NonDecreasing());
+	return function;
 }
 
 ScalarFunction TimeTZSortKeyFun::GetFunction() {

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -280,6 +280,12 @@ Value Value::MinimumValue(const LogicalType &type) {
 		min_ns *= Interval::NANOS_PER_DAY;
 		return Value::TIMESTAMPTZNS(timestamp_tz_ns_t(min_ns));
 	}
+	case LogicalTypeId::INTERVAL: {
+		const auto min_months = NumericLimits<int32_t>::Minimum();
+		const auto min_days = NumericLimits<int32_t>::Minimum();
+		const auto min_micros = NumericLimits<int64_t>::Minimum();
+		return Value::INTERVAL(min_months, min_days, min_micros);
+	}
 	case LogicalTypeId::FLOAT:
 		return Value::FLOAT(NumericLimits<float>::Minimum());
 	case LogicalTypeId::DOUBLE:
@@ -372,6 +378,12 @@ Value Value::MaximumValue(const LogicalType &type) {
 	case LogicalTypeId::TIME_TZ:
 		// "24:00:00-1559" from the PG docs but actually "24:00:00-15:59:59".
 		return Value::TIMETZ(dtime_tz_t(dtime_t(Interval::MICROS_PER_DAY), dtime_tz_t::MIN_OFFSET));
+	case LogicalTypeId::INTERVAL: {
+		const auto max_months = NumericLimits<int32_t>::Maximum();
+		const auto max_days = NumericLimits<int32_t>::Maximum();
+		const auto max_micros = NumericLimits<int64_t>::Maximum();
+		return Value::INTERVAL(max_months, max_days, max_micros);
+	}
 	case LogicalTypeId::FLOAT:
 		return Value::FLOAT(NumericLimits<float>::Maximum());
 	case LogicalTypeId::DOUBLE:

--- a/src/include/duckdb/storage/statistics/base_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/base_statistics.hpp
@@ -188,9 +188,6 @@ private:
 };
 
 template <>
-inline void BaseStatistics::UpdateNumericStats<interval_t>(interval_t new_value) {
-}
-template <>
 inline void BaseStatistics::UpdateNumericStats<list_entry_t>(list_entry_t new_value) {
 }
 

--- a/src/include/duckdb/storage/statistics/numeric_stats_union.hpp
+++ b/src/include/duckdb/storage/statistics/numeric_stats_union.hpp
@@ -29,7 +29,7 @@ struct NumericValueUnion {
 		float float_;   // NOLINT
 		double double_; // NOLINT
 		interval_t interval;
-	} value_;           // NOLINT
+	} value_; // NOLINT
 
 	template <class T>
 	T &GetReferenceUnsafe();

--- a/src/include/duckdb/storage/statistics/numeric_stats_union.hpp
+++ b/src/include/duckdb/storage/statistics/numeric_stats_union.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/types/interval.hpp"
 
 namespace duckdb {
 
@@ -27,6 +28,7 @@ struct NumericValueUnion {
 		uhugeint_t uhugeint;
 		float float_;   // NOLINT
 		double double_; // NOLINT
+		interval_t interval;
 	} value_;           // NOLINT
 
 	template <class T>
@@ -96,6 +98,11 @@ DUCKDB_API inline float &NumericValueUnion::GetReferenceUnsafe() {
 template <>
 DUCKDB_API inline double &NumericValueUnion::GetReferenceUnsafe() {
 	return value_.double_;
+}
+
+template <>
+DUCKDB_API inline interval_t &NumericValueUnion::GetReferenceUnsafe() {
+	return value_.interval;
 }
 
 } // namespace duckdb

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -189,6 +189,7 @@ static FilterPropagateResult CheckZonemapAgainstConstants(const BaseStatistics &
 	case PhysicalType::INT128:
 	case PhysicalType::FLOAT:
 	case PhysicalType::DOUBLE:
+	case PhysicalType::INTERVAL:
 		return NumericStats::CheckZonemap(stats, comparison_type, values);
 	case PhysicalType::VARCHAR:
 		if (stats.GetStatsType() == StatisticsType::STRING_STATS) {

--- a/src/storage/statistics/base_statistics.cpp
+++ b/src/storage/statistics/base_statistics.cpp
@@ -92,6 +92,7 @@ StatisticsType BaseStatistics::GetStatsType(const LogicalType &type) {
 	case PhysicalType::UINT128:
 	case PhysicalType::FLOAT:
 	case PhysicalType::DOUBLE:
+	case PhysicalType::INTERVAL:
 		return StatisticsType::NUMERIC_STATS;
 	case PhysicalType::VARCHAR:
 		return StatisticsType::STRING_STATS;
@@ -102,7 +103,6 @@ StatisticsType BaseStatistics::GetStatsType(const LogicalType &type) {
 	case PhysicalType::ARRAY:
 		return StatisticsType::ARRAY_STATS;
 	case PhysicalType::BIT:
-	case PhysicalType::INTERVAL:
 	default:
 		return StatisticsType::BASE_STATS;
 	}

--- a/src/storage/statistics/base_statistics.cpp
+++ b/src/storage/statistics/base_statistics.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/function/compression/compression.hpp"
 #include "duckdb/function/variant/variant_shredding.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/statistics/list_stats.hpp"
@@ -143,7 +144,7 @@ bool BaseStatistics::IsConstant() const {
 	}
 	switch (GetStatsType()) {
 	case StatisticsType::NUMERIC_STATS:
-		return NumericStats::IsConstant(*this);
+		return ConstantFun::TypeIsSupported(type.InternalType()) && NumericStats::IsConstant(*this);
 	default:
 		break;
 	}

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -553,6 +553,7 @@ static void DeserializeNumericStatsValue(const LogicalType &type, NumericValueUn
 
 void NumericStats::Serialize(const BaseStatistics &stats, Serializer &serializer) {
 	auto &numeric_stats = NumericStats::GetDataUnsafe(stats);
+	// INTERVAL stats are only serialized in V2.0.0 and later.
 	if (stats.GetType().id() == LogicalTypeId::INTERVAL && !serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
 		return;
 	}

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -127,6 +127,11 @@ double GetNumericValueUnion::Operation(const NumericValueUnion &v) {
 	return v.value_.double_;
 }
 
+template <>
+interval_t GetNumericValueUnion::Operation(const NumericValueUnion &v) {
+	return v.value_.interval;
+}
+
 template <class T>
 T NumericStats::GetMinUnsafe(const BaseStatistics &stats) {
 	return GetNumericValueUnion::Operation<T>(NumericStats::GetDataUnsafe(stats).min);
@@ -270,6 +275,8 @@ FilterPropagateResult NumericStats::CheckZonemap(const BaseStatistics &stats, Ex
 		return CheckZonemapTemplated<float>(stats, comparison_type, constants);
 	case PhysicalType::DOUBLE:
 		return CheckZonemapTemplated<double>(stats, comparison_type, constants);
+	case PhysicalType::INTERVAL:
+		return CheckZonemapTemplated<interval_t>(stats, comparison_type, constants);
 	default:
 		throw InternalException("Unsupported type for NumericStats::CheckZonemap");
 	}
@@ -328,6 +335,9 @@ void SetNumericValueInternal(const Value &input, const LogicalType &type, Numeri
 	case PhysicalType::DOUBLE:
 		val.value_.double_ = DoubleValue::Get(input);
 		break;
+	case PhysicalType::INTERVAL:
+		val.value_.interval = IntervalValue::Get(input);
+		break;
 	default:
 		throw InternalException("Unsupported type for NumericStatistics::SetValueInternal");
 	}
@@ -371,6 +381,8 @@ Value NumericValueUnionToValueInternal(const LogicalType &type, const NumericVal
 		return Value::FLOAT(val.value_.float_);
 	case PhysicalType::DOUBLE:
 		return Value::DOUBLE(val.value_.double_);
+	case PhysicalType::INTERVAL:
+		return Value::INTERVAL(val.value_.interval);
 	default:
 		throw InternalException("Unsupported type for NumericValueUnionToValue");
 	}
@@ -475,6 +487,9 @@ static void SerializeNumericStatsValue(const LogicalType &type, NumericValueUnio
 	case PhysicalType::DOUBLE:
 		serializer.WriteProperty(101, "value", val.value_.double_);
 		break;
+	case PhysicalType::INTERVAL:
+		serializer.WriteProperty(101, "value", val.value_.interval);
+		break;
 	default:
 		throw InternalException("Unsupported type for serializing numeric statistics");
 	}
@@ -528,6 +543,9 @@ static void DeserializeNumericStatsValue(const LogicalType &type, NumericValueUn
 	case PhysicalType::DOUBLE:
 		result.value_.double_ = deserializer.ReadProperty<double>(101, "value");
 		break;
+	case PhysicalType::INTERVAL:
+		result.value_.interval = deserializer.ReadProperty<interval_t>(101, "value");
+		break;
 	default:
 		throw InternalException("Unsupported type for serializing numeric statistics");
 	}
@@ -535,6 +553,9 @@ static void DeserializeNumericStatsValue(const LogicalType &type, NumericValueUn
 
 void NumericStats::Serialize(const BaseStatistics &stats, Serializer &serializer) {
 	auto &numeric_stats = NumericStats::GetDataUnsafe(stats);
+	if (stats.GetType().id() == LogicalTypeId::INTERVAL && !serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
+		return;
+	}
 	serializer.WriteObject(200, "min", [&](Serializer &object) {
 		SerializeNumericStatsValue(stats.GetType(), numeric_stats.min, numeric_stats.has_min, object);
 	});
@@ -545,7 +566,9 @@ void NumericStats::Serialize(const BaseStatistics &stats, Serializer &serializer
 
 void NumericStats::Deserialize(Deserializer &deserializer, BaseStatistics &result) {
 	auto &numeric_stats = NumericStats::GetDataUnsafe(result);
-
+	if (!deserializer.CanDeserializeProperty(200, "min") || !deserializer.CanDeserializeProperty(201, "max")) {
+		return;
+	}
 	deserializer.ReadObject(200, "min", [&](Deserializer &object) {
 		DeserializeNumericStatsValue(result.GetType(), numeric_stats.min, numeric_stats.has_min, object);
 	});
@@ -627,6 +650,9 @@ void NumericStats::Verify(const BaseStatistics &stats, const Vector &vector, con
 		break;
 	case PhysicalType::DOUBLE:
 		TemplatedVerify<double>(stats, vector, sel, count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedVerify<interval_t>(stats, vector, sel, count);
 		break;
 	default:
 		throw InternalException("Unsupported type %s for numeric statistics verify", type.ToString());

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -566,7 +566,7 @@ void NumericStats::Serialize(const BaseStatistics &stats, Serializer &serializer
 
 void NumericStats::Deserialize(Deserializer &deserializer, BaseStatistics &result) {
 	auto &numeric_stats = NumericStats::GetDataUnsafe(result);
-	if (!deserializer.CanDeserializeProperty(200, "min") || !deserializer.CanDeserializeProperty(201, "max")) {
+	if (!deserializer.CanDeserializeProperty(200, "min")) {
 		return;
 	}
 	deserializer.ReadObject(200, "min", [&](Deserializer &object) {

--- a/test/sql/optimizer/interval_row_group_pruning.test
+++ b/test/sql/optimizer/interval_row_group_pruning.test
@@ -1,0 +1,62 @@
+# name: test/sql/optimizer/interval_row_group_pruning.test
+# description: Row-group pruning using interval min/max statistics
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/interval_prune.duckdb' AS db (ROW_GROUP_SIZE 2048, STORAGE_VERSION 'v2.0.0');
+
+statement ok
+USE db;
+
+statement ok
+CREATE TABLE intervals AS
+    SELECT range * INTERVAL '1 day' AS iv, range::BIGINT AS i
+    FROM range(6144);
+
+statement ok
+FORCE CHECKPOINT;
+
+statement ok
+USE memory;
+
+statement ok
+DETACH db;
+
+statement ok
+ATTACH '{TEST_DIR}/interval_prune.duckdb' AS db;
+
+statement ok
+USE db;
+
+query I
+SELECT count(*) FROM intervals WHERE iv > INTERVAL '5000 days';
+----
+1143
+
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM intervals WHERE iv > INTERVAL '5000 days';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# Older storage versions omit interval min/max so old DuckDB versions can still read the file.
+statement ok
+ATTACH '{TEST_DIR}/interval_prune_v1_5.duckdb' AS compat (ROW_GROUP_SIZE 2048, STORAGE_VERSION 'v1.5.3');
+
+statement ok
+CREATE TABLE compat.intervals AS
+    SELECT range * INTERVAL '1 day' AS iv, range::BIGINT AS i
+    FROM range(6144);
+
+statement ok
+FORCE CHECKPOINT;
+
+statement ok
+DETACH compat;
+
+statement ok
+ATTACH '{TEST_DIR}/interval_prune_v1_5.duckdb' AS compat;
+
+query I
+SELECT count(*) FROM compat.intervals WHERE iv > INTERVAL '5000 days';
+----
+1143


### PR DESCRIPTION
https://github.com/duckdb/duckdb/issues/23909

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes optimizer pruning and on-disk statistics for INTERVAL with a version gate; incorrect interval ordering in zonemaps could skip valid row groups, but older storage formats remain readable without interval stats.
> 
> **Overview**
> **INTERVAL** columns now get **numeric min/max statistics** end-to-end, so filters like `iv > INTERVAL '5000 days'` can **prune row groups** via zonemaps (new optimizer test on storage **v2.0.0**).
> 
> `PhysicalType::INTERVAL` is treated as **`NUMERIC_STATS`** (not base stats): `interval_t` lives in `NumericValueUnion`, min/max use `Value::MinimumValue` / `MaximumValue` for INTERVAL, and the old no-op `UpdateNumericStats<interval_t>` override is removed. Expression filter statistics routing includes INTERVAL in `NumericStats::CheckZonemap`. Interval min/max are **serialized only for storage ≥ v2.0.0**; older files omit them so prior DuckDB versions can still read checkpoints (v1.5.3 compat test).
> 
> Minor: `normalized_interval` is marked **non-decreasing** unary arg properties (same pattern as `to_timestamp`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b053ee1c3da87b09bdc75ddead093857daa080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->