### PR TITLE
[WIP] Hjiang/prune leaf bloom filter

### DIFF
--- a/extension/parquet/include/reader/list_column_reader.hpp
+++ b/extension/parquet/include/reader/list_column_reader.hpp
@@ -20,6 +20,7 @@ public:
 public:
 	ListColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema,
 	                 unique_ptr<ColumnReader> child_column_reader_p);
+	ColumnReader &GetChildReader();
 
 	idx_t Read(ColumnReaderInput &input, Vector &result) override;
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1366,6 +1366,70 @@ static FilterPropagateResult CheckParquetFloatFilter(ClientContext &context, Col
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
 
+static bool TryGetListBloomFilterLeaf(ColumnReader &column_reader, const Expression &expr,
+                                      optional_ptr<ColumnReader> &leaf_reader) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
+		if (expr.Cast<BoundReferenceExpression>().Index() != 0) {
+			return false;
+		}
+		leaf_reader = &column_reader;
+		return true;
+	}
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		return false;
+	}
+
+	auto &function = expr.Cast<BoundFunctionExpression>();
+	if (function.GetChildren().empty() ||
+	    !TryGetListBloomFilterLeaf(column_reader, *function.GetChildren()[0], leaf_reader)) {
+		return false;
+	}
+	if (leaf_reader->Type().id() == LogicalTypeId::LIST &&
+	    (function.Function().GetName() == "list_extract" || function.Function().GetName() == "array_extract")) {
+		leaf_reader = &leaf_reader->Cast<ListColumnReader>().GetChildReader();
+		return true;
+	}
+	return false;
+}
+
+static bool TryGetBloomFilterLeaf(ColumnReader &column_reader, const TableFilter &filter,
+                                  optional_ptr<ColumnReader> &leaf_reader, unique_ptr<TableFilter> &leaf_filter) {
+	auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "ParquetReader::TryGetBloomFilterLeaf");
+	auto &expr = *expr_filter.expr;
+	if (!BoundComparisonExpression::IsComparison(expr) || expr.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+		return false;
+	}
+
+	auto &comparison = expr.Cast<BoundFunctionExpression>();
+	auto &left = BoundComparisonExpression::Left(comparison);
+	auto &right = BoundComparisonExpression::Right(comparison);
+	optional_ptr<const Expression> column_expr;
+	optional_ptr<const BoundConstantExpression> constant;
+	if (left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		constant = left.Cast<BoundConstantExpression>();
+		column_expr = &right;
+	} else if (right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		constant = right.Cast<BoundConstantExpression>();
+		column_expr = &left;
+	} else {
+		return false;
+	}
+	if (constant->GetValue().IsNull()) {
+		return false;
+	}
+
+	if (!TryGetListBloomFilterLeaf(column_reader, *column_expr, leaf_reader) ||
+	    leaf_reader->Type() != constant->GetValue().type()) {
+		return false;
+	}
+
+	auto leaf_comparison = BoundComparisonExpression::Create(
+	    ExpressionType::COMPARE_EQUAL, make_uniq<BoundReferenceExpression>(leaf_reader->Type(), 0ULL),
+	    make_uniq<BoundConstantExpression>(constant->GetValue()));
+	leaf_filter = make_uniq<ExpressionFilter>(std::move(leaf_comparison));
+	return true;
+}
+
 ColumnReader &ParquetReaderScanState::GetColumnReader(idx_t i) {
 	return *column_readers[i];
 }
@@ -1416,12 +1480,26 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 				prune_result = expr_filter.CheckStatistics(context, *stats);
 			}
 			// check the bloom filter if present
