### PR TITLE
Introduce data corruption exception

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -2002,19 +2002,20 @@ const StringUtil::EnumStringLiteral *GetExceptionTypeValues() {
 		{ static_cast<uint32_t>(ExceptionType::MISSING_EXTENSION), "MISSING_EXTENSION" },
 		{ static_cast<uint32_t>(ExceptionType::AUTOLOAD), "AUTOLOAD" },
 		{ static_cast<uint32_t>(ExceptionType::SEQUENCE), "SEQUENCE" },
-		{ static_cast<uint32_t>(ExceptionType::INVALID_CONFIGURATION), "INVALID_CONFIGURATION" }
+		{ static_cast<uint32_t>(ExceptionType::INVALID_CONFIGURATION), "INVALID_CONFIGURATION" },
+		{ static_cast<uint32_t>(ExceptionType::DATA_CORRUPTION), "DATA_CORRUPTION" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<ExceptionType>(ExceptionType value) {
-	return StringUtil::EnumToString(GetExceptionTypeValues(), 43, "ExceptionType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetExceptionTypeValues(), 44, "ExceptionType", static_cast<uint32_t>(value));
 }
 
 template<>
 ExceptionType EnumUtil::FromString<ExceptionType>(const char *value) {
-	return static_cast<ExceptionType>(StringUtil::StringToEnum(GetExceptionTypeValues(), 43, "ExceptionType", value));
+	return static_cast<ExceptionType>(StringUtil::StringToEnum(GetExceptionTypeValues(), 44, "ExceptionType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetExplainOutputTypeValues() {

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -72,6 +72,7 @@ bool Exception::InvalidatesTransaction(ExceptionType exception_type) {
 
 bool Exception::InvalidatesDatabase(ExceptionType exception_type) {
 	switch (exception_type) {
+	case ExceptionType::DATA_CORRUPTION:
 	case ExceptionType::FATAL:
 		return true;
 	default:
@@ -153,7 +154,8 @@ static constexpr ExceptionEntry EXCEPTION_MAP[] = {{ExceptionType::INVALID, "Inv
                                                    {ExceptionType::HTTP, "HTTP"},
                                                    {ExceptionType::AUTOLOAD, "Extension Autoloading"},
                                                    {ExceptionType::SEQUENCE, "Sequence"},
-                                                   {ExceptionType::INVALID_CONFIGURATION, "Invalid Configuration"}};
+                                                   {ExceptionType::INVALID_CONFIGURATION, "Invalid Configuration"},
+                                                   {ExceptionType::DATA_CORRUPTION, "Data Corruption"}};
 
 string Exception::ExceptionTypeToString(ExceptionType type) {
 	for (auto &e : EXCEPTION_MAP) {
@@ -308,6 +310,10 @@ IOException::IOException(const string &msg) : Exception(ExceptionType::IO, msg) 
 
 IOException::IOException(const unordered_map<string, string> &extra_info, const string &msg)
     : Exception(extra_info, ExceptionType::IO, msg) {
+}
+
+DataCorruptionException::DataCorruptionException(const string &msg)
+    : Exception(ExceptionType::DATA_CORRUPTION, msg) {
 }
 
 NotImplementedException::NotImplementedException(const unordered_map<string, string> &extra_info, const string &msg)

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -312,8 +312,7 @@ IOException::IOException(const unordered_map<string, string> &extra_info, const 
     : Exception(extra_info, ExceptionType::IO, msg) {
 }
 
-DataCorruptionException::DataCorruptionException(const string &msg)
-    : Exception(ExceptionType::DATA_CORRUPTION, msg) {
+DataCorruptionException::DataCorruptionException(const string &msg) : Exception(ExceptionType::DATA_CORRUPTION, msg) {
 }
 
 NotImplementedException::NotImplementedException(const unordered_map<string, string> &extra_info, const string &msg)

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -88,7 +88,8 @@ enum class ExceptionType : uint8_t {
 	AUTOLOAD = 40,          // Thrown when an extension fails to autoload
 	SEQUENCE = 41,
 	INVALID_CONFIGURATION =
-	    42 // An invalid configuration was detected (e.g. a Secret param was missing, or a required setting not found)
+	    42, // An invalid configuration was detected (e.g. a Secret param was missing, or a required setting not found)
+	DATA_CORRUPTION = 43 // Data corruption was detected in persistent storage
 };
 
 class Exception : public std::runtime_error {
@@ -245,6 +246,16 @@ public:
 	template <typename... ARGS>
 	explicit IOException(const unordered_map<string, string> &extra_info, const string &msg, ARGS &&...params)
 	    : IOException(extra_info, ConstructMessage(msg, std::forward<ARGS>(params)...)) {
+	}
+};
+
+class DataCorruptionException : public Exception {
+public:
+	DUCKDB_API explicit DataCorruptionException(const string &msg);
+
+	template <typename... ARGS>
+	explicit DataCorruptionException(const string &msg, ARGS &&...params)
+	    : DataCorruptionException(ConstructMessage(msg, std::forward<ARGS>(params)...)) {
 	}
 };
 

--- a/src/include/duckdb/common/fsst.hpp
+++ b/src/include/duckdb/common/fsst.hpp
@@ -60,7 +60,7 @@ public:
 		    duckdb_fsst_decompress(fsst_decoder, compressed_string_len, compressed_string_ptr,
 		                           string_t::INLINE_LENGTH + sizeof(StringWithExtraSpace::extra_space), target_ptr);
 		if (decompressed_string_size > string_t::INLINE_LENGTH) {
-			throw IOException("Corrupt database file: decoded FSST string of >=%llu bytes (should be <=%llu bytes)",
+			throw DataCorruptionException("Corrupt database file: decoded FSST string of >=%llu bytes (should be <=%llu bytes)",
 			                  decompressed_string_size, string_t::INLINE_LENGTH);
 		}
 		D_ASSERT(decompressed_string_size <= string_t::INLINE_LENGTH);

--- a/src/include/duckdb/common/fsst.hpp
+++ b/src/include/duckdb/common/fsst.hpp
@@ -60,8 +60,9 @@ public:
 		    duckdb_fsst_decompress(fsst_decoder, compressed_string_len, compressed_string_ptr,
 		                           string_t::INLINE_LENGTH + sizeof(StringWithExtraSpace::extra_space), target_ptr);
 		if (decompressed_string_size > string_t::INLINE_LENGTH) {
-			throw DataCorruptionException("Corrupt database file: decoded FSST string of >=%llu bytes (should be <=%llu bytes)",
-			                  decompressed_string_size, string_t::INLINE_LENGTH);
+			throw DataCorruptionException(
+			    "Corrupt database file: decoded FSST string of >=%llu bytes (should be <=%llu bytes)",
+			    decompressed_string_size, string_t::INLINE_LENGTH);
 		}
 		D_ASSERT(decompressed_string_size <= string_t::INLINE_LENGTH);
 		result.str.SetSizeAndFinalize(UnsafeNumericCast<uint32_t>(decompressed_string_size), string_t::INLINE_LENGTH);

--- a/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
+++ b/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/types/hash.hpp"
+#include "duckdb/common/types/value.hpp"
 #include "duckdb/storage/compression/alp/alp_constants.hpp"
 #include "duckdb/storage/compression/alp/alp_utils.hpp"
 

--- a/src/include/duckdb/storage/compression/alp/alp_scan.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_scan.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/storage/compression/alp/algorithm/alp.hpp"
 
 #include "duckdb/common/limits.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 
 #include "duckdb/storage/table/column_segment.hpp"

--- a/src/include/duckdb/storage/compression/alp/alp_scan.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_scan.hpp
@@ -147,7 +147,7 @@ public:
 				const idx_t value_buffer_copy_size = sizeof(T) * vector_size;
 				if (vector_ptr + value_buffer_copy_size > segment_data + block_size) {
 					const auto bytes_remaining_in_block = (segment_data + block_size) - vector_ptr;
-					throw IOException("Corrupted ALP segment: stored vector_size is invalid, to-copy bytes (%d) "
+					throw DataCorruptionException("Corrupted ALP segment: stored vector_size is invalid, to-copy bytes (%d) "
 					                  "would exceed bytes remaining in the block (%d)",
 					                  value_buffer_copy_size, bytes_remaining_in_block);
 				}
@@ -168,15 +168,15 @@ public:
 		vector_ptr += AlpConstants::BIT_WIDTH_SIZE;
 
 		if (vector_state.exceptions_count > vector_size) {
-			throw IOException("Corrupted ALP segment: exceptions_count (%d) exceeds vector_size (%d)",
+			throw DataCorruptionException("Corrupted ALP segment: exceptions_count (%d) exceeds vector_size (%d)",
 			                  vector_state.exceptions_count, vector_size);
 		}
 		if (vector_state.v_factor > vector_state.v_exponent) {
-			throw IOException("Corrupted ALP segment: v_factor (%d) exceeds v_exponent (%d)", vector_state.v_factor,
+			throw DataCorruptionException("Corrupted ALP segment: v_factor (%d) exceeds v_exponent (%d)", vector_state.v_factor,
 			                  vector_state.v_exponent);
 		}
 		if (vector_state.bit_width > sizeof(uint64_t) * 8) {
-			throw IOException("Corrupted ALP segment: Invalid bit_width encountered: %d", vector_state.bit_width);
+			throw DataCorruptionException("Corrupted ALP segment: Invalid bit_width encountered: %d", vector_state.bit_width);
 		}
 
 		idx_t read_bytes = 0;
@@ -185,7 +185,7 @@ public:
 
 			const idx_t max_encoded = sizeof(vector_state.for_encoded);
 			if (bp_size > max_encoded || data_byte_offset + read_bytes + bp_size > block_size) {
-				throw IOException("Corrupted ALP segment: encoded payload too large");
+				throw DataCorruptionException("Corrupted ALP segment: encoded payload too large");
 			}
 			memcpy(vector_state.for_encoded, (void *)vector_ptr, bp_size);
 			vector_ptr += bp_size;
@@ -198,7 +198,7 @@ public:
 			const idx_t exceptions_copy_size = sizeof(EXACT_TYPE) * vector_state.exceptions_count;
 			if (exceptions_copy_size > max_exceptions_size ||
 			    data_byte_offset + read_bytes + exceptions_copy_size > block_size) {
-				throw IOException("Corrupted ALP segment: exceptions payload too large");
+				throw DataCorruptionException("Corrupted ALP segment: exceptions payload too large");
 			}
 			memcpy(vector_state.exceptions, (void *)vector_ptr, exceptions_copy_size);
 			vector_ptr += exceptions_copy_size;
@@ -210,7 +210,7 @@ public:
 			    AlpConstants::EXCEPTION_POSITION_SIZE * vector_state.exceptions_count;
 			if (exceptions_positions_copy_size > max_exceptions_positions_size ||
 			    data_byte_offset + read_bytes + exceptions_positions_copy_size > block_size) {
-				throw IOException("Corrupted ALP segment: exceptions_positions payload too large");
+				throw DataCorruptionException("Corrupted ALP segment: exceptions_positions payload too large");
 			}
 			memcpy(vector_state.exceptions_positions, (void *)vector_ptr, exceptions_positions_copy_size);
 			vector_ptr += exceptions_positions_copy_size;

--- a/src/include/duckdb/storage/compression/alp/alp_scan.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_scan.hpp
@@ -147,9 +147,10 @@ public:
 				const idx_t value_buffer_copy_size = sizeof(T) * vector_size;
 				if (vector_ptr + value_buffer_copy_size > segment_data + block_size) {
 					const auto bytes_remaining_in_block = (segment_data + block_size) - vector_ptr;
-					throw DataCorruptionException("Corrupted ALP segment: stored vector_size is invalid, to-copy bytes (%d) "
-					                  "would exceed bytes remaining in the block (%d)",
-					                  value_buffer_copy_size, bytes_remaining_in_block);
+					throw DataCorruptionException(
+					    "Corrupted ALP segment: stored vector_size is invalid, to-copy bytes (%d) "
+					    "would exceed bytes remaining in the block (%d)",
+					    value_buffer_copy_size, bytes_remaining_in_block);
 				}
 				memcpy(value_buffer, vector_ptr, value_buffer_copy_size);
 			}
@@ -169,14 +170,15 @@ public:
 
 		if (vector_state.exceptions_count > vector_size) {
 			throw DataCorruptionException("Corrupted ALP segment: exceptions_count (%d) exceeds vector_size (%d)",
-			                  vector_state.exceptions_count, vector_size);
+			                              vector_state.exceptions_count, vector_size);
 		}
 		if (vector_state.v_factor > vector_state.v_exponent) {
-			throw DataCorruptionException("Corrupted ALP segment: v_factor (%d) exceeds v_exponent (%d)", vector_state.v_factor,
-			                  vector_state.v_exponent);
+			throw DataCorruptionException("Corrupted ALP segment: v_factor (%d) exceeds v_exponent (%d)",
+			                              vector_state.v_factor, vector_state.v_exponent);
 		}
 		if (vector_state.bit_width > sizeof(uint64_t) * 8) {
-			throw DataCorruptionException("Corrupted ALP segment: Invalid bit_width encountered: %d", vector_state.bit_width);
+			throw DataCorruptionException("Corrupted ALP segment: Invalid bit_width encountered: %d",
+			                              vector_state.bit_width);
 		}
 
 		idx_t read_bytes = 0;

--- a/src/include/duckdb/storage/compression/alprd/alprd_scan.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_scan.hpp
@@ -192,9 +192,10 @@ public:
 				const idx_t value_buffer_copy_size = sizeof(T) * vector_size;
 				if (vector_ptr + value_buffer_copy_size > segment_data + block_size) {
 					const auto bytes_remaining_in_block = (segment_data + block_size) - vector_ptr;
-					throw DataCorruptionException("Corrupted ALPRD segment: stored vector_size is invalid, to-copy bytes "
-					                  "(%d) would exceed bytes remaining in the block (%d)",
-					                  value_buffer_copy_size, bytes_remaining_in_block);
+					throw DataCorruptionException(
+					    "Corrupted ALPRD segment: stored vector_size is invalid, to-copy bytes "
+					    "(%d) would exceed bytes remaining in the block (%d)",
+					    value_buffer_copy_size, bytes_remaining_in_block);
 				}
 				memcpy(value_buffer, vector_ptr, value_buffer_copy_size);
 			}

--- a/src/include/duckdb/storage/compression/alprd/alprd_scan.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_scan.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/storage/compression/alprd/alprd_constants.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/function/compression_function.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 

--- a/src/include/duckdb/storage/compression/alprd/alprd_scan.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_scan.hpp
@@ -84,11 +84,11 @@ public:
 		metadata_ptr = segment_data + metadata_offset;
 		const idx_t metadata_ptr_offset = segment.GetBlockOffset() + metadata_offset;
 		if (metadata_ptr_offset > block_size) {
-			throw IOException("Corrupted ALPRD segment: metadata_offset value is corrupted");
+			throw DataCorruptionException("Corrupted ALPRD segment: metadata_offset value is corrupted");
 		}
 
 		if (total_segment_offset + AlpRDConstants::HEADER_SIZE > block_size) {
-			throw IOException("Corrupted ALPRD segment: reading header bytes would exceed block space");
+			throw DataCorruptionException("Corrupted ALPRD segment: reading header bytes would exceed block space");
 		}
 
 		// Load the Right Bit Width which is in the segment header after the pointer to the first metadata
@@ -104,7 +104,7 @@ public:
 		total_segment_offset += AlpRDConstants::HEADER_SIZE;
 
 		if (actual_dictionary_size > AlpRDConstants::MAX_DICTIONARY_SIZE) {
-			throw IOException("Corrupt database file: ALPRD dictionary size exceeds maximum");
+			throw DataCorruptionException("Corrupt database file: ALPRD dictionary size exceeds maximum");
 		}
 		idx_t actual_dictionary_size_bytes =
 		    static_cast<idx_t>(actual_dictionary_size) * AlpRDConstants::DICTIONARY_ELEMENT_SIZE;
@@ -112,7 +112,7 @@ public:
 		const idx_t left_parts_dict_max_size = sizeof(vector_state.left_parts_dict);
 		if (total_segment_offset + actual_dictionary_size_bytes > metadata_ptr_offset ||
 		    actual_dictionary_size_bytes > left_parts_dict_max_size) {
-			throw IOException("Corrupted ALPRD segment: actual_dictionary_size is corrupted");
+			throw DataCorruptionException("Corrupted ALPRD segment: actual_dictionary_size is corrupted");
 		}
 		// Load the left parts dictionary which is after the segment header and is of a fixed size
 		memcpy(vector_state.left_parts_dict, segment_ptr, actual_dictionary_size_bytes);
@@ -192,7 +192,7 @@ public:
 				const idx_t value_buffer_copy_size = sizeof(T) * vector_size;
 				if (vector_ptr + value_buffer_copy_size > segment_data + block_size) {
 					const auto bytes_remaining_in_block = (segment_data + block_size) - vector_ptr;
-					throw IOException("Corrupted ALPRD segment: stored vector_size is invalid, to-copy bytes "
+					throw DataCorruptionException("Corrupted ALPRD segment: stored vector_size is invalid, to-copy bytes "
 					                  "(%d) would exceed bytes remaining in the block (%d)",
 					                  value_buffer_copy_size, bytes_remaining_in_block);
 				}
@@ -207,7 +207,7 @@ public:
 		idx_t read_bytes = 0;
 		const idx_t max_left_encoded_size = sizeof(vector_state.left_encoded);
 		if (left_bp_size > max_left_encoded_size || data_byte_offset + read_bytes + left_bp_size > block_size) {
-			throw IOException("Corrupted ALPRD segment: left_encoded payload too large");
+			throw DataCorruptionException("Corrupted ALPRD segment: left_encoded payload too large");
 		}
 		memcpy(vector_state.left_encoded, (void *)vector_ptr, left_bp_size);
 		vector_ptr += left_bp_size;
@@ -215,7 +215,7 @@ public:
 
 		const idx_t max_right_encoded_size = sizeof(vector_state.right_encoded);
 		if (right_bp_size > max_right_encoded_size || data_byte_offset + read_bytes + right_bp_size > block_size) {
-			throw IOException("Corrupted ALPRD segment: left_encoded payload too large");
+			throw DataCorruptionException("Corrupted ALPRD segment: left_encoded payload too large");
 		}
 		memcpy(vector_state.right_encoded, (void *)vector_ptr, right_bp_size);
 		vector_ptr += right_bp_size;
@@ -227,7 +227,7 @@ public:
 			const idx_t exceptions_copy_size = AlpRDConstants::EXCEPTION_SIZE * vector_state.exceptions_count;
 			if (exceptions_copy_size > max_exceptions_size ||
 			    data_byte_offset + read_bytes + exceptions_copy_size > block_size) {
-				throw IOException("Corrupted ALPRD segment: exceptions payload too large");
+				throw DataCorruptionException("Corrupted ALPRD segment: exceptions payload too large");
 			}
 			memcpy(vector_state.exceptions, (void *)vector_ptr, exceptions_copy_size);
 			vector_ptr += exceptions_copy_size;
@@ -239,7 +239,7 @@ public:
 			    AlpRDConstants::EXCEPTION_POSITION_SIZE * vector_state.exceptions_count;
 			if (exceptions_positions_copy_size > max_exceptions_positions_size ||
 			    data_byte_offset + read_bytes + exceptions_positions_copy_size > block_size) {
-				throw IOException("Corrupted ALPRD segment: exceptions_positions payload too large");
+				throw DataCorruptionException("Corrupted ALPRD segment: exceptions_positions payload too large");
 			}
 			memcpy(vector_state.exceptions_positions, (void *)vector_ptr, exceptions_positions_copy_size);
 			vector_ptr += exceptions_positions_copy_size;

--- a/src/include/duckdb/storage/compression/patas/patas_scan.hpp
+++ b/src/include/duckdb/storage/compression/patas/patas_scan.hpp
@@ -104,7 +104,8 @@ public:
 		segment_data = handle.GetDataMutable() + segment.GetBlockOffset();
 		auto metadata_offset = Load<uint32_t>(segment_data);
 		if (segment.GetBlockOffset() + metadata_offset > segment.GetBlockSize()) {
-			throw DataCorruptionException("Corrupted Patas segment: metadata_offset reaches outside of the blocks memory");
+			throw DataCorruptionException(
+			    "Corrupted Patas segment: metadata_offset reaches outside of the blocks memory");
 		}
 		metadata_ptr = segment_data + metadata_offset;
 	}
@@ -166,7 +167,8 @@ public:
 		metadata_ptr -= sizeof(uint32_t);
 		auto data_byte_offset = Load<uint32_t>(metadata_ptr);
 		if (segment.GetBlockOffset() + data_byte_offset >= segment.GetBlockSize()) {
-			throw DataCorruptionException("Corrupted Patas segment: data_byte_offset would reach outside of the blocks memory");
+			throw DataCorruptionException(
+			    "Corrupted Patas segment: data_byte_offset would reach outside of the blocks memory");
 		}
 
 		// Initialize the byte_reader with the data values for the group

--- a/src/include/duckdb/storage/compression/patas/patas_scan.hpp
+++ b/src/include/duckdb/storage/compression/patas/patas_scan.hpp
@@ -68,11 +68,11 @@ public:
 		value_buffer[0] = (EXACT_TYPE)0;
 		for (idx_t i = 0; i < count; i++) {
 			if (unpacked_data[i].index_diff > i) {
-				throw IOException("Corrupted Patas segment: invalid backward reference");
+				throw DataCorruptionException("Corrupted Patas segment: invalid backward reference");
 			}
 			if (unpacked_data[i].significant_bytes > sizeof(EXACT_TYPE) ||
 			    unpacked_data[i].trailing_zeros >= sizeof(EXACT_TYPE) * 8) {
-				throw IOException("Corrupted Patas segment: invalid packed value metadata");
+				throw DataCorruptionException("Corrupted Patas segment: invalid packed value metadata");
 			}
 
 			value_buffer[i] = patas::PatasDecompression<EXACT_TYPE>::DecompressValue(
@@ -104,7 +104,7 @@ public:
 		segment_data = handle.GetDataMutable() + segment.GetBlockOffset();
 		auto metadata_offset = Load<uint32_t>(segment_data);
 		if (segment.GetBlockOffset() + metadata_offset > segment.GetBlockSize()) {
-			throw IOException("Corrupted Patas segment: metadata_offset reaches outside of the blocks memory");
+			throw DataCorruptionException("Corrupted Patas segment: metadata_offset reaches outside of the blocks memory");
 		}
 		metadata_ptr = segment_data + metadata_offset;
 	}
@@ -166,7 +166,7 @@ public:
 		metadata_ptr -= sizeof(uint32_t);
 		auto data_byte_offset = Load<uint32_t>(metadata_ptr);
 		if (segment.GetBlockOffset() + data_byte_offset >= segment.GetBlockSize()) {
-			throw IOException("Corrupted Patas segment: data_byte_offset would reach outside of the blocks memory");
+			throw DataCorruptionException("Corrupted Patas segment: data_byte_offset would reach outside of the blocks memory");
 		}
 
 		// Initialize the byte_reader with the data values for the group

--- a/src/include/duckdb/storage/compression/patas/patas_scan.hpp
+++ b/src/include/duckdb/storage/compression/patas/patas_scan.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/storage/compression/patas/algorithm/patas.hpp"
 #include "duckdb/storage/compression/patas/patas.hpp"
 
+#include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/function/compression_function.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -473,10 +473,10 @@ static unique_ptr<CreateInfo> ReadCreateInfo(Deserializer &deserializer, Catalog
 	// 100 is the serialization field ID for the catalog entry's CreateInfo payload
 	auto info = deserializer.ReadProperty<unique_ptr<CreateInfo>>(100, entry_name);
 	if (!info) {
-		throw IOException("corrupt database file - %s entry without create info", entry_name);
+		throw DataCorruptionException("corrupt database file - %s entry without create info", entry_name);
 	}
 	if (info->type != expected_type) {
-		throw IOException("corrupt database file - catalog entry type mismatch for %s", entry_name);
+		throw DataCorruptionException("corrupt database file - catalog entry type mismatch for %s", entry_name);
 	}
 	return info;
 }
@@ -522,7 +522,7 @@ void CheckpointReader::ReadEntry(CatalogTransaction transaction, Deserializer &d
 		break;
 	}
 	default:
-		throw IOException("corrupt database file - unrecognized catalog type in checkpoint");
+		throw DataCorruptionException("corrupt database file - unrecognized catalog type in checkpoint");
 	}
 }
 
@@ -563,7 +563,7 @@ void CheckpointReader::ReadTrigger(CatalogTransaction transaction, Deserializer 
 	auto &schema = catalog.GetSchema(transaction, trigger_info.GetQualifiedName().Schema());
 	auto table_entry = schema.GetEntry(transaction, CatalogType::TABLE_ENTRY, trigger_info.base_table->Table());
 	if (!table_entry) {
-		throw IOException("corrupt database file - trigger entry without table entry");
+		throw DataCorruptionException("corrupt database file - trigger entry without table entry");
 	}
 	auto &duck_table = table_entry->Cast<DuckTableEntry>();
 	duck_table.CreateTrigger(transaction, trigger_info);
@@ -611,7 +611,7 @@ void CheckpointReader::ReadIndex(CatalogTransaction transaction, Deserializer &d
 	auto catalog_table = schema.GetEntry(transaction, CatalogType::TABLE_ENTRY, info.table);
 	if (!catalog_table) {
 		// See internal issue 3663.
-		throw IOException("corrupt database file - index entry without table entry");
+		throw DataCorruptionException("corrupt database file - index entry without table entry");
 	}
 	auto &table = catalog_table->Cast<DuckTableEntry>();
 

--- a/src/storage/compression/dictionary/decompression.cpp
+++ b/src/storage/compression/dictionary/decompression.cpp
@@ -6,8 +6,9 @@ namespace duckdb {
 
 void CompressedStringScanState::ValidateDictionaryIndex(sel_t index) {
 	if (index >= index_buffer_count) {
-		throw DataCorruptionException("Failed to scan dictionary string - dictionary index was out of range. Database file appears "
-		                  "to be corrupted.");
+		throw DataCorruptionException(
+		    "Failed to scan dictionary string - dictionary index was out of range. Database file appears "
+		    "to be corrupted.");
 	}
 }
 
@@ -29,13 +30,15 @@ uint16_t CompressedStringScanState::GetStringLength(sel_t index) {
 		ValidateDictionaryOffset(dict_offset);
 		ValidateDictionaryOffset(previous_dict_offset);
 		if (dict_offset < previous_dict_offset) {
-			throw DataCorruptionException("Failed to scan dictionary string - dictionary offset was out of range. Database file "
-			                  "appears to be corrupted.");
+			throw DataCorruptionException(
+			    "Failed to scan dictionary string - dictionary offset was out of range. Database file "
+			    "appears to be corrupted.");
 		}
 		auto string_length = dict_offset - previous_dict_offset;
 		if (string_length > NumericLimits<uint16_t>::Maximum()) {
-			throw DataCorruptionException("Failed to scan dictionary string - dictionary offset was out of range. Database file "
-			                  "appears to be corrupted.");
+			throw DataCorruptionException(
+			    "Failed to scan dictionary string - dictionary offset was out of range. Database file "
+			    "appears to be corrupted.");
 		}
 		return UnsafeNumericCast<uint16_t>(string_length);
 	}
@@ -89,8 +92,9 @@ void CompressedStringScanState::Initialize(ColumnSegment &segment, bool initiali
 	auto selection_buffer_size = BitpackingPrimitives::GetRequiredSize(segment.count.load(), current_width);
 	auto expected_index_buffer_offset = DictionaryCompression::DICTIONARY_HEADER_SIZE + selection_buffer_size;
 	if (index_buffer_offset != expected_index_buffer_offset) {
-		throw DataCorruptionException("Failed to scan dictionary string - selection buffer was out of range. Database file appears "
-		                  "to be corrupted.");
+		throw DataCorruptionException(
+		    "Failed to scan dictionary string - selection buffer was out of range. Database file appears "
+		    "to be corrupted.");
 	}
 	if (index_buffer_offset > segment_capacity ||
 	    index_buffer_count > (segment_capacity - index_buffer_offset) / sizeof(uint32_t)) {

--- a/src/storage/compression/dictionary/decompression.cpp
+++ b/src/storage/compression/dictionary/decompression.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 void CompressedStringScanState::ValidateDictionaryIndex(sel_t index) {
 	if (index >= index_buffer_count) {
-		throw IOException("Failed to scan dictionary string - dictionary index was out of range. Database file appears "
+		throw DataCorruptionException("Failed to scan dictionary string - dictionary index was out of range. Database file appears "
 		                  "to be corrupted.");
 	}
 }
@@ -29,12 +29,12 @@ uint16_t CompressedStringScanState::GetStringLength(sel_t index) {
 		ValidateDictionaryOffset(dict_offset);
 		ValidateDictionaryOffset(previous_dict_offset);
 		if (dict_offset < previous_dict_offset) {
-			throw IOException("Failed to scan dictionary string - dictionary offset was out of range. Database file "
+			throw DataCorruptionException("Failed to scan dictionary string - dictionary offset was out of range. Database file "
 			                  "appears to be corrupted.");
 		}
 		auto string_length = dict_offset - previous_dict_offset;
 		if (string_length > NumericLimits<uint16_t>::Maximum()) {
-			throw IOException("Failed to scan dictionary string - dictionary offset was out of range. Database file "
+			throw DataCorruptionException("Failed to scan dictionary string - dictionary offset was out of range. Database file "
 			                  "appears to be corrupted.");
 		}
 		return UnsafeNumericCast<uint16_t>(string_length);
@@ -89,7 +89,7 @@ void CompressedStringScanState::Initialize(ColumnSegment &segment, bool initiali
 	auto selection_buffer_size = BitpackingPrimitives::GetRequiredSize(segment.count.load(), current_width);
 	auto expected_index_buffer_offset = DictionaryCompression::DICTIONARY_HEADER_SIZE + selection_buffer_size;
 	if (index_buffer_offset != expected_index_buffer_offset) {
-		throw IOException("Failed to scan dictionary string - selection buffer was out of range. Database file appears "
+		throw DataCorruptionException("Failed to scan dictionary string - selection buffer was out of range. Database file appears "
 		                  "to be corrupted.");
 	}
 	if (index_buffer_offset > segment_capacity ||

--- a/src/storage/compression/dictionary/decompression.cpp
+++ b/src/storage/compression/dictionary/decompression.cpp
@@ -14,7 +14,7 @@ void CompressedStringScanState::ValidateDictionaryIndex(sel_t index) {
 
 void CompressedStringScanState::ValidateDictionaryOffset(uint32_t dict_offset) {
 	if (dict_offset > dict.size) {
-		throw IOException(
+		throw DataCorruptionException(
 		    "Failed to scan dictionary string - dictionary offset was out of range. Database file appears "
 		    "to be corrupted.");
 	}

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -559,8 +559,9 @@ unique_ptr<SegmentScanState> FSSTStorage::StringInitScan(const QueryContext &con
 	auto block_size = segment.GetBlockSize();
 	auto block_offset = segment.GetBlockOffset();
 	if (block_offset > block_size) {
-		throw IOException("Failed to read FSST string segment - header was out of range. Database file appears to be "
-		                  "corrupted.");
+		throw DataCorruptionException(
+		    "Failed to read FSST string segment - header was out of range. Database file appears to be "
+		    "corrupted.");
 	}
 	auto segment_capacity = block_size - block_offset;
 	auto string_block_limit = StringUncompressed::GetStringBlockLimit(block_size);
@@ -731,8 +732,9 @@ void FSSTStorage::StringFetchRow(ColumnSegment &segment, ColumnFetchState &state
 	auto block_size = segment.GetBlockSize();
 	auto block_offset = segment.GetBlockOffset();
 	if (block_offset > block_size) {
-		throw IOException("Failed to read FSST string segment - header was out of range. Database file appears to be "
-		                  "corrupted.");
+		throw DataCorruptionException(
+		    "Failed to read FSST string segment - header was out of range. Database file appears to be "
+		    "corrupted.");
 	}
 	auto segment_capacity = block_size - block_offset;
 	auto base_ptr = handle.GetDataMutable() + block_offset;

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -818,7 +818,7 @@ char *FSSTStorage::FetchStringPointer(StringDictionaryContainer dict, data_ptr_t
 }
 
 static void ThrowInvalidFSSTSegment(const char *reason) {
-	throw IOException("Failed to read FSST string segment - %s. Database file appears to be corrupted.", reason);
+	throw DataCorruptionException("Failed to read FSST string segment - %s. Database file appears to be corrupted.", reason);
 }
 
 // Returns false if no symbol table was found. This means all strings are either empty or null

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -818,7 +818,8 @@ char *FSSTStorage::FetchStringPointer(StringDictionaryContainer dict, data_ptr_t
 }
 
 static void ThrowInvalidFSSTSegment(const char *reason) {
-	throw DataCorruptionException("Failed to read FSST string segment - %s. Database file appears to be corrupted.", reason);
+	throw DataCorruptionException("Failed to read FSST string segment - %s. Database file appears to be corrupted.",
+	                              reason);
 }
 
 // Returns false if no symbol table was found. This means all strings are either empty or null

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -259,15 +259,15 @@ struct RLEScanState : public SegmentScanState {
 	                    static_cast<idx_t>(sizeof(rle_count_t))) {
 		if (rle_count_offset < RLEConstants::RLE_HEADER_SIZE) {
 			//! This would make the index_pointer point into a region reserved for the header data
-			throw IOException("Corrupted RLE segment: rle_count_offset is corrupted");
+			throw DataCorruptionException("Corrupted RLE segment: rle_count_offset is corrupted");
 		}
 		if (segment.GetBlockOffset() + rle_count_offset > segment.GetBlockSize()) {
 			//! This would make the index_pointer start outside of the segment
-			throw IOException("Corrupted RLE segment: rle_count_offset is corrupted");
+			throw DataCorruptionException("Corrupted RLE segment: rle_count_offset is corrupted");
 		}
 		if ((rle_count_offset - RLEConstants::RLE_HEADER_SIZE) / sizeof(T) > max_entry_pos) {
 			//! This would make the indexing of the index_pointer[entry_pos] reach outside of the segment
-			throw IOException("Corrupted RLE segment: rle_count_offset is corrupted");
+			throw DataCorruptionException("Corrupted RLE segment: rle_count_offset is corrupted");
 		}
 	}
 

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -734,7 +734,7 @@ void SingleFileBlockManager::CheckChecksum(data_ptr_t start_ptr, uint64_t delta,
 
 	// verify the checksum
 	if (stored_checksum != computed_checksum) {
-		throw IOException("Corrupt database file: computed checksum %llu does not match stored checksum %llu in block "
+		throw DataCorruptionException("Corrupt database file: computed checksum %llu does not match stored checksum %llu in block "
 		                  "at location %llu",
 		                  computed_checksum, stored_checksum, start_ptr);
 	}
@@ -757,7 +757,7 @@ void SingleFileBlockManager::CheckChecksum(FileBuffer &block, uint64_t location,
 
 	// verify the checksum
 	if (stored_checksum != computed_checksum) {
-		throw IOException("Corrupt database file: computed checksum %llu does not match stored checksum %llu in block "
+		throw DataCorruptionException("Corrupt database file: computed checksum %llu does not match stored checksum %llu in block "
 		                  "at location %llu",
 		                  computed_checksum, stored_checksum, location);
 	}

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -734,9 +734,10 @@ void SingleFileBlockManager::CheckChecksum(data_ptr_t start_ptr, uint64_t delta,
 
 	// verify the checksum
 	if (stored_checksum != computed_checksum) {
-		throw DataCorruptionException("Corrupt database file: computed checksum %llu does not match stored checksum %llu in block "
-		                  "at location %llu",
-		                  computed_checksum, stored_checksum, start_ptr);
+		throw DataCorruptionException(
+		    "Corrupt database file: computed checksum %llu does not match stored checksum %llu in block "
+		    "at location %llu",
+		    computed_checksum, stored_checksum, start_ptr);
 	}
 }
 
@@ -757,9 +758,10 @@ void SingleFileBlockManager::CheckChecksum(FileBuffer &block, uint64_t location,
 
 	// verify the checksum
 	if (stored_checksum != computed_checksum) {
-		throw DataCorruptionException("Corrupt database file: computed checksum %llu does not match stored checksum %llu in block "
-		                  "at location %llu",
-		                  computed_checksum, stored_checksum, location);
+		throw DataCorruptionException(
+		    "Corrupt database file: computed checksum %llu does not match stored checksum %llu in block "
+		    "at location %llu",
+		    computed_checksum, stored_checksum, location);
 	}
 }
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -49,7 +49,7 @@ RowGroup::RowGroup(RowGroupCollection &collection_p, RowGroupPointer pointer)
       has_changes(false) {
 	// deserialize the columns
 	if (pointer.data_pointers.size() != collection_p.GetTypes().size()) {
-		throw IOException("Row group column count is unaligned with table column count. Corrupt file?");
+		throw DataCorruptionException("Row group column count is unaligned with table column count. Corrupt file?");
 	}
 	this->column_pointers = std::move(pointer.data_pointers);
 	this->columns.resize(column_pointers.size());

--- a/src/storage/table/table_statistics.cpp
+++ b/src/storage/table/table_statistics.cpp
@@ -20,7 +20,8 @@ void TableStatistics::Initialize(const vector<LogicalType> &types, PersistentTab
 		table_sample = make_uniq<ReservoirSample>(static_cast<idx_t>(FIXED_SAMPLE_SIZE));
 	}
 	if (column_stats.size() != types.size()) { // LCOV_EXCL_START
-		throw DataCorruptionException("Table statistics column count is not aligned with table column count. Corrupt file?");
+		throw DataCorruptionException(
+		    "Table statistics column count is not aligned with table column count. Corrupt file?");
 	} // LCOV_EXCL_STOP
 }
 

--- a/src/storage/table/table_statistics.cpp
+++ b/src/storage/table/table_statistics.cpp
@@ -20,7 +20,7 @@ void TableStatistics::Initialize(const vector<LogicalType> &types, PersistentTab
 		table_sample = make_uniq<ReservoirSample>(static_cast<idx_t>(FIXED_SAMPLE_SIZE));
 	}
 	if (column_stats.size() != types.size()) { // LCOV_EXCL_START
-		throw IOException("Table statistics column count is not aligned with table column count. Corrupt file?");
+		throw DataCorruptionException("Table statistics column count is not aligned with table column count. Corrupt file?");
 	} // LCOV_EXCL_STOP
 }
 

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -114,7 +114,7 @@ public:
 			// compute and verify the checksum
 			auto computed_checksum = Checksum(buffer.get(), size);
 			if (stored_checksum != computed_checksum) {
-				throw IOException("Corrupt WAL file: entry at byte position %llu computed checksum %llu does not match "
+				throw DataCorruptionException("Corrupt WAL file: entry at byte position %llu computed checksum %llu does not match "
 				                  "stored checksum %llu",
 				                  offset, computed_checksum, stored_checksum);
 			}
@@ -191,7 +191,7 @@ public:
 			// compute and verify the checksum
 			auto computed_checksum = Checksum(out_buffer.get(), size);
 			if (stored_checksum != computed_checksum) {
-				throw IOException("Corrupt WAL file: entry at byte position %llu computed checksum %llu does not match "
+				throw DataCorruptionException("Corrupt WAL file: entry at byte position %llu computed checksum %llu does not match "
 				                  "stored checksum %llu",
 				                  offset, computed_checksum, stored_checksum);
 			}
@@ -682,7 +682,7 @@ void WriteAheadLogDeserializer::ReplayVersion() {
 	bool is_set = false;
 	deserializer.ReadOptionalList(102, "db_identifier", [&](Deserializer::List &list, idx_t i) {
 		if (i >= MainHeader::DB_IDENTIFIER_LEN) {
-			throw IOException("Corrupt file - database identifier in header out of range");
+			throw DataCorruptionException("Corrupt file - database identifier in header out of range");
 		}
 		db_identifier[i] = list.ReadElement<uint8_t>();
 		is_set = true;

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -114,9 +114,10 @@ public:
 			// compute and verify the checksum
 			auto computed_checksum = Checksum(buffer.get(), size);
 			if (stored_checksum != computed_checksum) {
-				throw DataCorruptionException("Corrupt WAL file: entry at byte position %llu computed checksum %llu does not match "
-				                  "stored checksum %llu",
-				                  offset, computed_checksum, stored_checksum);
+				throw DataCorruptionException(
+				    "Corrupt WAL file: entry at byte position %llu computed checksum %llu does not match "
+				    "stored checksum %llu",
+				    offset, computed_checksum, stored_checksum);
 			}
 
 			return WriteAheadLogDeserializer(state_p, std::move(buffer), size, deserialize_only);
@@ -191,9 +192,10 @@ public:
 			// compute and verify the checksum
 			auto computed_checksum = Checksum(out_buffer.get(), size);
 			if (stored_checksum != computed_checksum) {
-				throw DataCorruptionException("Corrupt WAL file: entry at byte position %llu computed checksum %llu does not match "
-				                  "stored checksum %llu",
-				                  offset, computed_checksum, stored_checksum);
+				throw DataCorruptionException(
+				    "Corrupt WAL file: entry at byte position %llu computed checksum %llu does not match "
+				    "stored checksum %llu",
+				    offset, computed_checksum, stored_checksum);
 			}
 
 			return WriteAheadLogDeserializer(state_p, std::move(out_buffer), size, deserialize_only);

--- a/test/sql/storage/compression/alp/alp_corrupted_file.test
+++ b/test/sql/storage/compression/alp/alp_corrupted_file.test
@@ -19,4 +19,4 @@ ALP
 statement error
 SELECT * FROM alp LIMIT 1;
 ----
-IO Error: Corrupted ALP segment: Invalid bit_width encountered: 255
+Data Corruption Error: Corrupted ALP segment: Invalid bit_width encountered: 255

--- a/test/sql/storage/compression/alp/alp_corrupted_offsets.test
+++ b/test/sql/storage/compression/alp/alp_corrupted_offsets.test
@@ -19,4 +19,4 @@ ALP
 statement error
 SELECT * FROM random_alp_double LIMIT 1;
 ----
-IO Error: Corrupted ALP segment: stored vector_size is invalid, to-copy bytes (8192) would exceed bytes remaining in the block (7)
+Data Corruption Error: Corrupted ALP segment: stored vector_size is invalid, to-copy bytes (8192) would exceed bytes remaining in the block (7)

--- a/test/sql/storage/compression/alp/alp_corrupted_vector_size.test
+++ b/test/sql/storage/compression/alp/alp_corrupted_vector_size.test
@@ -20,4 +20,4 @@ ALP
 statement error
 SELECT * FROM two_alp LIMIT 1;
 ----
-IO Error: Corrupted ALP segment: stored vector_size is invalid, to-copy bytes (8192) would exceed bytes remaining in the block (2648)
+Data Corruption Error: Corrupted ALP segment: stored vector_size is invalid, to-copy bytes (8192) would exceed bytes remaining in the block (2648)

--- a/test/sql/storage/compression/alprd/alprd_corrupted_dict_size.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupted_dict_size.test
@@ -18,4 +18,4 @@ SELECT compression FROM pragma_storage_info('t') WHERE segment_type = 'DOUBLE' A
 statement error
 SELECT * FROM t LIMIT 1;
 ----
-IO Error: Corrupted ALPRD segment: exceptions payload too large
+Data Corruption Error: Corrupted ALPRD segment: exceptions payload too large

--- a/test/sql/storage/compression/dictionary/invalid_dictionary_metadata.test
+++ b/test/sql/storage/compression/dictionary/invalid_dictionary_metadata.test
@@ -31,6 +31,8 @@ SELECT sum(length(STREET)) FROM tbl
 ----
 Data Corruption Error: Failed to scan dictionary string - dictionary offset was out of range. Database file appears to be corrupted.
 
+restart
+
 statement ok
 ATTACH '{TEST_DIR}/dictionary_invalid_index.db' AS index_db
 
@@ -46,6 +48,8 @@ statement error
 SELECT sum(length(STREET)) FROM tbl
 ----
 Data Corruption Error: Failed to scan dictionary string - dictionary index was out of range. Database file appears to be corrupted.
+
+restart
 
 statement ok
 ATTACH '{TEST_DIR}/dictionary_invalid_dict_end.db' AS dict_end_db
@@ -63,6 +67,8 @@ SELECT sum(length(STREET)) FROM tbl
 ----
 Data Corruption Error: Failed to scan dictionary string - dictionary was out of range. Database file appears to be corrupted.
 
+restart
+
 statement ok
 ATTACH '{TEST_DIR}/dictionary_invalid_bitpacking_width.db' AS bitpacking_width_db
 
@@ -79,6 +85,8 @@ SELECT sum(length(STREET)) FROM tbl
 ----
 Data Corruption Error: Failed to scan dictionary string - bitpacking width was invalid. Database file appears to be corrupted.
 
+restart
+
 statement ok
 ATTACH '{TEST_DIR}/dictionary_invalid_selection_buffer.db' AS selection_buffer_db
 
@@ -94,6 +102,8 @@ statement error
 SELECT sum(length(STREET)) FROM tbl
 ----
 Data Corruption Error: Failed to scan dictionary string - selection buffer was out of range. Database file appears to be corrupted.
+
+restart
 
 statement ok
 ATTACH '{TEST_DIR}/dictionary_invalid_segment_end.db' AS segment_end_db

--- a/test/sql/storage/compression/dictionary/invalid_dictionary_metadata.test
+++ b/test/sql/storage/compression/dictionary/invalid_dictionary_metadata.test
@@ -29,7 +29,7 @@ SELECT count(*) FROM pragma_storage_info('tbl') WHERE compression='Dictionary'
 statement error
 SELECT sum(length(STREET)) FROM tbl
 ----
-IO Error: Failed to scan dictionary string - dictionary offset was out of range. Database file appears to be corrupted.
+Data Corruption Error: Failed to scan dictionary string - dictionary offset was out of range. Database file appears to be corrupted.
 
 statement ok
 ATTACH '{TEST_DIR}/dictionary_invalid_index.db' AS index_db
@@ -45,7 +45,7 @@ SELECT count(*) FROM pragma_storage_info('tbl') WHERE compression='Dictionary'
 statement error
 SELECT sum(length(STREET)) FROM tbl
 ----
-IO Error: Failed to scan dictionary string - dictionary index was out of range. Database file appears to be corrupted.
+Data Corruption Error: Failed to scan dictionary string - dictionary index was out of range. Database file appears to be corrupted.
 
 statement ok
 ATTACH '{TEST_DIR}/dictionary_invalid_dict_end.db' AS dict_end_db
@@ -61,7 +61,7 @@ SELECT count(*) FROM pragma_storage_info('tbl') WHERE compression='Dictionary'
 statement error
 SELECT sum(length(STREET)) FROM tbl
 ----
-IO Error: Failed to scan dictionary string - dictionary was out of range. Database file appears to be corrupted.
+Data Corruption Error: Failed to scan dictionary string - dictionary was out of range. Database file appears to be corrupted.
 
 statement ok
 ATTACH '{TEST_DIR}/dictionary_invalid_bitpacking_width.db' AS bitpacking_width_db
@@ -77,7 +77,7 @@ SELECT count(*) FROM pragma_storage_info('tbl') WHERE compression='Dictionary'
 statement error
 SELECT sum(length(STREET)) FROM tbl
 ----
-IO Error: Failed to scan dictionary string - bitpacking width was invalid. Database file appears to be corrupted.
+Data Corruption Error: Failed to scan dictionary string - bitpacking width was invalid. Database file appears to be corrupted.
 
 statement ok
 ATTACH '{TEST_DIR}/dictionary_invalid_selection_buffer.db' AS selection_buffer_db
@@ -93,7 +93,7 @@ SELECT count(*) FROM pragma_storage_info('tbl') WHERE compression='Dictionary'
 statement error
 SELECT sum(length(STREET)) FROM tbl
 ----
-IO Error: Failed to scan dictionary string - selection buffer was out of range. Database file appears to be corrupted.
+Data Corruption Error: Failed to scan dictionary string - selection buffer was out of range. Database file appears to be corrupted.
 
 statement ok
 ATTACH '{TEST_DIR}/dictionary_invalid_segment_end.db' AS segment_end_db
@@ -109,4 +109,4 @@ SELECT block_offset FROM pragma_storage_info('tbl') WHERE compression='Dictionar
 statement error
 SELECT sum(length(STREET)) FROM tbl
 ----
-IO Error: Failed to scan dictionary string - dictionary was out of range. Database file appears to be corrupted.
+Data Corruption Error: Failed to scan dictionary string - dictionary was out of range. Database file appears to be corrupted.

--- a/test/sql/storage/compression/fsst/invalid_fsst_bitpacking_width.test
+++ b/test/sql/storage/compression/fsst/invalid_fsst_bitpacking_width.test
@@ -15,4 +15,4 @@ USE invalid_fsst_db
 statement error
 SELECT sum(length(STREET)) FROM tbl
 ----
-IO Error: Failed to read FSST string segment - bitpacking width did not match the stored layout. Database file appears to be corrupted.
+Data Corruption Error: Failed to read FSST string segment - bitpacking width did not match the stored layout. Database file appears to be corrupted.

--- a/test/sql/storage/compression/patas/patas_corrupted_file.test
+++ b/test/sql/storage/compression/patas/patas_corrupted_file.test
@@ -16,4 +16,4 @@ Patas
 statement error
 SELECT * FROM temperatures_double LIMIT 1;
 ----
-IO Error: Corrupted Patas segment: invalid backward reference
+Data Corruption Error: Corrupted Patas segment: invalid backward reference

--- a/test/sql/storage/compression/rle/rle_corrupted_count_offset.test
+++ b/test/sql/storage/compression/rle/rle_corrupted_count_offset.test
@@ -13,4 +13,4 @@ RLE
 statement error
 SELECT * FROM t LIMIT 1;
 ----
-IO Error: Corrupted RLE segment: rle_count_offset is corrupted
+Data Corruption Error: Corrupted RLE segment: rle_count_offset is corrupted


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes error classification and database invalidation behavior on corruption paths across core storage; behavior is intentional but affects how failed reads surface and whether the DB is marked invalid.
> 
> **Overview**
> Adds a dedicated **`DATA_CORRUPTION`** exception type and **`DataCorruptionException`**, wired through enum/string helpers and treated like **`FATAL`** for **`InvalidatesDatabase`** so the engine can invalidate the database when on-disk data is untrustworthy.
> 
> **Storage and compression paths** that detect malformed checkpoints, WAL entries, block checksums, row-group/statistics layout, and corrupted ALP/ALPRD/Patas/RLE/FSST/dictionary segments now throw **`DataCorruptionException`** instead of **`IOException`**, so clients see a **Data Corruption** error rather than a generic I/O error. SQL tests are updated to match; dictionary corruption tests add **`restart`** between scenarios so each attach runs in a clean session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fb72a3c1ae12337cfd934e65d57b014c5cf5b7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->