### PR TITLE
[WIP] another version of null handle

### DIFF
--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -658,6 +658,9 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 		user_defined_parameters[loption] = val.ToSQLString();
 	}
 	if (loption == "columns") {
+		if (val.IsNull()) {
+			throw BinderException("read_csv %s cannot be NULL", key);
+		}
 		if (!name_list.empty()) {
 			throw BinderException("read_csv column_names/names can only be supplied once");
 		}
@@ -676,6 +679,9 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 		for (idx_t i = 0; i < struct_children.size(); i++) {
 			auto &name = StructType::GetChildName(child_type, i);
 			auto &val = struct_children[i];
+			if (val.IsNull()) {
+				throw BinderException("read_csv %s parameter cannot have a NULL value", key);
+			}
 			parsed_names.emplace_back(name);
 			if (val.type().id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("read_csv requires a type specification as string");
@@ -694,6 +700,9 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 		sql_type_list = std::move(parsed_types);
 		sql_types_per_column = std::move(parsed_types_per_column);
 	} else if (loption == "auto_type_candidates") {
+		if (val.IsNull()) {
+			throw BinderException("read_csv %s cannot be NULL", key);
+		}
 		auto_type_candidates.clear();
 		map<uint8_t, LogicalType> candidate_types;
 		// We always have the extremes of Null and Varchar, so we can default to varchar if the
@@ -710,6 +719,9 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 			throw BinderException("auto_type_candidates requires at least one type");
 		}
 		for (auto &child : list_children) {
+			if (child.IsNull()) {
+				throw BinderException("read_csv %s parameter cannot have a NULL value", key);
+			}
 			if (child.type().id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("auto_type_candidates requires a type specification as string");
 			}
@@ -751,6 +763,9 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 			column_names.insert(name);
 		}
 	} else if (loption == "column_types" || loption == "types" || loption == "dtypes") {
+		if (val.IsNull()) {
+			throw BinderException("read_csv %s cannot be NULL", key);
+		}
 		auto &child_type = val.type();
 		if (child_type.id() != LogicalTypeId::STRUCT && child_type.id() != LogicalTypeId::LIST) {
 			throw BinderException("read_csv %s requires a struct or list as input", key);
@@ -768,6 +783,9 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 			for (idx_t i = 0; i < struct_children.size(); i++) {
 				auto &name = StructType::GetChildName(child_type, i);
 				auto &val = struct_children[i];
+				if (val.IsNull()) {
+					throw BinderException("read_csv %s parameter cannot have a NULL value", key);
+				}
 				if (val.type().id() != LogicalTypeId::VARCHAR) {
 					throw BinderException("read_csv %s requires a type specification as string", key);
 				}
@@ -781,6 +799,9 @@ void CSVReaderOptions::ParseOption(ClientContext &context, const string &key, co
 			}
 			auto &children = ListValue::GetChildren(val);
 			for (auto &child : children) {
+				if (child.IsNull()) {
+					throw BinderException("read_csv %s parameter cannot have a NULL value", key);
+				}
 				sql_type_names.push_back(StringValue::Get(child));
 			}
 		}

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -388,6 +388,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 
 	TableFunction range_function({LogicalType::BIGINT}, nullptr, RangeFunctionBind<false>, nullptr,
 	                             RangeFunctionLocalInit);
+	range_function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	range_function.in_out_function = RangeFunction<false>;
 	range_function.cardinality = RangeCardinality;
 	range_function.parallelism = TableFunctionParallelism::FORCE_SINGLE_THREADED;
@@ -402,6 +403,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	range.AddFunction(range_function);
 	TableFunction range_in_out({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL}, nullptr,
 	                           RangeDateTimeBind<false>, nullptr, RangeDateTimeLocalInit);
+	range_in_out.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	range_in_out.in_out_function = RangeDateTimeFunction<false>;
 	range_in_out.cardinality = RangeDateTimeCardinality;
 	range_in_out.parallelism = TableFunctionParallelism::FORCE_SINGLE_THREADED;
@@ -420,6 +422,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	generate_series.AddFunction(range_function);
 	TableFunction generate_series_in_out({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL},
 	                                     nullptr, RangeDateTimeBind<true>, nullptr, RangeDateTimeLocalInit);
+	generate_series_in_out.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	generate_series_in_out.in_out_function = RangeDateTimeFunction<true>;
 	generate_series_in_out.parallelism = TableFunctionParallelism::FORCE_SINGLE_THREADED;
 	generate_series_in_out.return_type = TableFunctionReturnType::SET_RETURNING_FUNCTION;

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -168,6 +168,7 @@ static bool PushdownProjectionExpression(ClientContext &context, const TableFunc
 
 TableFunction ReadCSVTableFunction::GetFunction() {
 	MultiFileFunction<CSVMultiFileInfo> read_csv("read_csv");
+	read_csv.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	read_csv.serialize = CSVReaderSerialize;
 	read_csv.deserialize = CSVReaderDeserialize;
 	read_csv.projection_expression_pushdown = PushdownProjectionExpression;

--- a/src/function/table/repeat.cpp
+++ b/src/function/table/repeat.cpp
@@ -54,6 +54,7 @@ static unique_ptr<NodeStatistics> RepeatCardinality(ClientContext &context, cons
 
 void RepeatTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction repeat("repeat", {LogicalType::ANY, LogicalType::BIGINT}, RepeatFunction, RepeatBind, RepeatInit);
+	repeat.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	repeat.cardinality = RepeatCardinality;
 	set.AddFunction(repeat);
 }

--- a/src/function/table/repeat_row.cpp
+++ b/src/function/table/repeat_row.cpp
@@ -29,6 +29,10 @@ static unique_ptr<FunctionData> RepeatRowBind(ClientContext &context, TableFunct
 	if (entry == input.named_parameters.end()) {
 		throw BinderException("repeat_rows requires num_rows to be specified");
 	}
+	if (entry->second.IsNull()) {
+		throw InvalidInputException(
+		    "Table function \"repeat_row\" does not support NULL for named parameter \"num_rows\"");
+	}
 	if (inputs.empty()) {
 		throw BinderException("repeat_rows requires at least one column to be specified");
 	}
@@ -59,6 +63,7 @@ static unique_ptr<NodeStatistics> RepeatRowCardinality(ClientContext &context, c
 void RepeatRowTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction repeat_row("repeat_row", {}, RepeatRowFunction, RepeatRowBind, RepeatRowInit);
 	repeat_row.SetVarArgs(LogicalType::ANY);
+	repeat_row.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	repeat_row.named_parameters["num_rows"] = LogicalType::BIGINT;
 	repeat_row.cardinality = RepeatRowCardinality;
 	set.AddFunction(repeat_row);

--- a/src/function/table/system/create_external_resource.cpp
+++ b/src/function/table/system/create_external_resource.cpp
@@ -312,6 +312,7 @@ void CreateExternalResourceFun::RegisterFunction(BuiltinFunctions &set) {
 	fn.named_parameters["teardown_on_failure"] = LogicalType::BOOLEAN;
 	fn.named_parameters["timeout_seconds"] = LogicalType::BIGINT;
 	fn.named_parameters["poll_interval_seconds"] = LogicalType::BIGINT;
+	fn.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	set.AddFunction(fn);
 }
 

--- a/src/function/table/system/external_resource_types.cpp
+++ b/src/function/table/system/external_resource_types.cpp
@@ -153,6 +153,7 @@ void RegisterExternalResourceTypeFun::RegisterFunction(BuiltinFunctions &set) {
 	fn.named_parameters["status_function"] = LogicalType::VARCHAR;
 	fn.named_parameters["destroy_function"] = LogicalType::VARCHAR;
 	fn.named_parameters["resolve_function"] = LogicalType::VARCHAR;
+	fn.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	set.AddFunction(fn);
 }
 

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -78,7 +78,8 @@ bool TableFunction::operator==(const TableFunction &rhs) const {
 	       verify_serialization == rhs.verify_serialization && projection_pushdown == rhs.projection_pushdown &&
 	       filter_pushdown == rhs.filter_pushdown && filter_prune == rhs.filter_prune &&
 	       sampling_pushdown == rhs.sampling_pushdown && late_materialization == rhs.late_materialization &&
-	       return_type == rhs.return_type && global_initialization == rhs.global_initialization;
+	       return_type == rhs.return_type && global_initialization == rhs.global_initialization &&
+	       null_handling == rhs.null_handling;
 }
 
 bool TableFunction::operator!=(const TableFunction &rhs) const {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -425,6 +425,12 @@ public:
 	table_function_deserialize_t GetDeserializeCallback() const {
 		return deserialize;
 	}
+	auto GetNullHandling() const -> FunctionNullHandling {
+		return null_handling;
+	}
+	auto SetNullHandling(FunctionNullHandling value) -> void {
+		null_handling = value;
+	}
 
 	//! Bind function
 	//! This function is used for determining the return type of a table producing function and returning bind data
@@ -542,6 +548,9 @@ public:
 	DUCKDB_API bool Equal(const TableFunction &rhs) const;
 	DUCKDB_API bool operator==(const TableFunction &rhs) const;
 	DUCKDB_API bool operator!=(const TableFunction &rhs) const;
+
+private:
+	FunctionNullHandling null_handling = FunctionNullHandling::DEFAULT_NULL_HANDLING;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -282,6 +282,8 @@ public:
 	//! Check usage, and cast named parameters to their types
 	static void BindNamedParameters(named_parameter_type_map_t &types, named_parameter_map_t &values,
 	                                QueryErrorContext &error_context, const Identifier &func_name);
+	static void ValidateTableFunctionParameters(const TableFunction &function, const vector<Value> &parameters,
+	                                            const named_parameter_map_t &named_parameters);
 	unique_ptr<BoundPragmaInfo> BindPragma(PragmaInfo &info, QueryErrorContext error_context);
 
 	BoundStatement Bind(TableRef &ref);

--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -178,6 +178,7 @@ using duckdb::GetCTableFunction;
 duckdb_table_function duckdb_create_table_function() {
 	auto function = new duckdb::TableFunction("", {}, duckdb::CTableFunction, duckdb::CTableFunctionBind,
 	                                          duckdb::CTableFunctionInit, duckdb::CTableFunctionLocalInit);
+	function->SetNullHandling(duckdb::FunctionNullHandling::SPECIAL_HANDLING);
 	function->function_info = duckdb::make_shared_ptr<duckdb::CTableFunctionInfo>();
 	function->cardinality = duckdb::CTableFunctionCardinality;
 	return reinterpret_cast<duckdb_table_function>(function);

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -195,8 +195,7 @@ void Binder::ValidateTableFunctionParameters(const TableFunction &function, cons
 		if (!parameters[parameter_idx].IsNull()) {
 			continue;
 		}
-		if (parameters[parameter_idx].type() == LogicalType::TABLE &&
-		    parameter_idx < function.GetArguments().size() &&
+		if (parameters[parameter_idx].type() == LogicalType::TABLE && parameter_idx < function.GetArguments().size() &&
 		    function.GetArguments()[parameter_idx] == LogicalType::TABLE) {
 			continue;
 		}

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -136,7 +136,7 @@ bool Binder::BindTableFunctionParameters(TableFunctionCatalogEntry &table_functi
 			MoveCorrelatedExpressions(*binder);
 			seen_subquery = true;
 			arguments.emplace_back(LogicalTypeId::TABLE);
-			parameters.emplace_back();
+			parameters.emplace_back(LogicalType::TABLE);
 			continue;
 		}
 
@@ -186,6 +186,31 @@ static void ApplyPostgresSetofAliasCompatibility(const TableFunction &table_func
 	return_names[0] = ref.alias;
 }
 
+void Binder::ValidateTableFunctionParameters(const TableFunction &function, const vector<Value> &parameters,
+                                             const named_parameter_map_t &named_parameters) {
+	if (function.GetNullHandling() == FunctionNullHandling::SPECIAL_HANDLING) {
+		return;
+	}
+	for (idx_t parameter_idx = 0; parameter_idx < parameters.size(); parameter_idx++) {
+		if (!parameters[parameter_idx].IsNull()) {
+			continue;
+		}
+		if (parameters[parameter_idx].type() == LogicalType::TABLE &&
+		    parameter_idx < function.GetArguments().size() &&
+		    function.GetArguments()[parameter_idx] == LogicalType::TABLE) {
+			continue;
+		}
+		throw InvalidInputException("Table function \"%s\" does not support NULL for positional parameter %llu",
+		                            function.name, parameter_idx + 1);
+	}
+	for (const auto &entry : named_parameters) {
+		if (entry.second.IsNull()) {
+			throw InvalidInputException("Table function \"%s\" does not support NULL for named parameter \"%s\"",
+			                            function.name, entry.first);
+		}
+	}
+}
+
 BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, const TableFunctionRef &ref,
                                                  vector<Value> parameters, named_parameter_map_t named_parameters,
                                                  vector<LogicalType> input_table_types,
@@ -202,6 +227,7 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 	string ordinality_column_name = ordinality_name;
 	optional_idx ordinality_column_id;
 	if (table_function.bind || table_function.bind_replace || table_function.bind_operator) {
+		ValidateTableFunctionParameters(table_function, parameters, named_parameters);
 		TableFunctionBindInput bind_input(parameters, named_parameters, input_table_types, input_table_names,
 		                                  table_function.function_info.get(), this, table_function, ref, input_plan);
 		if (table_function.bind_operator) {

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
+#include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 
 namespace duckdb {
@@ -374,6 +375,7 @@ unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) 
 	auto &context = deserializer.Get<ClientContext &>();
 	virtual_column_map_t virtual_columns;
 	if (!has_serialize) {
+		Binder::ValidateTableFunctionParameters(function, result->parameters, result->named_parameters);
 		TableFunctionRef empty_ref;
 		TableFunctionBindInput input(result->parameters, result->named_parameters, result->input_table_types,
 		                             result->input_table_names, function.function_info.get(), nullptr, result->function,

--- a/test/issues/general/test_23723.test
+++ b/test/issues/general/test_23723.test
@@ -1,0 +1,31 @@
+# name: test/issues/general/test_23723.test
+# description: Table function NULL arguments are user errors by default
+# group: [general]
+
+statement ok
+CREATE TABLE storage_info_table(i INTEGER);
+
+# Default handling rejects positional NULL before the callback.
+statement error
+FROM pragma_storage_info(NULL)
+----
+<REGEX>:Invalid Input Error:.*pragma_storage_info.*NULL.*positional parameter 1
+
+# Default handling rejects named NULL before the callback.
+statement error
+FROM pragma_storage_info('storage_info_table', include_segment_info=NULL)
+----
+<REGEX>:Invalid Input Error:.*pragma_storage_info.*NULL.*named parameter.*include_segment_info
+
+# Special handling preserves NULL row values.
+query I
+FROM repeat_row(NULL, num_rows=2)
+----
+NULL
+NULL
+
+# Required values inside special-handling functions remain checked.
+statement error
+FROM repeat_row(42, num_rows=NULL)
+----
+<REGEX>:Invalid Input Error:.*repeat_row.*NULL.*named parameter.*num_rows


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default binder behavior for all table functions without SPECIAL_HANDLING, which may surface new errors for queries that previously passed NULL into bind; opt-in list must stay aligned with functions that interpret NULL at runtime.
> 
> **Overview**
> **Table functions now reject NULL call arguments at bind time** unless the function opts into `FunctionNullHandling::SPECIAL_HANDLING`. `Binder::ValidateTableFunctionParameters` runs before bind (and on `LogicalGet` deserialize when there is no serialize path), throwing `InvalidInputException` for NULL positional or named parameters; `TABLE`-typed positional placeholders are still allowed.
> 
> `TableFunction` gains `GetNullHandling` / `SetNullHandling` (included in equality). Builtins that need NULL semantics (`range`, `generate_series`, `read_csv`, `repeat`, `repeat_row`, external-resource helpers, etc.) and **C API** `duckdb_create_table_function` use **SPECIAL_HANDLING**. `read_csv` option parsing adds explicit NULL checks for `columns`, `auto_type_candidates`, and type/name options; `repeat_row` rejects NULL `num_rows`. Subquery table parameters are bound as `Value(LogicalType::TABLE)` instead of an empty value.
> 
> Adds regression coverage in `test_23723.test` (e.g. `pragma_storage_info` vs `repeat_row`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d96aaa658665ac984b0af75bf0c71b084bda14d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->