-			if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE && !column_reader.Type().IsNested() &&
-			    is_column && ParquetStatisticsUtils::BloomFilterSupported(column_reader.Schema()) &&
-			    ParquetStatisticsUtils::BloomFilterExcludes(filter, group.columns[schema_column_index].meta_data,
-			                                                *state.thrift_file_proto, allocator,
-			                                                column_reader.Schema())) {
-				prune_result = FilterPropagateResult::FILTER_ALWAYS_FALSE;
+			if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE && is_column) {
+				optional_ptr<ColumnReader> bloom_reader = &column_reader;
+				optional_ptr<const TableFilter> bloom_filter = &filter;
+				unique_ptr<TableFilter> leaf_filter;
+				if (column_reader.Type().IsNested()) {
+					if (!TryGetBloomFilterLeaf(column_reader, filter, bloom_reader, leaf_filter)) {
+						bloom_reader = nullptr;
+					} else {
+						bloom_filter = leaf_filter.get();
+					}
+				}
+				if (bloom_reader && bloom_filter &&
+				    bloom_reader->Schema().schema_type == ParquetColumnSchemaType::COLUMN &&
+				    bloom_reader->ColumnIndex() < group.columns.size() &&
+				    ParquetStatisticsUtils::BloomFilterSupported(bloom_reader->Schema()) &&
+				    ParquetStatisticsUtils::BloomFilterExcludes(
+				        *bloom_filter, group.columns[bloom_reader->ColumnIndex()].meta_data, *state.thrift_file_proto,
+				        allocator, bloom_reader->Schema())) {
+					prune_result = FilterPropagateResult::FILTER_ALWAYS_FALSE;
+				}
 			}
 
 			if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1448,6 +1448,77 @@ static bool TryGetBloomFilterLeaf(ColumnReader &column_reader, const TableFilter
 	return true;
 }
 
