### PR TITLE
Implement min/max pruning for parquet list type

### DIFF
--- a/extension/parquet/include/reader/expression_column_reader.hpp
+++ b/extension/parquet/include/reader/expression_column_reader.hpp
@@ -59,6 +59,7 @@ public:
 public:
 	void InitializeRead(idx_t row_group_idx_p, idx_t row_group_num_rows, const vector<ColumnChunk> &columns,
 	                    TProtocol &protocol_p) override;
+	unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns) override;
 
 	idx_t Read(ColumnReaderInput &input, Vector &result) override;
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1523,9 +1523,9 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 					              group.columns[schema_column_index].meta_data.statistics.__isset.max_value;
 				}
 				if (!is_generated_column && has_min_max &&
-				           (column_reader.Type().id() == LogicalTypeId::FLOAT ||
-				            column_reader.Type().id() == LogicalTypeId::DOUBLE) &&
-				           parquet_options.can_have_nan) {
+				    (column_reader.Type().id() == LogicalTypeId::FLOAT ||
+				     column_reader.Type().id() == LogicalTypeId::DOUBLE) &&
+				    parquet_options.can_have_nan) {
 					// floating point columns can have NaN values in addition to the min/max bounds defined in the file
 					// in order to do optimal pruning - we prune based on the [min, max] of the file followed by pruning
 					// based on nan

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1515,7 +1515,6 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 			FilterPropagateResult prune_result;
 			bool is_generated_column = schema_column_index >= group.columns.size();
 			bool is_column = column_reader.Schema().schema_type == ParquetColumnSchemaType::COLUMN;
-			bool is_expression = column_reader.Schema().schema_type == ParquetColumnSchemaType::EXPRESSION;
 			auto stats = column_reader.Stats(state.group_index, group.columns);
 			if (stats) {
 				bool has_min_max = false;
@@ -1523,10 +1522,7 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 					has_min_max = group.columns[schema_column_index].meta_data.statistics.__isset.min_value &&
 					              group.columns[schema_column_index].meta_data.statistics.__isset.max_value;
 				}
-				if (is_expression) {
-					// no pruning possible for expressions
-					prune_result = FilterPropagateResult::NO_PRUNING_POSSIBLE;
-				} else if (!is_generated_column && has_min_max &&
+				if (!is_generated_column && has_min_max &&
 				           (column_reader.Type().id() == LogicalTypeId::FLOAT ||
 				            column_reader.Type().id() == LogicalTypeId::DOUBLE) &&
 				           parquet_options.can_have_nan) {

--- a/extension/parquet/reader/expression_column_reader.cpp
+++ b/extension/parquet/reader/expression_column_reader.cpp
@@ -5,6 +5,7 @@
 #include "parquet_reader.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 
 namespace duckdb_apache {
 namespace thrift {
@@ -67,6 +68,17 @@ void ExpressionColumnReader::InitializeRead(idx_t row_group_idx_p, idx_t row_gro
 	for (auto &child_reader : child_readers) {
 		child_reader->InitializeRead(row_group_idx_p, row_group_num_rows, columns, protocol_p);
 	}
+}
+
+unique_ptr<BaseStatistics> ExpressionColumnReader::Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns) {
+	if (child_readers.size() != 1 || expr->GetExpressionClass() != ExpressionClass::BOUND_REF) {
+		return nullptr;
+	}
+	auto &ref = expr->Cast<BoundReferenceExpression>();
+	if (ref.Index() != 0) {
+		return nullptr;
+	}
+	return child_readers[0]->Stats(row_group_idx_p, columns);
 }
 
 static void ReverseSelectionVector(const SelectionVector &input, SelectionVector &output, idx_t input_count,

--- a/src/include/duckdb/storage/statistics/array_stats.hpp
+++ b/src/include/duckdb/storage/statistics/array_stats.hpp
@@ -20,6 +20,7 @@ class Vector;
 class Serializer;
 class Deserializer;
 class Value;
+struct StorageIndex;
 
 struct ArrayStats {
 	DUCKDB_API static void Construct(BaseStatistics &stats);
@@ -29,6 +30,7 @@ struct ArrayStats {
 	DUCKDB_API static const BaseStatistics &GetChildStats(const BaseStatistics &stats);
 	DUCKDB_API static BaseStatistics &GetChildStats(BaseStatistics &stats);
 	DUCKDB_API static void SetChildStats(BaseStatistics &stats, unique_ptr<BaseStatistics> new_stats);
+	DUCKDB_API static unique_ptr<BaseStatistics> PushdownExtract(const BaseStatistics &stats, const StorageIndex &index);
 
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);

--- a/src/include/duckdb/storage/statistics/array_stats.hpp
+++ b/src/include/duckdb/storage/statistics/array_stats.hpp
@@ -30,7 +30,8 @@ struct ArrayStats {
 	DUCKDB_API static const BaseStatistics &GetChildStats(const BaseStatistics &stats);
 	DUCKDB_API static BaseStatistics &GetChildStats(BaseStatistics &stats);
 	DUCKDB_API static void SetChildStats(BaseStatistics &stats, unique_ptr<BaseStatistics> new_stats);
-	DUCKDB_API static unique_ptr<BaseStatistics> PushdownExtract(const BaseStatistics &stats, const StorageIndex &index);
+	DUCKDB_API static unique_ptr<BaseStatistics> PushdownExtract(const BaseStatistics &stats,
+	                                                             const StorageIndex &index);
 
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);

--- a/src/include/duckdb/storage/statistics/list_stats.hpp
+++ b/src/include/duckdb/storage/statistics/list_stats.hpp
@@ -28,7 +28,8 @@ struct ListStats {
 	DUCKDB_API static const BaseStatistics &GetChildStats(const BaseStatistics &stats);
 	DUCKDB_API static BaseStatistics &GetChildStats(BaseStatistics &stats);
 	DUCKDB_API static void SetChildStats(BaseStatistics &stats, unique_ptr<BaseStatistics> new_stats);
-	DUCKDB_API static unique_ptr<BaseStatistics> PushdownExtract(const BaseStatistics &stats, const StorageIndex &index);
+	DUCKDB_API static unique_ptr<BaseStatistics> PushdownExtract(const BaseStatistics &stats,
+	                                                             const StorageIndex &index);
 
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);

--- a/src/include/duckdb/storage/statistics/list_stats.hpp
+++ b/src/include/duckdb/storage/statistics/list_stats.hpp
@@ -18,6 +18,7 @@ class BaseStatistics;
 struct SelectionVector;
 class Vector;
 class Value;
+struct StorageIndex;
 
 struct ListStats {
 	DUCKDB_API static void Construct(BaseStatistics &stats);
@@ -27,6 +28,7 @@ struct ListStats {
 	DUCKDB_API static const BaseStatistics &GetChildStats(const BaseStatistics &stats);
 	DUCKDB_API static BaseStatistics &GetChildStats(BaseStatistics &stats);
 	DUCKDB_API static void SetChildStats(BaseStatistics &stats, unique_ptr<BaseStatistics> new_stats);
+	DUCKDB_API static unique_ptr<BaseStatistics> PushdownExtract(const BaseStatistics &stats, const StorageIndex &index);
 
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/planner/filter/prefix_range_filter.hpp"
 #include "duckdb/planner/filter/selectivity_optional_filter.hpp"
 #include "duckdb/planner/filter/table_filter_functions.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
@@ -350,10 +351,19 @@ static optional_ptr<const BaseStatistics> TryGetArrayExtractStats(const BoundFun
 	auto array_size = ArrayType::GetSize(stats.GetType());
 	idx_t child_index;
 	if (index > 0) {
-		child_index = UnsafeNumericCast<idx_t>(index - 1);
+		idx_t positive_index;
+		if (!TryCast::Operation(index, positive_index) || positive_index == 0 || positive_index > array_size) {
+			child_index = array_size;
+		} else {
+			child_index = positive_index - 1;
+		}
 	} else {
-		auto offset_from_end = UnsafeNumericCast<idx_t>(-(index + 1)) + 1;
-		child_index = offset_from_end > array_size ? array_size : array_size - offset_from_end;
+		idx_t offset_from_end;
+		if (index == NumericLimits<int64_t>::Minimum() || !TryCast::Operation(-index, offset_from_end)) {
+			child_index = array_size;
+		} else {
+			child_index = offset_from_end > array_size ? array_size : array_size - offset_from_end;
+		}
 	}
 	if (child_index >= array_size) {
 		auto result = BaseStatistics::CreateEmpty(func.GetReturnType());

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -22,6 +22,8 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/storage/statistics/array_stats.hpp"
+#include "duckdb/storage/statistics/list_stats.hpp"
 #include "duckdb/storage/statistics/numeric_stats.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
@@ -201,6 +203,14 @@ static FilterPropagateResult CheckZonemapAgainstConstants(const BaseStatistics &
 	}
 }
 
+static optional_ptr<const BaseStatistics> TryGetArrayExtractStats(const BoundFunctionExpression &func,
+                                                                  const BaseStatistics &stats,
+                                                                  vector<unique_ptr<BaseStatistics>> &owned_stats);
+static optional_ptr<const BaseStatistics> TryGetListExtractStats(optional_ptr<ClientContext> context_p,
+                                                                 const BoundFunctionExpression &func,
+                                                                 const BaseStatistics &stats,
+                                                                 vector<unique_ptr<BaseStatistics>> &owned_stats);
+
 static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientContext> context_p,
                                                             const Expression &expr, const BaseStatistics &stats,
                                                             vector<unique_ptr<BaseStatistics>> &owned_stats) {
@@ -231,6 +241,21 @@ static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientC
 			}
 			owned_stats.push_back(std::move(cast_stats));
 			return owned_stats.back().get();
+		}
+
+		if ((func.Function().GetName() == "array_extract" || func.Function().GetName() == "list_extract") &&
+		    stats.GetType().id() == LogicalTypeId::ARRAY) {
+			auto array_extract_stats = TryGetArrayExtractStats(func, stats, owned_stats);
+			if (array_extract_stats) {
+				return array_extract_stats;
+			}
+		}
+		if ((func.Function().GetName() == "array_extract" || func.Function().GetName() == "list_extract") &&
+		    stats.GetType().id() == LogicalTypeId::LIST) {
+			auto list_extract_stats = TryGetListExtractStats(context_p, func, stats, owned_stats);
+			if (list_extract_stats) {
+				return list_extract_stats;
+			}
 		}
 
 		if (!context_p) {
@@ -289,6 +314,75 @@ static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientC
 	default:
 		return nullptr;
 	}
+}
+
+static optional_ptr<const BaseStatistics> TryGetArrayExtractStats(const BoundFunctionExpression &func,
+                                                                  const BaseStatistics &stats,
+                                                                  vector<unique_ptr<BaseStatistics>> &owned_stats) {
+	auto &children = func.GetChildren();
+	if (children.size() != 2) {
+		return nullptr;
+	}
+	auto &array_expr = *children[0];
+	auto &index_expr = *children[1];
+	if (array_expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION ||
+	    index_expr.GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+		return nullptr;
+	}
+	auto &array_cast = array_expr.Cast<BoundFunctionExpression>();
+	if (!BoundCastExpression::IsCast(array_cast)) {
+		return nullptr;
+	}
+	auto &cast_child = BoundCastExpression::Child(array_cast);
+	if (cast_child.GetExpressionClass() != ExpressionClass::BOUND_REF ||
+	    cast_child.GetReturnType().id() != LogicalTypeId::ARRAY ||
+	    stats.GetType().id() != LogicalTypeId::ARRAY) {
+		return nullptr;
+	}
+	auto &index_value = index_expr.Cast<BoundConstantExpression>().GetValue();
+	if (index_value.IsNull()) {
+		return nullptr;
+	}
+	auto index = index_value.GetValue<int64_t>();
+	if (index == 0) {
+		return nullptr;
+	}
+	auto array_size = ArrayType::GetSize(stats.GetType());
+	idx_t child_index;
+	if (index > 0) {
+		child_index = UnsafeNumericCast<idx_t>(index - 1);
+	} else {
+		auto offset_from_end = UnsafeNumericCast<idx_t>(-(index + 1)) + 1;
+		child_index = offset_from_end > array_size ? array_size : array_size - offset_from_end;
+	}
+	if (child_index >= array_size) {
+		auto result = BaseStatistics::CreateEmpty(func.GetReturnType());
+		result.Set(StatsInfo::CANNOT_HAVE_VALID_VALUES);
+		owned_stats.push_back(result.ToUnique());
+		return owned_stats.back().get();
+	}
+	auto child_stats = ArrayStats::GetChildStats(stats).Copy();
+	child_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	owned_stats.push_back(child_stats.ToUnique());
+	return owned_stats.back().get();
+}
+
+static optional_ptr<const BaseStatistics> TryGetListExtractStats(optional_ptr<ClientContext> context_p,
+                                                                 const BoundFunctionExpression &func,
+                                                                 const BaseStatistics &stats,
+                                                                 vector<unique_ptr<BaseStatistics>> &owned_stats) {
+	auto &children = func.GetChildren();
+	if (children.size() != 2) {
+		return nullptr;
+	}
+	auto list_stats = TryGetFilterStats(context_p, *children[0], stats, owned_stats);
+	if (!list_stats || list_stats->GetType().id() != LogicalTypeId::LIST) {
+		return nullptr;
+	}
+	auto child_stats = ListStats::GetChildStats(*list_stats).Copy();
+	child_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	owned_stats.push_back(child_stats.ToUnique());
+	return owned_stats.back().get();
 }
 
 static bool TryGetVariantComparisonStatsType(const LogicalType &typed_type, const LogicalType &constant_type,

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -336,8 +336,7 @@ static optional_ptr<const BaseStatistics> TryGetArrayExtractStats(const BoundFun
 	}
 	auto &cast_child = BoundCastExpression::Child(array_cast);
 	if (cast_child.GetExpressionClass() != ExpressionClass::BOUND_REF ||
-	    cast_child.GetReturnType().id() != LogicalTypeId::ARRAY ||
-	    stats.GetType().id() != LogicalTypeId::ARRAY) {
+	    cast_child.GetReturnType().id() != LogicalTypeId::ARRAY || stats.GetType().id() != LogicalTypeId::ARRAY) {
 		return nullptr;
 	}
 	auto &index_value = index_expr.Cast<BoundConstantExpression>().GetValue();
@@ -349,19 +348,15 @@ static optional_ptr<const BaseStatistics> TryGetArrayExtractStats(const BoundFun
 		return nullptr;
 	}
 	auto array_size = ArrayType::GetSize(stats.GetType());
-	idx_t child_index;
+	idx_t child_index = array_size;
 	if (index > 0) {
 		idx_t positive_index;
-		if (!TryCast::Operation(index, positive_index) || positive_index == 0 || positive_index > array_size) {
-			child_index = array_size;
-		} else {
+		if (TryCast::Operation(index, positive_index) && positive_index > 0 && positive_index <= array_size) {
 			child_index = positive_index - 1;
 		}
 	} else {
 		idx_t offset_from_end;
-		if (index == NumericLimits<int64_t>::Minimum() || !TryCast::Operation(-index, offset_from_end)) {
-			child_index = array_size;
-		} else {
+		if (index != NumericLimits<int64_t>::Minimum() && TryCast::Operation(-index, offset_from_end)) {
 			child_index = offset_from_end > array_size ? array_size : array_size - offset_from_end;
 		}
 	}

--- a/src/storage/statistics/array_stats.cpp
+++ b/src/storage/statistics/array_stats.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/storage/storage_index.hpp"
 
 namespace duckdb {
 
@@ -56,6 +57,23 @@ void ArrayStats::SetChildStats(BaseStatistics &stats, unique_ptr<BaseStatistics>
 	} else {
 		stats.child_stats[0].Copy(*new_stats);
 	}
+}
+
+unique_ptr<BaseStatistics> ArrayStats::PushdownExtract(const BaseStatistics &stats, const StorageIndex &index) {
+	if (!index.HasPrimaryIndex()) {
+		return nullptr;
+	}
+	auto array_size = ArrayType::GetSize(stats.GetType());
+	auto child_index = index.GetPrimaryIndex();
+	if (child_index >= array_size) {
+		return nullptr;
+	}
+	auto child_stats = ArrayStats::GetChildStats(stats).Copy();
+	if (index.HasChildren()) {
+		return child_stats.PushdownExtract(index.GetChildIndex(0));
+	}
+	child_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	return child_stats.ToUnique();
 }
 
 void ArrayStats::Merge(BaseStatistics &stats, const BaseStatistics &other, StatsMergeType merge_type) {

--- a/src/storage/statistics/base_statistics.cpp
+++ b/src/storage/statistics/base_statistics.cpp
@@ -277,8 +277,12 @@ void BaseStatistics::Copy(const BaseStatistics &other) {
 unique_ptr<BaseStatistics> BaseStatistics::PushdownExtract(const StorageIndex &index) const {
 	auto stats_type = GetStatsType();
 	switch (stats_type) {
+	case StatisticsType::LIST_STATS:
+		return ListStats::PushdownExtract(*this, index);
 	case StatisticsType::STRUCT_STATS:
 		return StructStats::PushdownExtract(*this, index);
+	case StatisticsType::ARRAY_STATS:
+		return ArrayStats::PushdownExtract(*this, index);
 	case StatisticsType::VARIANT_STATS:
 		return VariantStats::PushdownExtract(*this, index);
 	default:

--- a/src/storage/statistics/list_stats.cpp
+++ b/src/storage/statistics/list_stats.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/storage/storage_index.hpp"
 
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
@@ -57,6 +58,18 @@ void ListStats::SetChildStats(BaseStatistics &stats, unique_ptr<BaseStatistics> 
 	} else {
 		stats.child_stats[0].Copy(*new_stats);
 	}
+}
+
+unique_ptr<BaseStatistics> ListStats::PushdownExtract(const BaseStatistics &stats, const StorageIndex &index) {
+	if (index.HasPrimaryIndex() && index.GetPrimaryIndex() != 0) {
+		return nullptr;
+	}
+	auto child_stats = ListStats::GetChildStats(stats).Copy();
+	if (index.HasChildren()) {
+		return child_stats.PushdownExtract(index.GetChildIndex(0));
+	}
+	child_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	return child_stats.ToUnique();
 }
 
 void ListStats::Merge(BaseStatistics &stats, const BaseStatistics &other, StatsMergeType merge_type) {

--- a/test/sql/copy/parquet/parquet_list_row_group_pruning.test
+++ b/test/sql/copy/parquet/parquet_list_row_group_pruning.test
@@ -4,8 +4,6 @@
 
 require parquet
 
-require json
-
 require no_vector_verification
 
 statement ok
@@ -23,27 +21,9 @@ ORDER BY row_group_id;
 0	0	2047
 1	2048	4095
 
-statement ok
-PRAGMA enable_profiling = 'json';
-
-statement ok
-PRAGMA profiling_output = '{TEST_DIR}/list_row_group_pruning_profile.json';
-
-statement ok
-SET tracked_metrics = ['operator.row_groups_scanned', 'operator.total_row_groups_to_scan', 'operator.type', 'query.total_row_groups_scanned', 'query.total_row_groups_to_scan'];
-
-query I
-SELECT count(*)
+query II
+EXPLAIN ANALYZE SELECT count(*)
 FROM read_parquet('{TEST_DIR}/list_row_group_pruning.parquet')
 WHERE l[1] = 3500;
 ----
-1
-
-statement ok
-PRAGMA disable_profiling;
-
-query II
-SELECT query.total_row_groups_scanned::BIGINT, query.total_row_groups_to_scan::BIGINT
-FROM '{TEST_DIR}/list_row_group_pruning_profile.json';
-----
-1	2
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 2.*

--- a/test/sql/copy/parquet/parquet_list_row_group_pruning.test
+++ b/test/sql/copy/parquet/parquet_list_row_group_pruning.test
@@ -1,0 +1,49 @@
+# name: test/sql/copy/parquet/parquet_list_row_group_pruning.test
+# description: Test row group pruning using Parquet LIST element statistics
+# group: [parquet]
+
+require parquet
+
+require json
+
+require no_vector_verification
+
+statement ok
+COPY (
+	SELECT i, [i] AS l
+	FROM range(0, 4096) t(i)
+) TO '{TEST_DIR}/list_row_group_pruning.parquet' (FORMAT parquet, ROW_GROUP_SIZE 2048);
+
+query ITT
+SELECT row_group_id, stats_min, stats_max
+FROM parquet_metadata('{TEST_DIR}/list_row_group_pruning.parquet')
+WHERE path_in_schema = 'l, list, element'
+ORDER BY row_group_id;
+----
+0	0	2047
+1	2048	4095
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/list_row_group_pruning_profile.json';
+
+statement ok
+SET tracked_metrics = ['operator.row_groups_scanned', 'operator.total_row_groups_to_scan', 'operator.type', 'query.total_row_groups_scanned', 'query.total_row_groups_to_scan'];
+
+query I
+SELECT count(*)
+FROM read_parquet('{TEST_DIR}/list_row_group_pruning.parquet')
+WHERE l[1] = 3500;
+----
+1
+
+statement ok
+PRAGMA disable_profiling;
+
+query II
+SELECT query.total_row_groups_scanned::BIGINT, query.total_row_groups_to_scan::BIGINT
+FROM '{TEST_DIR}/list_row_group_pruning_profile.json';
+----
+1	2

--- a/test/sql/optimizer/array_row_group_pruning.test
+++ b/test/sql/optimizer/array_row_group_pruning.test
@@ -1,0 +1,52 @@
+# name: test/sql/optimizer/array_row_group_pruning.test
+# description: Row-group pruning on fixed-size array element filters
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/array_prune.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+statement ok
+CREATE TABLE arrays AS
+    SELECT ([range::INTEGER, (range + 1)::INTEGER, (range + 2)::INTEGER]::INTEGER[3]) AS a
+    FROM range(6144);
+
+statement ok
+CHECKPOINT;
+
+query I
+SELECT count(*) FROM arrays WHERE a[1] = 3000;
+----
+1
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM arrays WHERE a[1] = 3000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM arrays WHERE a[2] BETWEEN 3000 AND 3010;
+----
+11
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM arrays WHERE a[2] BETWEEN 3000 AND 3010;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM arrays WHERE a[-1] = 3000;
+----
+1
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM arrays WHERE a[-1] = 3000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM arrays WHERE a[4] = 3000;
+----
+0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes filter pruning and statistics derivation for nested LIST/ARRAY types in Parquet and the optimizer; incorrect bounds could skip row groups incorrectly, though behavior is covered by new pruning tests.
> 
> **Overview**
> Enables **row-group pruning** when filters target **list or fixed-size array elements** (e.g. `l[1] = 3500`, `a[2] BETWEEN ...`), using element-level min/max statistics instead of skipping pruning for expression-backed columns.
> 
> **Parquet:** `ExpressionColumnReader` implements `Stats()` and forwards child statistics for a single-child **bound reference** expression. `PrepareRowGroupBuffer` drops the rule that treated all expression columns as non-prunable, so `ExpressionFilter::CheckStatistics` can run on derived stats.
> 
> **Planner / statistics:** `ExpressionFilter` derives stats for **`array_extract` / `list_extract`** (constant indices, casts, out-of-range → empty stats). **`ArrayStats::PushdownExtract`** and **`ListStats::PushdownExtract`** are wired through **`BaseStatistics::PushdownExtract`**, aligning storage partition stats with nested index pushdown.
> 
> Tests assert Parquet list scans read **1 / 2** row groups and attached DuckDB tables prune arrays to **1 / 3** row groups for element predicates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f24ad7686b21304e398920383e32bc9570b929. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->