### PR TITLE
reject null options

### DIFF
--- a/src/function/table/sniff_csv.cpp
+++ b/src/function/table/sniff_csv.cpp
@@ -62,7 +62,11 @@ static unique_ptr<FunctionData> CSVSniffBind(ClientContext &context, TableFuncti
 		input.named_parameters.erase("force_match");
 	}
 	MultiFileOptions file_options;
-	result->options.FromNamedParameters(input.named_parameters, context, file_options);
+	named_parameter_map_t named_parameters;
+	for (auto &entry : input.named_parameters) {
+		named_parameters.emplace(entry.first, entry.second.GetValueOrNull());
+	}
+	result->options.FromNamedParameters(named_parameters, context, file_options);
 	result->options.Verify(file_options);
 
 	// We want to return the whole CSV Configuration

--- a/src/function/table/system/logging_utils.cpp
+++ b/src/function/table/system/logging_utils.cpp
@@ -71,11 +71,11 @@ static unique_ptr<FunctionData> BindEnableLogging(ClientContext &context, TableF
 				    children[i];
 			}
 		} else if (key == "storage_path") {
-			result->storage_config["path"] = param.second;
+			result->storage_config["path"] = param.second.GetValueOrNull();
 		} else if (key == "storage_normalize") {
-			result->storage_config["normalize"] = param.second;
+			result->storage_config["normalize"] = param.second.GetValueOrNull();
 		} else if (key == "storage_buffer_size") {
-			result->storage_config["buffer_size"] = param.second;
+			result->storage_config["buffer_size"] = param.second.GetValueOrNull();
 		} else {
 			throw InvalidInputException("EnableLogging: unknown named parameter: %s", param.first.c_str());
 		}

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -200,7 +200,7 @@ public:
 		for (auto &kv : input.named_parameters) {
 			auto loption = StringUtil::Lower(kv.first.GetIdentifierName());
 			if (loption == "allow_empty") {
-				multi_file_reader->ParseOption(loption, kv.second, file_options, context);
+				multi_file_reader->ParseOption(loption, kv.second.GetValueOrNull(), file_options, context);
 				if (file_options.allow_empty) {
 					glob_input.allow_empty = true;
 				}
@@ -215,10 +215,11 @@ public:
 		auto options = interface->InitializeOptions(context, input.info);
 		for (auto &kv : input.named_parameters) {
 			auto loption = StringUtil::Lower(kv.first.GetIdentifierName());
-			if (multi_file_reader->ParseOption(loption, kv.second, file_options, context)) {
+			if (multi_file_reader->ParseOption(loption, kv.second.GetValueOrNull(), file_options, context)) {
 				continue;
 			}
-			if (interface->ParseOption(context, kv.first.GetIdentifierName(), kv.second, file_options, *options)) {
+			if (interface->ParseOption(context, kv.first.GetIdentifierName(), kv.second.GetValueOrNull(), file_options,
+			                           *options)) {
 				continue;
 			}
 			throw NotImplementedException("Unimplemented option %s", kv.first);

--- a/src/include/duckdb/common/named_parameter_map.hpp
+++ b/src/include/duckdb/common/named_parameter_map.hpp
@@ -9,10 +9,65 @@
 #pragma once
 
 #include "duckdb/common/case_insensitive_map.hpp"
-#include "duckdb/common/types.hpp"
+#include "duckdb/common/optional.hpp"
+#include "duckdb/common/types/value.hpp"
 namespace duckdb {
+
+class BoundNamedParameterValue {
+public:
+	BoundNamedParameterValue(Value value_p, Identifier function_name_p, Identifier option_name_p)
+	    : value(std::move(value_p)), function_name(std::move(function_name_p)), option_name(std::move(option_name_p)) {
+	}
+
+	bool IsNull() const {
+		return value.IsNull();
+	}
+	const LogicalType &type() const {
+		return value.type();
+	}
+	string ToString() const {
+		ValidateNotNull();
+		return value.ToString();
+	}
+
+	template <class T>
+	T GetValue() const {
+		ValidateNotNull();
+		return value.GetValue<T>();
+	}
+
+	template <class T>
+	optional<T> GetOptionalValue() const {
+		if (IsNull()) {
+			return nullopt;
+		}
+		return value.GetValue<T>();
+	}
+
+	operator const Value &() const {
+		ValidateNotNull();
+		return value;
+	}
+
+	const Value &GetValueOrNull() const {
+		return value;
+	}
+
+private:
+	void ValidateNotNull() const {
+		if (IsNull()) {
+			throw InvalidInputException("Named parameter \"%s\" for table function \"%s\" cannot be NULL", option_name,
+			                            function_name);
+		}
+	}
+
+	Value value;
+	Identifier function_name;
+	Identifier option_name;
+};
 
 using named_parameter_type_map_t = identifier_map_t<LogicalType>;
 using named_parameter_map_t = identifier_map_t<Value>;
+using bound_named_parameter_map_t = identifier_map_t<BoundNamedParameterValue>;
 
 } // namespace duckdb

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -111,14 +111,11 @@ struct TableFunctionBindInput {
 	                       vector<LogicalType> &input_table_types, vector<Identifier> &input_table_names,
 	                       optional_ptr<TableFunctionInfo> info, optional_ptr<Binder> binder,
 	                       TableFunction &table_function, const TableFunctionRef &ref,
-	                       optional_ptr<unique_ptr<LogicalOperator>> input_plan = nullptr)
-	    : inputs(inputs), named_parameters(named_parameters), input_table_types(input_table_types),
-	      input_table_names(input_table_names), info(info), binder(binder), table_function(table_function), ref(ref),
-	      input_plan(input_plan) {
-	}
+	                       optional_ptr<unique_ptr<LogicalOperator>> input_plan = nullptr);
 
 	vector<Value> &inputs;
-	named_parameter_map_t &named_parameters;
+	bound_named_parameter_map_t bound_named_parameters;
+	bound_named_parameter_map_t &named_parameters;
 	vector<LogicalType> &input_table_types;
 	vector<Identifier> &input_table_names;
 	optional_ptr<TableFunctionInfo> info;
@@ -543,5 +540,20 @@ public:
 	DUCKDB_API bool operator==(const TableFunction &rhs) const;
 	DUCKDB_API bool operator!=(const TableFunction &rhs) const;
 };
+
+inline TableFunctionBindInput::TableFunctionBindInput(vector<Value> &inputs, named_parameter_map_t &named_parameters,
+                                                      vector<LogicalType> &input_table_types,
+                                                      vector<Identifier> &input_table_names,
+                                                      optional_ptr<TableFunctionInfo> info, optional_ptr<Binder> binder,
+                                                      TableFunction &table_function, const TableFunctionRef &ref,
+                                                      optional_ptr<unique_ptr<LogicalOperator>> input_plan)
+    : inputs(inputs), named_parameters(bound_named_parameters), input_table_types(input_table_types),
+      input_table_names(input_table_names), info(info), binder(binder), table_function(table_function), ref(ref),
+      input_plan(input_plan) {
+	for (auto &entry : named_parameters) {
+		bound_named_parameters.emplace(entry.first,
+		                               BoundNamedParameterValue(entry.second, table_function.name, entry.first));
+	}
+}
 
 } // namespace duckdb

--- a/src/include/duckdb/main/capi/capi_internal_table.hpp
+++ b/src/include/duckdb/main/capi/capi_internal_table.hpp
@@ -61,6 +61,15 @@ struct CTableInternalBindInfo {
 	    : context(context), parameters(parameters), named_parameters(named_parameters), return_types(return_types),
 	      names(names), bind_data(bind_data), function_info(function_info), success(true) {
 	}
+	CTableInternalBindInfo(ClientContext &context, const vector<Value> &parameters,
+	                       const bound_named_parameter_map_t &bound_named_parameters, vector<LogicalType> &return_types,
+	                       vector<string> &names, CTableBindData &bind_data, CTableFunctionInfo &function_info)
+	    : context(context), parameters(parameters), return_types(return_types), names(names), bind_data(bind_data),
+	      function_info(function_info), success(true) {
+		for (auto &entry : bound_named_parameters) {
+			named_parameters.emplace(entry.first, entry.second.GetValueOrNull());
+		}
+	}
 
 	ClientContext &context;
 

--- a/test/fuzzer/duckfuzz/repeat_row_null.test
+++ b/test/fuzzer/duckfuzz/repeat_row_null.test
@@ -15,6 +15,11 @@ NULL
 NULL
 
 statement error
+FROM repeat_row(42, num_rows=NULL)
+----
+Invalid Input Error: Named parameter "num_rows" for table function "repeat_row" cannot be NULL
+
+statement error
 FROM repeat_row(num_rows=3)
 ----
 requires at least one column to be specified


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches all table-function bind paths and multi-file option parsing; behavior change for queries that previously passed NULL options silently or incorrectly.
> 
> **Overview**
> Table function bind now wraps named parameters in **`BoundNamedParameterValue`**, so **`GetValue()`**, **`ToString()`**, and implicit **`Value`** conversion throw **`InvalidInputError`** when an option is NULL (e.g. `repeat_row(..., num_rows=NULL)`), including function and option names in the message.
> 
> **`TableFunctionBindInput`** builds this map at construction; callers that must allow NULL pass **`GetValueOrNull()`** into legacy **`Value`** APIs (**`sniff_csv`**, multi-file **`ParseOption`**, **`enable_logging`** storage fields). The C table-function bind path unwraps bound parameters back to plain **`Value`**s for extensions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fdba039e8432703ff52f6e0659a5507add1cad1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->