+static bool IsIdentityRemap(const Value &remap) {
+	if (remap.IsNull()) {
+		return true;
+	}
+	if (!StructType::IsStruct(remap.type())) {
+		return false;
+	}
+	auto &types = StructType::GetChildTypes(remap.type());
+	auto &values = StructValue::GetChildren(remap);
+	for (idx_t child_idx = 0; child_idx < values.size(); child_idx++) {
+		auto &target_name = types[child_idx].first;
+		auto &mapping = values[child_idx];
+		if (mapping.type().id() == LogicalTypeId::VARCHAR) {
+			if (!StringUtil::CIEquals(target_name.GetIdentifierName(), mapping.ToString())) {
+				return false;
+			}
+			continue;
+		}
+		if (mapping.type().id() != LogicalTypeId::TUPLE) {
+			return false;
+		}
+		auto &mapping_children = StructValue::GetChildren(mapping);
+		if (mapping_children.size() != 2 || mapping_children[0].type().id() != LogicalTypeId::VARCHAR ||
+		    !StringUtil::CIEquals(target_name.GetIdentifierName(), mapping_children[0].ToString()) ||
+		    !IsIdentityRemap(mapping_children[1])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static optional_idx GetIdentityExpressionChild(const ExpressionColumnReader &reader) {
+	if (reader.expr->GetExpressionClass() == ExpressionClass::BOUND_REF) {
+		return reader.expr->Cast<BoundReferenceExpression>().Index();
+	}
+	if (reader.expr->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		return optional_idx();
+	}
+	auto &function = reader.expr->Cast<BoundFunctionExpression>();
+	if (function.Function().GetName() != "remap_struct" || function.GetChildren().size() != 4 ||
+	    function.GetChildren()[0]->GetExpressionClass() != ExpressionClass::BOUND_REF ||
+	    function.GetChildren()[2]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT ||
+	    function.GetChildren()[3]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+		return optional_idx();
+	}
+	auto &remap = function.GetChildren()[2]->Cast<BoundConstantExpression>().GetValue();
+	auto &defaults = function.GetChildren()[3]->Cast<BoundConstantExpression>().GetValue();
+	if (!defaults.IsNull() || !IsIdentityRemap(remap)) {
+		return optional_idx();
+	}
+	return function.GetChildren()[0]->Cast<BoundReferenceExpression>().Index();
+}
+
+static ColumnReader &GetPruningReader(ColumnReader &column_reader) {
+	auto reader = optional_ptr<ColumnReader>(column_reader);
+	while (reader->Schema().schema_type == ParquetColumnSchemaType::EXPRESSION) {
+		auto &expression_reader = reader->Cast<ExpressionColumnReader>();
+		auto child_idx = GetIdentityExpressionChild(expression_reader);
+		if (!child_idx.IsValid()) {
+			break;
+		}
+		if (child_idx.GetIndex() >= expression_reader.child_readers.size() ||
+		    !expression_reader.child_readers[child_idx.GetIndex()] ||
+		    expression_reader.child_readers[child_idx.GetIndex()]->Type() != reader->Type()) {
+			break;
+		}
+		reader = expression_reader.child_readers[child_idx.GetIndex()].get();
+	}
+	return *reader;
+}
+
 ColumnReader &ParquetReaderScanState::GetColumnReader(idx_t i) {
 	return *column_readers[i];
 }
@@ -1456,6 +1527,7 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 	auto &group = GetGroup(state);
 	auto col_idx = MultiFileLocalIndex(i);
 	auto &column_reader = state.GetColumnReader(col_idx);
+	auto &pruning_reader = GetPruningReader(column_reader);
 
 	// keep track of column and row group ordinal if data is encrypted
 	if (metadata->crypto_metadata->encryption_algorithm.__isset.AES_GCM_CTR_V1) {
@@ -1464,17 +1536,17 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 	}
 
 	if (filters) {
-		auto stats = column_reader.Stats(state.group_index, group.columns);
+		auto stats = pruning_reader.Stats(state.group_index, group.columns);
 		// filters contain output chunk index, not file col idx!
 		auto filter_entry = filters->TryGetFilterByColumnIndex(col_idx);
 		if (stats && filter_entry) {
 			auto &filter = *filter_entry;
 
-			auto schema_column_index = column_reader.ColumnIndex();
+			auto schema_column_index = pruning_reader.ColumnIndex();
 			FilterPropagateResult prune_result;
 			bool is_generated_column = schema_column_index >= group.columns.size();
-			bool is_column = column_reader.Schema().schema_type == ParquetColumnSchemaType::COLUMN;
-			bool is_expression = column_reader.Schema().schema_type == ParquetColumnSchemaType::EXPRESSION;
+			bool is_column = pruning_reader.Schema().schema_type == ParquetColumnSchemaType::COLUMN;
+			bool is_expression = pruning_reader.Schema().schema_type == ParquetColumnSchemaType::EXPRESSION;
 			bool has_min_max = false;
 			if (!is_generated_column) {
 				has_min_max = group.columns[schema_column_index].meta_data.statistics.__isset.min_value &&
@@ -1484,13 +1556,13 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 				// no pruning possible for expressions
 				prune_result = FilterPropagateResult::NO_PRUNING_POSSIBLE;
 			} else if (!is_generated_column && has_min_max &&
-			           (column_reader.Type().id() == LogicalTypeId::FLOAT ||
-			            column_reader.Type().id() == LogicalTypeId::DOUBLE) &&
+			           (pruning_reader.Type().id() == LogicalTypeId::FLOAT ||
+			            pruning_reader.Type().id() == LogicalTypeId::DOUBLE) &&
 			           parquet_options.can_have_nan) {
 				// floating point columns can have NaN values in addition to the min/max bounds defined in the file
 				// in order to do optimal pruning - we prune based on the [min, max] of the file followed by pruning
 				// based on nan
-				prune_result = CheckParquetFloatFilter(context, column_reader,
+				prune_result = CheckParquetFloatFilter(context, pruning_reader,
 				                                       group.columns[schema_column_index].meta_data.statistics, filter);
 			} else {
 				auto &expr_filter =
@@ -1499,11 +1571,11 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 			}
 			// check the bloom filter if present
 			if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE && is_column) {
-				optional_ptr<ColumnReader> bloom_reader = &column_reader;
+				optional_ptr<ColumnReader> bloom_reader = &pruning_reader;
 				optional_ptr<const TableFilter> bloom_filter = &filter;
 				unique_ptr<TableFilter> leaf_filter;
-				if (column_reader.Type().IsNested()) {
-					if (!TryGetBloomFilterLeaf(column_reader, filter, bloom_reader, leaf_filter)) {
+				if (pruning_reader.Type().IsNested()) {
+					if (!TryGetBloomFilterLeaf(pruning_reader, filter, bloom_reader, leaf_filter)) {
 						bloom_reader = nullptr;
 					} else {
 						bloom_filter = leaf_filter.get();

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -47,6 +47,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_size.hpp"
+#include "duckdb/function/scalar/struct_utils.hpp"
 #include "duckdb/logging/log_type.hpp"
 #include "duckdb/logging/logger.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -1366,8 +1367,8 @@ static FilterPropagateResult CheckParquetFloatFilter(ClientContext &context, Col
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
 
-static bool TryGetListBloomFilterLeaf(ColumnReader &column_reader, const Expression &expr,
-                                      optional_ptr<ColumnReader> &leaf_reader) {
+static bool TryGetNestedBloomFilterLeaf(ColumnReader &column_reader, const Expression &expr,
+                                        optional_ptr<ColumnReader> &leaf_reader) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
 		if (expr.Cast<BoundReferenceExpression>().Index() != 0) {
 			return false;
@@ -1381,14 +1382,31 @@ static bool TryGetListBloomFilterLeaf(ColumnReader &column_reader, const Express
 
 	auto &function = expr.Cast<BoundFunctionExpression>();
 	if (function.GetChildren().empty() ||
-	    !TryGetListBloomFilterLeaf(column_reader, *function.GetChildren()[0], leaf_reader)) {
+	    !TryGetNestedBloomFilterLeaf(column_reader, *function.GetChildren()[0], leaf_reader)) {
 		return false;
 	}
+
+	// Handle LIST type.
 	if (leaf_reader->Type().id() == LogicalTypeId::LIST &&
 	    (function.Function().GetName() == "list_extract" || function.Function().GetName() == "array_extract")) {
 		leaf_reader = &leaf_reader->Cast<ListColumnReader>().GetChildReader();
 		return true;
 	}
+
+	// Handle STRUCT type.
+	if (leaf_reader->Type().id() == LogicalTypeId::STRUCT) {
+		idx_t child_idx;
+		if (!TryGetStructExtractChildIndex(function, child_idx)) {
+			return false;
+		}
+		auto &struct_reader = leaf_reader->Cast<StructColumnReader>();
+		if (child_idx >= struct_reader.child_readers.size() || !struct_reader.child_readers[child_idx]) {
+			return false;
+		}
+		leaf_reader = struct_reader.child_readers[child_idx].get();
+		return true;
+	}
+
 	return false;
 }
 
@@ -1418,7 +1436,7 @@ static bool TryGetBloomFilterLeaf(ColumnReader &column_reader, const TableFilter
 		return false;
 	}
 
-	if (!TryGetListBloomFilterLeaf(column_reader, *column_expr, leaf_reader) ||
+	if (!TryGetNestedBloomFilterLeaf(column_reader, *column_expr, leaf_reader) ||
 	    leaf_reader->Type() != constant->GetValue().type()) {
 		return false;
 	}

--- a/extension/parquet/reader/list_column_reader.cpp
+++ b/extension/parquet/reader/list_column_reader.cpp
@@ -205,6 +205,10 @@ ListColumnReader::ListColumnReader(const ParquetReader &reader, const ParquetCol
 	}
 }
 
+ColumnReader &ListColumnReader::GetChildReader() {
+	return *child_column_reader;
+}
+
 void ListColumnReader::ApplyPendingSkips(data_ptr_t define_out, data_ptr_t repeat_out) {
 	ColumnReaderInput empty_input(pending_skips, nullptr, nullptr);
 	ReadInternal<TemplatedListSkipper>(empty_input, nullptr);

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -39,6 +39,87 @@ SELECT BOOL_AND(bloom_filter_excludes) FROM parquet_bloom_probe('{TEST_DIR}/bloo
 true
 
 statement ok
+COPY (
+    SELECT
+        [v, v + 2] AS list_value,
+        [[[v, v + 2]]] AS deep_list,
+        i::BIGINT AS payload
+    FROM (
+        SELECT i, ((i % 100) * 2)::INTEGER AS v
+        FROM range(20480) t(i)
+    ) data
+) TO '{TEST_DIR}/bloom_list.parquet' (
+    FORMAT PARQUET,
+    ROW_GROUP_SIZE 2048,
+    DICTIONARY_SIZE_LIMIT 1000,
+    WRITE_BLOOM_FILTER TRUE
+);
+
+# A projected list still uses its primitive leaf Bloom filter
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE list_value[1] = 101;
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT list_value, payload
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE list_value[1] = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# Explicit list_extract follows the same leaf
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE list_extract(list_value, 1) = 101;
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT list_value, payload
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE list_extract(list_value, 1) = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# Deeply nested lists
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE deep_list[1][1][1] = 101;
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT deep_list, payload
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE deep_list[1][1][1] = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# A possible deep-list leaf match must retain its row groups
+query I
+SELECT count(deep_list)
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE deep_list[1][1][1] = 100;
+----
+205
+
+# A match in a non-first list element must not be pruned
+query I
+SELECT count(list_value)
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE list_value[2] = 102;
+----
+205
+
+statement ok
 CREATE MACRO assert_bloom_filter_hit(file, col, val) AS TABLE
     SELECT COUNT(*) > 0 AND COUNT(*) < MAX(row_group_id+1) FROM parquet_bloom_probe(file, col, val) WHERE NOT bloom_filter_excludes;
 

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -43,6 +43,17 @@ COPY (
     SELECT
         [v, v + 2] AS list_value,
         [[[v, v + 2]]] AS deep_list,
+        {
+            'level_1': {'level_2': {'value': v}},
+            'values': [v, v + 2],
+            'nested_values': [[[v, v + 2]]]
+        } AS struct_value,
+        [{'value': v, 'present': i}, {'value': v + 2, 'present': i}] AS struct_list,
+        [
+            {'level_1': {'level_2': {'value': v}}},
+            {'level_1': {'level_2': {'value': v + 2}}}
+        ] AS nested_struct_list,
+        {'items': [{'values': [v, v + 2]}, {'values': [v + 4, v + 6]}]} AS deep_mixed,
         i::BIGINT AS payload
     FROM (
         SELECT i, ((i % 100) * 2)::INTEGER AS v
@@ -118,6 +129,102 @@ FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
 WHERE list_value[2] = 102;
 ----
 205
+
+# Deeply nested structs
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE struct_value.level_1.level_2.value = 101;
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT struct_value, payload
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE struct_value.level_1.level_2.value = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# List inside a struct
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE struct_value.values[1] = 101;
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT struct_value, payload
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE struct_value.values[1] = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# Nested list inside a struct
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE struct_value.nested_values[1][1][1] = 101;
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT struct_value, payload
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE struct_value.nested_values[1][1][1] = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# Struct inside a list
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE struct_list[1].value = 101;
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT struct_list, payload
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE struct_list[1].value = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# Nested struct inside a list
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE nested_struct_list[1].level_1.level_2.value = 101;
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT nested_struct_list, payload
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE nested_struct_list[1].level_1.level_2.value = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
+
+# Alternating struct -> list -> struct -> list nesting
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE deep_mixed.items[1].values[1] = 101;
+----
+0
+
+query II
+EXPLAIN ANALYZE
+SELECT deep_mixed, payload
+FROM read_parquet('{TEST_DIR}/bloom_list.parquet')
+WHERE deep_mixed.items[1].values[1] = 101;
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 0 / 10.*
 
 statement ok
 CREATE MACRO assert_bloom_filter_hit(file, col, val) AS TABLE


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Incorrect leaf resolution or Bloom application could skip row groups and drop matching rows; tests focus on nested paths but pruning logic is subtle.
> 
> **Overview**
> Parquet row-group pruning can now use **Bloom filters on primitive leaves** when filters target nested paths (lists, structs, and mixed nesting), not only top-level scalar columns.
> 
> `PrepareRowGroupBuffer` resolves filters through `list_extract`/`array_extract` and struct field access to the underlying `ColumnReader`, builds a leaf equality filter, and applies the leaf column’s Bloom filter. **Identity `remap_struct` expression readers** are peeled via `GetPruningReader` so stats and Bloom checks use the physical column when safe. `ListColumnReader::GetChildReader()` exposes the child reader for list navigation.
> 
> New `bloom_filters.test` coverage writes nested Parquet with Bloom filters and asserts **0 row groups scanned** for absent values and correct behavior when values may exist (e.g. non-first list elements).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4638b868137c62510754903834768df22191c01e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->