### PR TITLE
Hjiang/pr 24062 no new enum

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1847,19 +1847,20 @@ const StringUtil::EnumStringLiteral *GetDestroyBufferUponValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(DestroyBufferUpon::BLOCK), "BLOCK" },
 		{ static_cast<uint32_t>(DestroyBufferUpon::EVICTION), "EVICTION" },
-		{ static_cast<uint32_t>(DestroyBufferUpon::UNPIN), "UNPIN" }
+		{ static_cast<uint32_t>(DestroyBufferUpon::UNPIN), "UNPIN" },
+		{ static_cast<uint32_t>(DestroyBufferUpon::SPILL_FAILURE), "SPILL_FAILURE" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<DestroyBufferUpon>(DestroyBufferUpon value) {
-	return StringUtil::EnumToString(GetDestroyBufferUponValues(), 3, "DestroyBufferUpon", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetDestroyBufferUponValues(), 4, "DestroyBufferUpon", static_cast<uint32_t>(value));
 }
 
 template<>
 DestroyBufferUpon EnumUtil::FromString<DestroyBufferUpon>(const char *value) {
-	return static_cast<DestroyBufferUpon>(StringUtil::StringToEnum(GetDestroyBufferUponValues(), 3, "DestroyBufferUpon", value));
+	return static_cast<DestroyBufferUpon>(StringUtil::StringToEnum(GetDestroyBufferUponValues(), 4, "DestroyBufferUpon", value));
 }
 
 const StringUtil::EnumStringLiteral *GetDialectCompatibilityModeValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1848,7 +1848,7 @@ const StringUtil::EnumStringLiteral *GetDestroyBufferUponValues() {
 		{ static_cast<uint32_t>(DestroyBufferUpon::BLOCK), "BLOCK" },
 		{ static_cast<uint32_t>(DestroyBufferUpon::EVICTION), "EVICTION" },
 		{ static_cast<uint32_t>(DestroyBufferUpon::UNPIN), "UNPIN" },
-		{ static_cast<uint32_t>(DestroyBufferUpon::SPILL_FAILURE), "SPILL_FAILURE" }
+		{ static_cast<uint32_t>(DestroyBufferUpon::EVICTION_UNLESS_SPILLED), "EVICTION_UNLESS_SPILLED" }
 	};
 	return values;
 }

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1847,20 +1847,19 @@ const StringUtil::EnumStringLiteral *GetDestroyBufferUponValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(DestroyBufferUpon::BLOCK), "BLOCK" },
 		{ static_cast<uint32_t>(DestroyBufferUpon::EVICTION), "EVICTION" },
