### PR TITLE
Optimize LRU cache

### DIFF
--- a/src/include/duckdb/common/lru_cache.hpp
+++ b/src/include/duckdb/common/lru_cache.hpp
@@ -65,14 +65,14 @@ public:
 		}
 
 		// Add new entry
-		lru_list.emplace_front(key);
+		lru_list.emplace_front(std::move(key));
 		Entry new_entry;
 		new_entry.value = std::move(value);
 		new_entry.lru_iterator = lru_list.begin();
 		new_entry.payload = std::move(payload);
 		new_entry.payload_weight = payload_weight;
 
-		entry_map[std::move(key)] = std::move(new_entry);
+		entry_map.emplace(std::cref(lru_list.front()), std::move(new_entry));
 		current_total_weight += payload_weight;
 	}
 
@@ -143,12 +143,27 @@ private:
 		idx_t payload_weight;
 	};
 
-	using EntryMap = unordered_map<Key, Entry, KeyHash, KeyEqual>;
+	using KeyConstReference = std::reference_wrapper<const Key>;
+
+	struct KeyReferenceHash {
+		size_t operator()(KeyConstReference key) const {
+			return KeyHash()(key.get());
+		}
+	};
+
+	struct KeyReferenceEqual {
+		bool operator()(KeyConstReference lhs, KeyConstReference rhs) const {
+			return KeyEqual()(lhs.get(), rhs.get());
+		}
+	};
+
+	using EntryMap = unordered_map<KeyConstReference, Entry, KeyReferenceHash, KeyReferenceEqual>;
 
 	void DeleteImpl(typename EntryMap::iterator iter) {
+		auto lru_iterator = iter->second.lru_iterator;
 		current_total_weight -= iter->second.payload_weight;
-		lru_list.erase(iter->second.lru_iterator);
 		entry_map.erase(iter);
+		lru_list.erase(lru_iterator);
 	}
 
 	void EvictIfNeeded(idx_t required_weight) {

--- a/test/common/test_lru_cache.cpp
+++ b/test/common/test_lru_cache.cpp
@@ -19,6 +19,29 @@ struct TestValue {
 	}
 };
 
+struct MoveOnlyKey {
+	explicit MoveOnlyKey(int value_p) : value(value_p) {
+	}
+	MoveOnlyKey(MoveOnlyKey &&) = default;
+	MoveOnlyKey &operator=(MoveOnlyKey &&) = default;
+	MoveOnlyKey(const MoveOnlyKey &) = delete;
+	MoveOnlyKey &operator=(const MoveOnlyKey &) = delete;
+
+	int value;
+};
+
+struct MoveOnlyKeyHash {
+	size_t operator()(const MoveOnlyKey &key) const {
+		return std::hash<int>()(key.value);
+	}
+};
+
+struct MoveOnlyKeyEqual {
+	bool operator()(const MoveOnlyKey &lhs, const MoveOnlyKey &rhs) const {
+		return lhs.value == rhs.value;
+	}
+};
+
 } // namespace
 
 TEST_CASE("LRU Cache Basic Operations", "[lru_cache]") {
@@ -134,6 +157,31 @@ TEST_CASE("LRU Cache Eviction", "[lru_cache]") {
 		REQUIRE(cache.Get("key3") != nullptr);
 		REQUIRE(cache.Get("key4") != nullptr);
 	}
+}
+
+TEST_CASE("LRU Cache Move-Only Key", "[lru_cache]") {
+	SharedLruCache<MoveOnlyKey, TestValue, DefaultPayload, MoveOnlyKeyHash, MoveOnlyKeyEqual> cache(2);
+
+	auto val1 = make_shared_ptr<TestValue>(1);
+	auto val2 = make_shared_ptr<TestValue>(2);
+	auto val3 = make_shared_ptr<TestValue>(3);
+	auto val4 = make_shared_ptr<TestValue>(4);
+
+	cache.Put(MoveOnlyKey(1), val1);
+	cache.Put(MoveOnlyKey(2), val2);
+
+	MoveOnlyKey key1(1);
+	REQUIRE(cache.Get(key1)->value == 1);
+
+	cache.Put(MoveOnlyKey(3), val3);
+
+	MoveOnlyKey key2(2);
+	REQUIRE(cache.Get(key2) == nullptr);
+	REQUIRE(cache.Get(key1)->value == 1);
+
+	cache.Put(MoveOnlyKey(1), val4);
+	REQUIRE(cache.Get(key1)->value == 4);
+	REQUIRE(cache.Size() == 2);
 }
 
 TEST_CASE("LRU Cache Unlimited Memory", "[lru_cache]") {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core LRU/object-cache key storage and erase ordering; behavior should match for copyable keys like strings but incorrect reference lifetimes would be subtle.
> 
> **Overview**
> **`SharedLruCache`** no longer keeps a separate copy of each key in the hash map. On **`Put`**, the key is moved into the LRU list and the map entry is keyed with **`std::cref(lru_list.front())`**, using custom hash/equality on **`reference_wrapper<const Key>`**.
> 
> **`DeleteImpl`** now removes the map entry before erasing the list node, so iterators/references into list-stored keys stay valid for the erase order.
> 
> A new unit test covers **move-only** key types (put, get, eviction, replace).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db714cb19ab0ce7cf8abcc489ca14eb7909b85c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->