-		{ static_cast<uint32_t>(DestroyBufferUpon::UNPIN), "UNPIN" },
-		{ static_cast<uint32_t>(DestroyBufferUpon::EVICTION_UNLESS_SPILLED), "EVICTION_UNLESS_SPILLED" }
+		{ static_cast<uint32_t>(DestroyBufferUpon::UNPIN), "UNPIN" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<DestroyBufferUpon>(DestroyBufferUpon value) {
-	return StringUtil::EnumToString(GetDestroyBufferUponValues(), 4, "DestroyBufferUpon", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetDestroyBufferUponValues(), 3, "DestroyBufferUpon", static_cast<uint32_t>(value));
 }
 
 template<>
 DestroyBufferUpon EnumUtil::FromString<DestroyBufferUpon>(const char *value) {
-	return static_cast<DestroyBufferUpon>(StringUtil::StringToEnum(GetDestroyBufferUponValues(), 4, "DestroyBufferUpon", value));
+	return static_cast<DestroyBufferUpon>(StringUtil::StringToEnum(GetDestroyBufferUponValues(), 3, "DestroyBufferUpon", value));
 }
 
 const StringUtil::EnumStringLiteral *GetDialectCompatibilityModeValues() {
@@ -6552,4 +6551,3 @@ WindowMergeSortStage EnumUtil::FromString<WindowMergeSortStage>(const char *valu
 }
 
 }
-

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -775,6 +775,13 @@
         ]
     },
     {
+        "name": "external_file_cache_spill",
+        "description": "Whether evicted external file cache blocks spill to the temporary directory instead of being dropped, so that they are re-read from there rather than from the source",
+        "type": "BOOLEAN",
+        "scope": "global",
+        "default_value": "false"
+    },
+    {
         "name": "external_threads",
         "description": "The number of external threads that work on DuckDB tasks.",
         "type": "UBIGINT",

--- a/src/function/table/system/duckdb_external_file_cache.cpp
+++ b/src/function/table/system/duckdb_external_file_cache.cpp
@@ -25,6 +25,9 @@ static unique_ptr<FunctionData> DuckDBExternalFileCacheBind(ClientContext &conte
 	names.emplace_back("loaded");
 	return_types.emplace_back(LogicalType::BOOLEAN);
 
+	names.emplace_back("spilled");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
 	return nullptr;
 }
 
@@ -53,6 +56,8 @@ void DuckDBExternalFileCacheFunction(ClientContext &context, TableFunctionInput 
 	auto &location = output.data[2];
 	// loaded, BOOLEAN
 	auto &loaded = output.data[3];
+	// spilled, BOOLEAN
+	auto &spilled = output.data[4];
 
 	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &entry = data.entries[data.offset++];
@@ -60,6 +65,7 @@ void DuckDBExternalFileCacheFunction(ClientContext &context, TableFunctionInput 
 		nr_bytes.Append(Value::BIGINT(NumericCast<int64_t>(entry.nr_bytes)));
 		location.Append(Value::BIGINT(NumericCast<int64_t>(entry.location)));
 		loaded.Append(Value::BOOLEAN(entry.loaded));
+		spilled.Append(Value::BOOLEAN(entry.spilled));
 		count++;
 	}
 }

--- a/src/include/duckdb/common/enums/destroy_buffer_upon.hpp
+++ b/src/include/duckdb/common/enums/destroy_buffer_upon.hpp
@@ -13,9 +13,10 @@
 namespace duckdb {
 
 enum class DestroyBufferUpon : uint8_t {
-	BLOCK = 0,    //! Destroy the data buffer upon destroying the associated BlockHandle (block can be evicted)
-	EVICTION = 1, //! Destroy the data buffer upon eviction to storage (destroy instead of evict)
-	UNPIN = 2     //! Destroy the data buffer upon unpin (destroyed immediately, not added to eviction queue)
+	BLOCK = 0,        //! Destroy the data buffer upon destroying the associated BlockHandle (block can be evicted)
+	EVICTION = 1,     //! Destroy the data buffer upon eviction to storage (destroy instead of evict)
+	UNPIN = 2,        //! Destroy the data buffer upon unpin (destroyed immediately, not added to eviction queue)
+	SPILL_FAILURE = 3 //! Evict to storage like BLOCK, but destroy the data buffer if it cannot be written there
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/enums/destroy_buffer_upon.hpp
+++ b/src/include/duckdb/common/enums/destroy_buffer_upon.hpp
@@ -13,10 +13,10 @@
 namespace duckdb {
 
 enum class DestroyBufferUpon : uint8_t {
-	BLOCK = 0,        //! Destroy the data buffer upon destroying the associated BlockHandle (block can be evicted)
-	EVICTION = 1,     //! Destroy the data buffer upon eviction to storage (destroy instead of evict)
-	UNPIN = 2,        //! Destroy the data buffer upon unpin (destroyed immediately, not added to eviction queue)
-	SPILL_FAILURE = 3 //! Evict to storage like BLOCK, but destroy the data buffer if it cannot be written there
+	BLOCK = 0,    //! Destroy the data buffer upon destroying the associated BlockHandle (block can be evicted)
+	EVICTION = 1, //! Destroy the data buffer upon eviction to storage (destroy instead of evict)
+	UNPIN = 2,    //! Destroy the data buffer upon unpin (destroyed immediately, not added to eviction queue)
+	EVICTION_UNLESS_SPILLED = 3 //! Destroy upon eviction, unless the buffer can be written to temporary storage
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/enums/destroy_buffer_upon.hpp
+++ b/src/include/duckdb/common/enums/destroy_buffer_upon.hpp
@@ -15,8 +15,7 @@ namespace duckdb {
 enum class DestroyBufferUpon : uint8_t {
 	BLOCK = 0,    //! Destroy the data buffer upon destroying the associated BlockHandle (block can be evicted)
 	EVICTION = 1, //! Destroy the data buffer upon eviction to storage (destroy instead of evict)
-	UNPIN = 2,    //! Destroy the data buffer upon unpin (destroyed immediately, not added to eviction queue)
-	EVICTION_UNLESS_SPILLED = 3 //! Destroy upon eviction, unless the buffer can be written to temporary storage
+	UNPIN = 2     //! Destroy the data buffer upon unpin (destroyed immediately, not added to eviction queue)
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1170,6 +1170,18 @@ struct ExternalFileCacheRemoteBlockSizeSetting {
 	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
+struct ExternalFileCacheSpillSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "external_file_cache_spill";
+	static constexpr const char *Description =
+	    "Whether evicted external file cache blocks spill to the temporary directory instead of being dropped, so that "
+	    "they are re-read from there rather than from the source";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct ExternalThreadsSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "external_threads";

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -150,6 +150,11 @@ public:
 	bool MustWriteToTemporaryFile() const {
 		return destroy_buffer_upon == DestroyBufferUpon::BLOCK;
 	}
+	//! Returns true, if unloading the buffer writes it to a temporary file.
+	bool WritesToTemporaryFile() const {
+		const auto destroy_upon = destroy_buffer_upon.load();
+		return destroy_upon == DestroyBufferUpon::BLOCK || destroy_upon == DestroyBufferUpon::SPILL_FAILURE;
+	}
 	//! Returns the memory usage.
 	idx_t GetMemoryUsage() const {
 		return memory_usage;
@@ -208,6 +213,8 @@ public:
 	bool CanUnload() const;
 	unique_ptr<FileBuffer> UnloadAndTakeBlock(BlockLock &l, QueryContext context = QueryContext());
 	void Unload(BlockLock &l, QueryContext context = QueryContext());
+	//! Try to write the buffer to a temporary file, returns false if it cannot be written
+	bool TrySpill(QueryContext context);
 
 private:
 	//! A reference to the buffer manager.

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -153,7 +153,7 @@ public:
 	//! Returns true, if unloading the buffer writes it to a temporary file.
 	bool WritesToTemporaryFile() const {
 		const auto destroy_upon = destroy_buffer_upon.load();
-		return destroy_upon == DestroyBufferUpon::BLOCK || destroy_upon == DestroyBufferUpon::SPILL_FAILURE;
+		return destroy_upon == DestroyBufferUpon::BLOCK || destroy_upon == DestroyBufferUpon::EVICTION_UNLESS_SPILLED;
 	}
 	//! Returns the memory usage.
 	idx_t GetMemoryUsage() const {

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -150,10 +150,9 @@ public:
 	bool MustWriteToTemporaryFile() const {
 		return destroy_buffer_upon == DestroyBufferUpon::BLOCK;
 	}
-	//! Returns true, if unloading the buffer writes it to a temporary file.
-	bool WritesToTemporaryFile() const {
-		const auto destroy_upon = destroy_buffer_upon.load();
-		return destroy_upon == DestroyBufferUpon::BLOCK || destroy_upon == DestroyBufferUpon::EVICTION_UNLESS_SPILLED;
+	//! Returns true if this buffer may be destroyed when writing it to temporary storage fails.
+	bool CanDestroyOnTemporaryWriteFailure() const {
+		return tag == MemoryTag::EXTERNAL_FILE_CACHE;
 	}
 	//! Returns the memory usage.
 	idx_t GetMemoryUsage() const {
@@ -213,8 +212,8 @@ public:
 	bool CanUnload() const;
 	unique_ptr<FileBuffer> UnloadAndTakeBlock(BlockLock &l, QueryContext context = QueryContext());
 	void Unload(BlockLock &l, QueryContext context = QueryContext());
-	//! Try to write the buffer to a temporary file, returns false if it cannot be written
-	bool TrySpill(QueryContext context);
+	//! Try to write the buffer to a temporary file.
+	bool TryWriteToTemporaryFile(QueryContext context);
 
 private:
 	//! A reference to the buffer manager.

--- a/src/include/duckdb/storage/buffer/temporary_file_information.hpp
+++ b/src/include/duckdb/storage/buffer/temporary_file_information.hpp
@@ -29,6 +29,7 @@ struct CachedFileInformation {
 	idx_t nr_bytes;
 	idx_t location;
 	bool loaded;
+	bool spilled;
 };
 
 struct EvictionQueueInformation {

--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -20,6 +20,7 @@
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/winapi.hpp"
+#include "duckdb/storage/buffer/buffer_handle.hpp"
 #include "duckdb/storage/buffer/temporary_file_information.hpp"
 #include "duckdb/storage/external_file_cache/external_file_cache_block.hpp"
 
@@ -86,6 +87,11 @@ public:
 	//! Gets the shared cached file for the given path, creating it if not yet present.
 	//! When caching is disabled, returns a transient CachedFile that is not tracked in the cached file map.
 	shared_ptr<CachedFile> GetOrCreateCachedFile(const string &path);
+
+	//! Allocate a buffer holding a cache block. Blocks of at least the block allocation size spill to
+	//! the temporary directory when they are evicted, instead of being dropped and re-read from the
+	//! source. Smaller blocks are always dropped, they would each need their own file to spill.
+	static BufferHandle AllocateCacheBuffer(BufferManager &buffer_manager, idx_t nr_bytes);
 
 	DUCKDB_API static bool IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
 	                               const string &current_version_tag, timestamp_t current_last_modified);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -163,6 +163,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ExtensionDirectorySetting),
     DUCKDB_SETTING_CALLBACK(ExternalFileCacheLocalBlockSizeSetting),
     DUCKDB_SETTING_CALLBACK(ExternalFileCacheRemoteBlockSizeSetting),
+    DUCKDB_SETTING(ExternalFileCacheSpillSetting),
     DUCKDB_SETTING_CALLBACK(ExternalThreadsSetting),
     DUCKDB_SETTING(FileSearchPathSetting),
     DUCKDB_SETTING_CALLBACK(ForceBitpackingModeSetting),
@@ -249,12 +250,12 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("configure_metrics", 30),
                                                      DUCKDB_SETTING_ALIAS("custom_profiling_settings", 30),
-                                                     DUCKDB_SETTING_ALIAS("memory_limit", 128),
+                                                     DUCKDB_SETTING_ALIAS("memory_limit", 129),
                                                      DUCKDB_SETTING_ALIAS("null_order", 61),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 151),
-                                                     DUCKDB_SETTING_ALIAS("user", 170),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 152),
+                                                     DUCKDB_SETTING_ALIAS("user", 171),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 29),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 168),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 169),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -106,6 +106,19 @@ void BlockMemory::ResizeBuffer(BlockLock &l, idx_t block_size, idx_t block_heade
 	D_ASSERT(memory_usage == buffer->AllocSize());
 }
 
+bool BlockMemory::TrySpill(QueryContext context) {
+	if (!GetBufferManager().HasTemporaryDirectory()) {
+		return false;
+	}
+	try {
+		buffer_manager.WriteTemporaryBuffer(context, GetMemoryTag(), BlockId(), *GetBuffer());
+		return true;
+	} catch (std::exception &) {
+		// The temporary directory is full or cannot be written to
+		return false;
+	}
+}
+
 bool BlockMemory::CanUnload() const {
 	if (GetState() == BlockState::BLOCK_UNLOADED) {
 		// The block has already been unloaded.
@@ -134,10 +147,16 @@ unique_ptr<FileBuffer> BlockMemory::UnloadAndTakeBlock(BlockLock &l, QueryContex
 	D_ASSERT(IsSwizzled());
 	D_ASSERT(CanUnload());
 
-	if (BlockId() >= MAXIMUM_BLOCK && MustWriteToTemporaryFile()) {
-		// This is a temporary block that cannot be destroyed upon evict/unpin.
-		// Thus, we write to it to a temporary file.
-		buffer_manager.WriteTemporaryBuffer(context, GetMemoryTag(), BlockId(), *GetBuffer());
+	if (BlockId() >= MAXIMUM_BLOCK && WritesToTemporaryFile()) {
+		if (MustWriteToTemporaryFile()) {
+			// This is a temporary block that cannot be destroyed upon evict/unpin.
+			// Thus, we write to it to a temporary file.
+			buffer_manager.WriteTemporaryBuffer(context, GetMemoryTag(), BlockId(), *GetBuffer());
+		} else if (!TrySpill(context)) {
+			// The buffer could not be written to a temporary file, destroy it instead.
+			// Loads of this block now return an invalid handle, like any destroyed buffer.
+			SetDestroyBufferUpon(DestroyBufferUpon::EVICTION);
+		}
 	}
 	memory_charge.Resize(0);
 	SetState(BlockState::BLOCK_UNLOADED);
@@ -229,7 +248,7 @@ BufferHandle BlockHandle::Load(QueryContext context, unique_ptr<FileBuffer> reus
 		block_manager.Read(context, *block);
 		memory.GetBuffer() = std::move(block);
 	} else {
-		if (!memory.MustWriteToTemporaryFile()) {
+		if (!memory.WritesToTemporaryFile()) {
 			// The buffer was destroyed upon unpin/evict, so there is no temporary buffer to read.
 			return BufferHandle();
 		}

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -106,7 +106,7 @@ void BlockMemory::ResizeBuffer(BlockLock &l, idx_t block_size, idx_t block_heade
 	D_ASSERT(memory_usage == buffer->AllocSize());
 }
 
-bool BlockMemory::TrySpill(QueryContext context) {
+bool BlockMemory::TryWriteToTemporaryFile(QueryContext context) {
 	if (!GetBufferManager().HasTemporaryDirectory()) {
 		return false;
 	}
@@ -128,7 +128,8 @@ bool BlockMemory::CanUnload() const {
 		// There are active readers.
 		return false;
 	}
-	if (BlockId() >= MAXIMUM_BLOCK && MustWriteToTemporaryFile() && !GetBufferManager().HasTemporaryDirectory()) {
+	if (BlockId() >= MAXIMUM_BLOCK && MustWriteToTemporaryFile() && !CanDestroyOnTemporaryWriteFailure() &&
+	    !GetBufferManager().HasTemporaryDirectory()) {
 		// The block memory cannot be destroyed upon eviction/unpinning.
 		// In order to unload this block we need to write it to a temporary buffer.
 		// However, no temporary directory is specified, hence, we cannot unload.
@@ -147,15 +148,16 @@ unique_ptr<FileBuffer> BlockMemory::UnloadAndTakeBlock(BlockLock &l, QueryContex
 	D_ASSERT(IsSwizzled());
 	D_ASSERT(CanUnload());
 
-	if (BlockId() >= MAXIMUM_BLOCK && WritesToTemporaryFile()) {
-		if (MustWriteToTemporaryFile()) {
+	if (BlockId() >= MAXIMUM_BLOCK && MustWriteToTemporaryFile()) {
+		if (CanDestroyOnTemporaryWriteFailure()) {
+			if (!TryWriteToTemporaryFile(context)) {
+				// Loads of this block now return an invalid handle, like any destroyed buffer.
+				SetDestroyBufferUpon(DestroyBufferUpon::EVICTION);
+			}
+		} else {
 			// This is a temporary block that cannot be destroyed upon evict/unpin.
 			// Thus, we write to it to a temporary file.
 			buffer_manager.WriteTemporaryBuffer(context, GetMemoryTag(), BlockId(), *GetBuffer());
-		} else if (!TrySpill(context)) {
-			// The buffer could not be written to a temporary file, destroy it instead.
-			// Loads of this block now return an invalid handle, like any destroyed buffer.
-			SetDestroyBufferUpon(DestroyBufferUpon::EVICTION);
 		}
 	}
 	memory_charge.Resize(0);
@@ -248,7 +250,7 @@ BufferHandle BlockHandle::Load(QueryContext context, unique_ptr<FileBuffer> reus
 		block_manager.Read(context, *block);
 		memory.GetBuffer() = std::move(block);
 	} else {
-		if (!memory.WritesToTemporaryFile()) {
+		if (!memory.MustWriteToTemporaryFile()) {
 			// The buffer was destroyed upon unpin/evict, so there is no temporary buffer to read.
 			return BufferHandle();
 		}

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -78,7 +78,7 @@ public:
 						return;
 					}
 					const idx_t to_read = MinValue(block_size, file_size - offset);
-					auto buf = buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, to_read);
+					auto buf = ExternalFileCache::AllocateCacheBuffer(buffer_manager, to_read);
 					caching_file_handle.ReadAndRecord(context, buf.GetDataMutable(), to_read, offset);
 
 					lk.lock();

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -88,6 +88,11 @@ void ExternalFileCache::ReindexCachedFileCore(CachedFile &cached_file, idx_t fil
 		if (block.state != CacheBlockState::LOADED || !block.block_handle) {
 			continue;
 		}
+		if (block.block_handle->GetMemory().IsUnloaded()) {
+			// Evicted blocks do not survive a re-index, whether they spilled or were dropped:
+			// pinning all of them to copy them over could exceed the memory limit
+			continue;
+		}
 		auto pin = buffer_manager.Pin(block.block_handle);
 		if (pin.IsValid()) {
 			pinned.emplace(old_idx, make_pair(std::move(pin), block.nr_bytes));
@@ -129,7 +134,7 @@ void ExternalFileCache::ReindexCachedFileCore(CachedFile &cached_file, idx_t fil
 			}
 			const idx_t new_size = new_end - new_start;
 
-			auto buf = buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, new_size);
+			auto buf = AllocateCacheBuffer(buffer_manager, new_size);
 
 			// Copy from each contributing old block in the run.
 			const idx_t contrib_first = new_start / old_block_size;
@@ -328,6 +333,16 @@ ExternalFileCache &ExternalFileCache::Get(ClientContext &context) {
 
 BufferManager &ExternalFileCache::GetBufferManager() const {
 	return buffer_manager;
+}
+
+BufferHandle ExternalFileCache::AllocateCacheBuffer(BufferManager &buffer_manager, idx_t nr_bytes) {
+	if (nr_bytes < buffer_manager.GetBlockAllocSize() ||
+	    !Settings::Get<ExternalFileCacheSpillSetting>(buffer_manager.GetDatabase())) {
+		return buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
+	}
+	auto buffer = buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes, false);
+	buffer.GetBlockHandle()->GetMemory().SetDestroyBufferUpon(DestroyBufferUpon::SPILL_FAILURE);
+	return buffer;
 }
 
 void ExternalFileCache::DeleteObjectCacheEntries(const vector<string> &paths) {

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -311,8 +311,11 @@ vector<CachedFileInformation> ExternalFileCache::GetCachedFileInformation() cons
 				continue;
 			}
 			const idx_t location = block_idx * block_size;
-			const bool loaded = !block.block_handle->GetMemory().IsUnloaded();
-			result.push_back({file->path, block.nr_bytes, location, loaded});
+			const auto &memory = block.block_handle->GetMemory();
+			const bool loaded = !memory.IsUnloaded();
+			// An unloaded block sits in the temporary directory if it could be written there on eviction
+			const bool spilled = !loaded && memory.WritesToTemporaryFile();
+			result.push_back({file->path, block.nr_bytes, location, loaded, spilled});
 		}
 	}
 	return result;
@@ -341,7 +344,7 @@ BufferHandle ExternalFileCache::AllocateCacheBuffer(BufferManager &buffer_manage
 		return buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
 	}
 	auto buffer = buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes, false);
-	buffer.GetBlockHandle()->GetMemory().SetDestroyBufferUpon(DestroyBufferUpon::SPILL_FAILURE);
+	buffer.GetBlockHandle()->GetMemory().SetDestroyBufferUpon(DestroyBufferUpon::EVICTION_UNLESS_SPILLED);
 	return buffer;
 }
 

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -313,8 +313,8 @@ vector<CachedFileInformation> ExternalFileCache::GetCachedFileInformation() cons
 			const idx_t location = block_idx * block_size;
 			const auto &memory = block.block_handle->GetMemory();
 			const bool loaded = !memory.IsUnloaded();
-			// An unloaded block sits in the temporary directory if it could be written there on eviction
-			const bool spilled = !loaded && memory.WritesToTemporaryFile();
+			// An unloaded cache block is spilled if it still has a temporary-file backing.
+			const bool spilled = !loaded && memory.MustWriteToTemporaryFile();
 			result.push_back({file->path, block.nr_bytes, location, loaded, spilled});
 		}
 	}
@@ -343,9 +343,7 @@ BufferHandle ExternalFileCache::AllocateCacheBuffer(BufferManager &buffer_manage
 	    !Settings::Get<ExternalFileCacheSpillSetting>(buffer_manager.GetDatabase())) {
 		return buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
 	}
-	auto buffer = buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes, false);
-	buffer.GetBlockHandle()->GetMemory().SetDestroyBufferUpon(DestroyBufferUpon::EVICTION_UNLESS_SPILLED);
-	return buffer;
+	return buffer_manager.Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes, false);
 }
 
 void ExternalFileCache::DeleteObjectCacheEntries(const vector<string> &paths) {

--- a/test/sql/storage/external_file_cache/external_file_cache_spill.test_slow
+++ b/test/sql/storage/external_file_cache/external_file_cache_spill.test_slow
@@ -37,6 +37,11 @@ SELECT temporary_storage_bytes FROM duckdb_memory() WHERE tag = 'EXTERNAL_FILE_C
 ----
 0
 
+query I
+SELECT count(*) FROM duckdb_external_file_cache() WHERE spilled;
+----
+0
+
 statement ok
 SET external_file_cache_spill=true;
 
@@ -63,6 +68,17 @@ SELECT temporary_storage_bytes > 0 FROM duckdb_memory() WHERE tag = 'EXTERNAL_FI
 ----
 true
 
+# the cache listing shows which blocks are in memory and which sit in the temporary directory
+query I
+SELECT count(*) > 0 FROM duckdb_external_file_cache() WHERE NOT loaded AND spilled;
+----
+true
+
+query I
+SELECT count(*) FROM duckdb_external_file_cache() WHERE loaded AND spilled;
+----
+0
+
 # reads must reassemble the same data through the spilled blocks
 query II
 SELECT sum(b) - (SELECT sum(hash(i * 2)) FROM range(12000000) t(i)),
@@ -71,8 +87,10 @@ FROM read_parquet('__TEST_DIR__/efc_spill.parquet');
 ----
 0	0
 
-# blocks below the block allocation size are never spilled: with tiny cache blocks
-# the cache drops them under pressure, and reads still work
+# changing the cache block size re-indexes the cache, dropping the spilled blocks,
+# and reads still reassemble the correct content afterwards.
+# blocks below the block allocation size are also never spilled: with tiny cache blocks
+# the cache drops them under pressure instead
 statement ok
 SET external_file_cache_local_block_size=16384;
 
@@ -80,3 +98,43 @@ query I
 SELECT sum(a) - (SELECT sum(hash(i)) FROM range(12000000) t(i)) FROM read_parquet('__TEST_DIR__/efc_spill.parquet');
 ----
 0
+
+query I
+SELECT count(*) FROM duckdb_external_file_cache() WHERE spilled;
+----
+0
+
+query I
+SELECT temporary_storage_bytes FROM duckdb_memory() WHERE tag = 'EXTERNAL_FILE_CACHE';
+----
+0
+
+# spill again with large blocks, then disabling the cache must also delete the spilled blocks
+statement ok
+SET external_file_cache_local_block_size=2097152;
+
+query I
+SELECT sum(a) - (SELECT sum(hash(i)) FROM range(12000000) t(i)) FROM read_parquet('__TEST_DIR__/efc_spill.parquet');
+----
+0
+
+query I
+SELECT temporary_storage_bytes > 0 FROM duckdb_memory() WHERE tag = 'EXTERNAL_FILE_CACHE';
+----
+true
+
+statement ok
+SET enable_external_file_cache=false;
+
+query I
+SELECT count(*) FROM duckdb_external_file_cache();
+----
+0
+
+query I
+SELECT temporary_storage_bytes FROM duckdb_memory() WHERE tag = 'EXTERNAL_FILE_CACHE';
+----
+0
+
+statement ok
+SET enable_external_file_cache=true;

--- a/test/sql/storage/external_file_cache/external_file_cache_spill.test_slow
+++ b/test/sql/storage/external_file_cache/external_file_cache_spill.test_slow
@@ -1,0 +1,82 @@
+# name: test/sql/storage/external_file_cache/external_file_cache_spill.test_slow
+# description: External file cache blocks spill to the temporary directory instead of being dropped
+# group: [external_file_cache]
+
+require parquet
+
+require skip_reload
+
+statement ok
+SET cache_local_files=true;
+
+statement ok
+SET external_file_cache_local_block_size=2097152;
+
+statement ok
+SET memory_limit='200MB';
+
+statement ok
+SET temp_directory='__TEST_DIR__/external_file_cache_spill';
+
+statement ok
+SET preserve_insertion_order=false;
+
+# roughly 290MB of incompressible data, well above the memory limit
+statement ok
+COPY (SELECT hash(i) a, hash(i * 2) b, hash(i * 3) c FROM range(12000000) t(i))
+TO '__TEST_DIR__/efc_spill.parquet' (FORMAT parquet);
+
+# by default, evicted cache blocks are dropped, nothing is written to the temporary directory
+query I
+SELECT sum(a) - (SELECT sum(hash(i)) FROM range(12000000) t(i)) FROM read_parquet('__TEST_DIR__/efc_spill.parquet');
+----
+0
+
+query I
+SELECT temporary_storage_bytes FROM duckdb_memory() WHERE tag = 'EXTERNAL_FILE_CACHE';
+----
+0
+
+statement ok
+SET external_file_cache_spill=true;
+
+# when the temporary directory cannot hold the blocks, the cache still drops them instead of failing
+statement ok
+SET max_temp_directory_size='1MB';
+
+query I
+SELECT sum(a) - (SELECT sum(hash(i)) FROM range(12000000) t(i)) FROM read_parquet('__TEST_DIR__/efc_spill.parquet');
+----
+0
+
+statement ok
+RESET max_temp_directory_size;
+
+# the cache exceeds the memory limit, so evicted blocks now spill to the temporary directory
+query I
+SELECT sum(a) - (SELECT sum(hash(i)) FROM range(12000000) t(i)) FROM read_parquet('__TEST_DIR__/efc_spill.parquet');
+----
+0
+
+query I
+SELECT temporary_storage_bytes > 0 FROM duckdb_memory() WHERE tag = 'EXTERNAL_FILE_CACHE';
+----
+true
+
+# reads must reassemble the same data through the spilled blocks
+query II
+SELECT sum(b) - (SELECT sum(hash(i * 2)) FROM range(12000000) t(i)),
+       sum(c) - (SELECT sum(hash(i * 3)) FROM range(12000000) t(i))
+FROM read_parquet('__TEST_DIR__/efc_spill.parquet');
+----
+0	0
+
+# blocks below the block allocation size are never spilled: with tiny cache blocks
+# the cache drops them under pressure, and reads still work
+statement ok
+SET external_file_cache_local_block_size=16384;
+
+query I
+SELECT sum(a) - (SELECT sum(hash(i)) FROM range(12000000) t(i)) FROM read_parquet('__TEST_DIR__/efc_spill.parquet');
+----
+0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches buffer eviction, temporary storage, and external file cache under memory pressure; incorrect spill or reload logic could cause wrong reads or extra I/O, though failures are designed to degrade to the prior drop behavior for cache blocks.
> 
> **Overview**
> Introduces the global boolean setting **`external_file_cache_spill`** (default **off**). When enabled, external file cache blocks at least as large as the buffer pool block allocation size are allocated so eviction can **write them to the temporary directory** instead of discarding them and re-reading from the original source.
> 
> **`ExternalFileCache::AllocateCacheBuffer`** centralizes that policy for cache reads and re-indexing; smaller blocks still drop on eviction because they are not worth per-block spill files. **`BlockMemory::TryWriteToTemporaryFile`** attempts spill on unload; for **`EXTERNAL_FILE_CACHE`** buffers, a failed write (e.g. full temp dir) **falls back to destroying the block** rather than blocking eviction. Re-indexing **skips already-unloaded** blocks so reassembly does not pin every spilled/dropped block under memory pressure.
> 
> **`duckdb_external_file_cache()`** gains a **`spilled`** column (unloaded but still backed by temp storage). A slow SQL test exercises default drop behavior, spill under memory limits, temp-dir size limits, re-index, and cache disable cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92531cc035a9ce81f498fbcf6e77c7fd5dcf8a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->