### PR TITLE
Hjiang/http cache control

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -2,4 +2,5 @@ duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG a7b3862d86808ea7a8baa89391c96c5ca2141a53
+    APPLY_PATCHES
 )

--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG a7b3862d86808ea7a8baa89391c96c5ca2141a53
+    GIT_TAG d40d52c602b9b6627433f15ee82ece872bafc5f4
     APPLY_PATCHES
 )

--- a/.github/patches/extensions/httpfs/0001-cache-metadata.patch
+++ b/.github/patches/extensions/httpfs/0001-cache-metadata.patch
@@ -1,11 +1,11 @@
-commit 2ed756997a07a99bd0061e4a545d9b66e8090c28
+commit 58cec0216987eca659dd8060183d8e41812f01fe
 Author: dentinyhao <dentinyhao@gmail.com>
 Date:   Tue Aug 4 02:50:57 2026 -0700
 
     Consider HTTP cache
 
 diff --git a/src/http/httpfs.cpp b/src/http/httpfs.cpp
-index 0fc503a..4546969 100644
+index 0fc503a..8114726 100644
 --- a/src/http/httpfs.cpp
 +++ b/src/http/httpfs.cpp
 @@ -7,8 +7,13 @@
@@ -40,7 +40,7 @@ index 0fc503a..4546969 100644
  bool HTTPFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
  	try {
  		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_READ, opener);
-@@ -574,6 +590,105 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
+@@ -574,6 +590,107 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
  	return true;
  }
  
@@ -65,7 +65,9 @@ index 0fc503a..4546969 100644
 +
 +optional<timestamp_t> HTTPFileSystem::ComputeCacheValidUntil(const HTTPHeaders &headers) {
 +	// Freshness lifetime in seconds (RFC 9111): Cache-Control max-age takes precedence over Expires
-+	// TODO: handle no-cache; unset means no freshness information, negative infinity means explicitly stale
++	if (HasCacheControlDirective(headers, "no-cache")) {
++		return timestamp_t::ninfinity();
++	}
 +	int64_t freshness_lifetime = 0;
 +	bool has_freshness_lifetime = false;
 +	bool has_max_age = false;
@@ -146,7 +148,7 @@ index 0fc503a..4546969 100644
  struct HTTPFileInfoParser {
  	static optional_idx TryParseContentRange(const HTTPHeaders &headers) {
  		if (!headers.HasHeader("Content-Range")) {
-@@ -675,6 +790,11 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
+@@ -675,6 +792,11 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
  	if (response.headers.HasHeader("ETag")) {
  		etag = response.headers.GetHeaderValue("ETag");
  	}
@@ -158,7 +160,7 @@ index 0fc503a..4546969 100644
  	if (request_session->Capture().snapshot->Params().s3_version_id_pinning &&
  	    response.headers.HasHeader("x-amz-version-id")) {
  		SetVersionId(response.headers.GetHeaderValue("x-amz-version-id"));
-@@ -716,6 +836,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
+@@ -716,6 +838,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
  	last_modified = cache_entry.last_modified;
  	length = cache_entry.length;
  	etag = cache_entry.etag;
@@ -166,7 +168,7 @@ index 0fc503a..4546969 100644
  	SetVersionId(cache_entry.version_id);
  
  	// TODO: handle properties
-@@ -726,6 +847,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
+@@ -726,6 +849,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
  	result.length = length;
  	result.last_modified = last_modified;
  	result.etag = etag;
@@ -174,7 +176,7 @@ index 0fc503a..4546969 100644
  	result.version_id = GetVersionId();
  	// TODO: handle properties
  	return result;
-@@ -793,7 +915,7 @@ void HTTPFileHandle::InitializeFileInfo(HTTPFileSystem &hfs, optional_ptr<HTTPMe
+@@ -793,7 +917,7 @@ void HTTPFileHandle::InitializeFileInfo(HTTPFileSystem &hfs, optional_ptr<HTTPMe
  		if (should_full_download) {
  			length = hfs.FullDownload(*this, GetReadConfig(), should_write_cache)->GetSize();
  		}

--- a/.github/patches/extensions/httpfs/0001-cache-metadata.patch
+++ b/.github/patches/extensions/httpfs/0001-cache-metadata.patch
@@ -1,4 +1,4 @@
-commit bb8994c854cc556fafaf672906fabd636f9b6175
+commit ca0895720355475ece3f28ef6115c91822626719
 Author: dentinyhao <dentinyhao@gmail.com>
 Date:   Tue Aug 4 02:50:57 2026 -0700
 
@@ -127,27 +127,27 @@ index 0fc503a..e2d2de0 100644
  	// TODO: handle properties
  	return result;
 diff --git a/src/include/http/http_metadata_cache.hpp b/src/include/http/http_metadata_cache.hpp
-index 2908a43..540d96f 100644
+index 2908a43..64bd2e8 100644
 --- a/src/include/http/http_metadata_cache.hpp
 +++ b/src/include/http/http_metadata_cache.hpp
 @@ -19,6 +19,8 @@ struct HTTPMetadataCacheEntry {
  	idx_t length;
  	timestamp_t last_modified;
  	string etag;
-+	//! Freshness deadline; if unset (infinite), the server does not provide expiry information
++	//! Freshness deadline (inclusive); if unset (infinite), the server does not provide expiry information
 +	timestamp_t cache_valid_until = timestamp_t::infinity();
  	string version_id;
  	unordered_map<string, string> properties;
  };
 diff --git a/src/include/http/httpfs.hpp b/src/include/http/httpfs.hpp
-index 1764acc..6d77d08 100644
+index 1764acc..3097fe4 100644
 --- a/src/include/http/httpfs.hpp
 +++ b/src/include/http/httpfs.hpp
 @@ -64,6 +64,10 @@ public:
  	idx_t length;
  	timestamp_t last_modified;
  	string etag;
-+	//! Freshness deadline derived from HTTP caching headers (Cache-Control/Expires).
++	//! Freshness deadline (inclusive) derived from HTTP caching headers (Cache-Control/Expires).
 +	//! If unset (infinite), the server does not provide information on when cached data expires.
 +	//! Used to cache files that provide no validators (no ETag/Last-Modified).
 +	timestamp_t cache_valid_until = timestamp_t::infinity();
@@ -158,7 +158,7 @@ index 1764acc..6d77d08 100644
  class HTTPFileSystem : public FileSystem {
  public:
  	static bool TryParseLastModifiedTime(const string &timestamp, timestamp_t &result);
-+	//! Compute the freshness deadline from HTTP caching headers (RFC 9111): Cache-Control max-age,
++	//! Compute the freshness deadline (inclusive) from HTTP caching headers (RFC 9111): Cache-Control max-age,
 +	//! falling back to Expires/Date, adjusted by the response's current age. Infinite if not provided.
 +	static timestamp_t ComputeCacheValidUntil(const HTTPHeaders &headers);
  

--- a/.github/patches/extensions/httpfs/0001-cache-metadata.patch
+++ b/.github/patches/extensions/httpfs/0001-cache-metadata.patch
@@ -1,0 +1,164 @@
+commit 9e5c505de48669bbf14102a96780199b9d8a0c70
+Author: dentinyhao <dentinyhao@gmail.com>
+Date:   Tue Aug 4 02:50:57 2026 -0700
+
+    Consider HTTP cache
+
+diff --git a/src/http/httpfs.cpp b/src/http/httpfs.cpp
+index 0fc503a..219d81a 100644
+--- a/src/http/httpfs.cpp
++++ b/src/http/httpfs.cpp
+@@ -473,6 +473,16 @@ string HTTPFileSystem::GetVersionTag(FileHandle &handle) {
+ 	return sfh.etag;
+ }
+ 
++FileMetadata HTTPFileSystem::Stats(FileHandle &handle) {
++	auto &sfh = handle.Cast<HTTPFileHandle>();
++	FileMetadata metadata;
++	metadata.file_size = NumericCast<int64_t>(sfh.length);
++	metadata.last_modification_time = sfh.last_modified;
++	metadata.file_type = FileType::FILE_TYPE_REGULAR;
++	metadata.cache_valid_until = sfh.cache_valid_until;
++	return metadata;
++}
++
+ bool HTTPFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
+ 	try {
+ 		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_READ, opener);
+@@ -574,6 +584,66 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
+ 	return true;
+ }
+ 
++static bool TryParseNonNegativeSeconds(const string &input, int64_t &result) {
++	try {
++		result = std::stoll(input);
++	} catch (...) {
++		return false;
++	}
++	return result >= 0;
++}
++
++timestamp_t HTTPFileSystem::ComputeCacheValidUntil(const HTTPHeaders &headers) {
++	static constexpr int64_t MICROS_PER_SECOND = 1000000LL;
++	// Clamp the freshness lifetime to guard against overflow from absurd server-provided values
++	static constexpr int64_t MAX_FRESHNESS_SECONDS = 365LL * 24 * 60 * 60;
++
++	// Freshness lifetime in seconds (RFC 9111): Cache-Control max-age takes precedence over Expires
++	int64_t freshness_lifetime = 0;
++	bool has_freshness_lifetime = false;
++	if (headers.HasHeader("Cache-Control")) {
++		const string MAX_AGE_PREFIX = "max-age=";
++		for (auto &directive_p : StringUtil::Split(headers.GetHeaderValue("Cache-Control"), ',')) {
++			auto directive = StringUtil::Lower(directive_p);
++			StringUtil::Trim(directive);
++			if (StringUtil::StartsWith(directive, "no-store") || StringUtil::StartsWith(directive, "no-cache")) {
++				// no-store: must not be cached, no-cache: must be revalidated before every use
++				return timestamp_t::infinity();
++			}
++			if (StringUtil::StartsWith(directive, MAX_AGE_PREFIX)) {
++				has_freshness_lifetime =
++				    TryParseNonNegativeSeconds(directive.substr(MAX_AGE_PREFIX.size()), freshness_lifetime);
++			}
++		}
++	}
++	if (!has_freshness_lifetime && headers.HasHeader("Expires") && headers.HasHeader("Date")) {
++		timestamp_t expires;
++		timestamp_t date;
++		if (TryParseLastModifiedTime(headers.GetHeaderValue("Expires"), expires) &&
++		    TryParseLastModifiedTime(headers.GetHeaderValue("Date"), date)) {
++			freshness_lifetime = (expires.value - date.value) / MICROS_PER_SECOND;
++			has_freshness_lifetime = true;
++		}
++	}
++	if (!has_freshness_lifetime) {
++		return timestamp_t::infinity();
++	}
++
++	// The response may have already spent time in intermediate caches (RFC 9111 current age)
++	int64_t age = 0;
++	if (headers.HasHeader("Age")) {
++		if (!TryParseNonNegativeSeconds(headers.GetHeaderValue("Age"), age)) {
++			age = 0;
++		}
++	}
++
++	const int64_t remaining = MinValue<int64_t>(freshness_lifetime - age, MAX_FRESHNESS_SECONDS);
++	if (remaining <= 0) {
++		return timestamp_t::infinity(); // Already stale: no freshness to grant
++	}
++	return timestamp_t(Timestamp::GetCurrentTimestamp().value + remaining * MICROS_PER_SECOND);
++}
++
+ struct HTTPFileInfoParser {
+ 	static optional_idx TryParseContentRange(const HTTPHeaders &headers) {
+ 		if (!headers.HasHeader("Content-Range")) {
+@@ -675,6 +745,7 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
+ 	if (response.headers.HasHeader("ETag")) {
+ 		etag = response.headers.GetHeaderValue("ETag");
+ 	}
++	cache_valid_until = HTTPFileSystem::ComputeCacheValidUntil(response.headers);
+ 	if (request_session->Capture().snapshot->Params().s3_version_id_pinning &&
+ 	    response.headers.HasHeader("x-amz-version-id")) {
+ 		SetVersionId(response.headers.GetHeaderValue("x-amz-version-id"));
+@@ -716,6 +787,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
+ 	last_modified = cache_entry.last_modified;
+ 	length = cache_entry.length;
+ 	etag = cache_entry.etag;
++	cache_valid_until = cache_entry.cache_valid_until;
+ 	SetVersionId(cache_entry.version_id);
+ 
+ 	// TODO: handle properties
+@@ -726,6 +798,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
+ 	result.length = length;
+ 	result.last_modified = last_modified;
+ 	result.etag = etag;
++	result.cache_valid_until = cache_valid_until;
+ 	result.version_id = GetVersionId();
+ 	// TODO: handle properties
+ 	return result;
+diff --git a/src/include/http/http_metadata_cache.hpp b/src/include/http/http_metadata_cache.hpp
+index 2908a43..540d96f 100644
+--- a/src/include/http/http_metadata_cache.hpp
++++ b/src/include/http/http_metadata_cache.hpp
+@@ -19,6 +19,8 @@ struct HTTPMetadataCacheEntry {
+ 	idx_t length;
+ 	timestamp_t last_modified;
+ 	string etag;
++	//! Freshness deadline; if unset (infinite), the server does not provide expiry information
++	timestamp_t cache_valid_until = timestamp_t::infinity();
+ 	string version_id;
+ 	unordered_map<string, string> properties;
+ };
+diff --git a/src/include/http/httpfs.hpp b/src/include/http/httpfs.hpp
+index 1764acc..6d77d08 100644
+--- a/src/include/http/httpfs.hpp
++++ b/src/include/http/httpfs.hpp
+@@ -64,6 +64,10 @@ public:
+ 	idx_t length;
+ 	timestamp_t last_modified;
+ 	string etag;
++	//! Freshness deadline derived from HTTP caching headers (Cache-Control/Expires).
++	//! If unset (infinite), the server does not provide information on when cached data expires.
++	//! Used to cache files that provide no validators (no ETag/Last-Modified).
++	timestamp_t cache_valid_until = timestamp_t::infinity();
+ 	bool force_full_download;
+ 	bool initialized = false;
+ 
+@@ -133,6 +137,9 @@ private:
+ class HTTPFileSystem : public FileSystem {
+ public:
+ 	static bool TryParseLastModifiedTime(const string &timestamp, timestamp_t &result);
++	//! Compute the freshness deadline from HTTP caching headers (RFC 9111): Cache-Control max-age,
++	//! falling back to Expires/Date, adjusted by the response's current age. Infinite if not provided.
++	static timestamp_t ComputeCacheValidUntil(const HTTPHeaders &headers);
+ 
+ 	//! FileSystem overrides.
+ 	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override {
+@@ -155,6 +162,7 @@ public:
+ 	int64_t GetFileSize(FileHandle &handle) override;
+ 	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
+ 	string GetVersionTag(FileHandle &handle) override;
++	FileMetadata Stats(FileHandle &handle) override;
+ 	bool FileExists(const string &filename, optional_ptr<FileOpener> opener) override;
+ 	void Seek(FileHandle &handle, idx_t location) override;
+ 	idx_t SeekPosition(FileHandle &handle) override;

--- a/.github/patches/extensions/httpfs/0001-cache-metadata.patch
+++ b/.github/patches/extensions/httpfs/0001-cache-metadata.patch
@@ -1,14 +1,14 @@
-commit 3f3f3fcc8563eea14fca49a3092c142b6da10219
+commit 82427d21c7fbbe8dac740c64524515d2f43fef70
 Author: dentinyhao <dentinyhao@gmail.com>
 Date:   Tue Aug 4 02:50:57 2026 -0700
 
     Consider HTTP cache
 
 diff --git a/src/http/httpfs.cpp b/src/http/httpfs.cpp
-index 0fc503a..2505821 100644
+index a4ae59f..efd18b4 100644
 --- a/src/http/httpfs.cpp
 +++ b/src/http/httpfs.cpp
-@@ -7,8 +7,13 @@
+@@ -8,9 +8,14 @@
  #include "duckdb/common/file_opener.hpp"
  #include "duckdb/common/helper.hpp"
  #include "duckdb/common/http_util.hpp"
@@ -16,13 +16,14 @@ index 0fc503a..2505821 100644
 +#include "duckdb/common/operator/cast_operators.hpp"
 +#include "duckdb/common/operator/multiply.hpp"
 +#include "duckdb/common/operator/subtract.hpp"
+ #include "duckdb/common/string_util.hpp"
  #include "duckdb/common/thread.hpp"
  #include "duckdb/common/types/hash.hpp"
 +#include "duckdb/common/types/interval.hpp"
  #include "duckdb/common/types/time.hpp"
  #include "duckdb/function/scalar/strftime_format.hpp"
  #include "duckdb/logging/file_system_logger.hpp"
-@@ -473,6 +478,17 @@ string HTTPFileSystem::GetVersionTag(FileHandle &handle) {
+@@ -512,6 +517,17 @@ string HTTPFileSystem::GetVersionTag(FileHandle &handle) {
  	return sfh.etag;
  }
  
@@ -40,7 +41,7 @@ index 0fc503a..2505821 100644
  bool HTTPFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
  	try {
  		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_READ, opener);
-@@ -574,6 +590,123 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
+@@ -648,6 +664,151 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
  	return true;
  }
  
@@ -48,14 +49,43 @@ index 0fc503a..2505821 100644
 +	return TryCast::Operation<string_t, int64_t>(string_t(input), result) && result >= 0;
 +}
 +
-+static bool HasCacheControlDirective(const HTTPHeaders &headers, const string &name) {
++static vector<string> GetCacheControlDirectives(const HTTPHeaders &headers) {
++	vector<string> result;
 +	if (!headers.HasHeader("Cache-Control")) {
-+		return false;
++		return result;
 +	}
-+	for (auto &directive : StringUtil::Split(headers.GetHeaderValue("Cache-Control"), ',')) {
++	for (const auto &header_value : headers.GetHeaderValues("Cache-Control")) {
++		string directive;
++		bool quoted = false;
++		bool escaped = false;
++		for (const auto ch : header_value) {
++			if (escaped) {
++				directive.push_back(ch);
++				escaped = false;
++			} else if (quoted && ch == '\\') {
++				directive.push_back(ch);
++				escaped = true;
++			} else if (ch == '"') {
++				directive.push_back(ch);
++				quoted = !quoted;
++			} else if (ch == ',' && !quoted) {
++				result.push_back(std::move(directive));
++				directive.clear();
++			} else {
++				directive.push_back(ch);
++			}
++		}
++		result.push_back(std::move(directive));
++	}
++	return result;
++}
++
++static bool HasCacheControlDirective(const HTTPHeaders &headers, const string &name) {
++	for (auto directive : GetCacheControlDirectives(headers)) {
 +		StringUtil::Trim(directive);
 +		const auto separator = directive.find('=');
-+		const auto directive_name = separator == string::npos ? directive : directive.substr(0, separator);
++		auto directive_name = separator == string::npos ? directive : directive.substr(0, separator);
++		StringUtil::Trim(directive_name);
 +		if (StringUtil::CIEquals(directive_name, name)) {
 +			return true;
 +		}
@@ -73,8 +103,7 @@ index 0fc503a..2505821 100644
 +	bool has_freshness_lifetime = false;
 +	bool has_max_age = false;
 +	if (headers.HasHeader("Cache-Control")) {
-+		for (auto &directive_p : StringUtil::Split(headers.GetHeaderValue("Cache-Control"), ',')) {
-+			auto directive = directive_p;
++		for (auto directive : GetCacheControlDirectives(headers)) {
 +			StringUtil::Trim(directive);
 +			const auto separator = directive.find('=');
 +			if (separator == string::npos) {
@@ -162,9 +191,9 @@ index 0fc503a..2505821 100644
 +}
 +
  struct HTTPFileInfoParser {
+ public:
  	static optional_idx TryParseContentRange(const HTTPHeaders &headers) {
- 		if (!headers.HasHeader("Content-Range")) {
-@@ -675,6 +808,11 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
+@@ -750,6 +911,11 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
  	if (response.headers.HasHeader("ETag")) {
  		etag = response.headers.GetHeaderValue("ETag");
  	}
@@ -176,7 +205,7 @@ index 0fc503a..2505821 100644
  	if (request_session->Capture().snapshot->Params().s3_version_id_pinning &&
  	    response.headers.HasHeader("x-amz-version-id")) {
  		SetVersionId(response.headers.GetHeaderValue("x-amz-version-id"));
-@@ -716,6 +854,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
+@@ -791,6 +957,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
  	last_modified = cache_entry.last_modified;
  	length = cache_entry.length;
  	etag = cache_entry.etag;
@@ -184,7 +213,7 @@ index 0fc503a..2505821 100644
  	SetVersionId(cache_entry.version_id);
  
  	// TODO: handle properties
-@@ -726,6 +865,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
+@@ -801,6 +968,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
  	result.length = length;
  	result.last_modified = last_modified;
  	result.etag = etag;
@@ -192,7 +221,7 @@ index 0fc503a..2505821 100644
  	result.version_id = GetVersionId();
  	// TODO: handle properties
  	return result;
-@@ -793,7 +933,7 @@ void HTTPFileHandle::InitializeFileInfo(HTTPFileSystem &hfs, optional_ptr<HTTPMe
+@@ -868,7 +1036,7 @@ void HTTPFileHandle::InitializeFileInfo(HTTPFileSystem &hfs, optional_ptr<HTTPMe
  		if (should_full_download) {
  			length = hfs.FullDownload(*this, GetReadConfig(), should_write_cache)->GetSize();
  		}
@@ -202,7 +231,7 @@ index 0fc503a..2505821 100644
  		}
  	}
 diff --git a/src/include/http/http_metadata_cache.hpp b/src/include/http/http_metadata_cache.hpp
-index 2908a43..a8bc5e0 100644
+index 1c6e500..ae2f221 100644
 --- a/src/include/http/http_metadata_cache.hpp
 +++ b/src/include/http/http_metadata_cache.hpp
 @@ -4,6 +4,7 @@
@@ -222,7 +251,7 @@ index 2908a43..a8bc5e0 100644
  	string version_id;
  	unordered_map<string, string> properties;
  };
-@@ -44,6 +47,11 @@ public:
+@@ -48,6 +51,11 @@ public:
  		if (lookup == map.end()) {
  			return false;
  		}
@@ -233,9 +262,9 @@ index 2908a43..a8bc5e0 100644
 +		}
  		ret_val = lookup->second;
  		return true;
- 	};
+ 	}
 diff --git a/src/include/http/httpfs.hpp b/src/include/http/httpfs.hpp
-index 1764acc..8b23ecf 100644
+index 6d19b18..985bd2b 100644
 --- a/src/include/http/httpfs.hpp
 +++ b/src/include/http/httpfs.hpp
 @@ -2,6 +2,7 @@
@@ -246,7 +275,7 @@ index 1764acc..8b23ecf 100644
  #include "http/http_state.hpp"
  #include "duckdb/common/pair.hpp"
  #include "duckdb/common/unordered_map.hpp"
-@@ -64,6 +65,12 @@ public:
+@@ -99,6 +100,12 @@ public:
  	idx_t length;
  	timestamp_t last_modified;
  	string etag;
@@ -258,8 +287,8 @@ index 1764acc..8b23ecf 100644
 +	bool cache_no_store = false;
  	bool force_full_download;
  	bool initialized = false;
- 
-@@ -133,6 +140,10 @@ private:
+ 	bool auto_fallback_to_full_file_download = true;
+@@ -128,6 +135,10 @@ private:
  class HTTPFileSystem : public FileSystem {
  public:
  	static bool TryParseLastModifiedTime(const string &timestamp, timestamp_t &result);
@@ -269,8 +298,8 @@ index 1764acc..8b23ecf 100644
 +	static optional<timestamp_t> ComputeCacheValidUntil(const HTTPHeaders &headers);
  
  	//! FileSystem overrides.
- 	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override {
-@@ -155,6 +166,7 @@ public:
+ 	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override;
+@@ -140,6 +151,7 @@ public:
  	int64_t GetFileSize(FileHandle &handle) override;
  	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
  	string GetVersionTag(FileHandle &handle) override;

--- a/.github/patches/extensions/httpfs/0001-cache-metadata.patch
+++ b/.github/patches/extensions/httpfs/0001-cache-metadata.patch
@@ -1,14 +1,25 @@
-commit 9e5c505de48669bbf14102a96780199b9d8a0c70
+commit b9615d99c7c44ef477d3aad540c5c342db9fdb68
 Author: dentinyhao <dentinyhao@gmail.com>
 Date:   Tue Aug 4 02:50:57 2026 -0700
 
     Consider HTTP cache
 
 diff --git a/src/http/httpfs.cpp b/src/http/httpfs.cpp
-index 0fc503a..219d81a 100644
+index 0fc503a..98cbca5 100644
 --- a/src/http/httpfs.cpp
 +++ b/src/http/httpfs.cpp
-@@ -473,6 +473,16 @@ string HTTPFileSystem::GetVersionTag(FileHandle &handle) {
+@@ -7,8 +7,10 @@
+ #include "duckdb/common/file_opener.hpp"
+ #include "duckdb/common/helper.hpp"
+ #include "duckdb/common/http_util.hpp"
++#include "duckdb/common/operator/cast_operators.hpp"
+ #include "duckdb/common/thread.hpp"
+ #include "duckdb/common/types/hash.hpp"
++#include "duckdb/common/types/interval.hpp"
+ #include "duckdb/common/types/time.hpp"
+ #include "duckdb/function/scalar/strftime_format.hpp"
+ #include "duckdb/logging/file_system_logger.hpp"
+@@ -473,6 +475,16 @@ string HTTPFileSystem::GetVersionTag(FileHandle &handle) {
  	return sfh.etag;
  }
  
@@ -25,25 +36,21 @@ index 0fc503a..219d81a 100644
  bool HTTPFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
  	try {
  		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_READ, opener);
-@@ -574,6 +584,66 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
+@@ -574,6 +586,58 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
  	return true;
  }
  
 +static bool TryParseNonNegativeSeconds(const string &input, int64_t &result) {
-+	try {
-+		result = std::stoll(input);
-+	} catch (...) {
-+		return false;
-+	}
-+	return result >= 0;
++	return TryCast::Operation<string_t, int64_t>(string_t(input), result) && result >= 0;
 +}
 +
 +timestamp_t HTTPFileSystem::ComputeCacheValidUntil(const HTTPHeaders &headers) {
-+	static constexpr int64_t MICROS_PER_SECOND = 1000000LL;
 +	// Clamp the freshness lifetime to guard against overflow from absurd server-provided values
-+	static constexpr int64_t MAX_FRESHNESS_SECONDS = 365LL * 24 * 60 * 60;
++	static constexpr int64_t MAX_FRESHNESS_SECONDS = Interval::DAYS_PER_YEAR * Interval::SECS_PER_DAY;
 +
 +	// Freshness lifetime in seconds (RFC 9111): Cache-Control max-age takes precedence over Expires
++	// TODO: handle no-store/no-cache directives; note that this function is only consulted for responses
++	// without validators (no ETag/Last-Modified), and infinity means no freshness is granted
 +	int64_t freshness_lifetime = 0;
 +	bool has_freshness_lifetime = false;
 +	if (headers.HasHeader("Cache-Control")) {
@@ -51,10 +58,6 @@ index 0fc503a..219d81a 100644
 +		for (auto &directive_p : StringUtil::Split(headers.GetHeaderValue("Cache-Control"), ',')) {
 +			auto directive = StringUtil::Lower(directive_p);
 +			StringUtil::Trim(directive);
-+			if (StringUtil::StartsWith(directive, "no-store") || StringUtil::StartsWith(directive, "no-cache")) {
-+				// no-store: must not be cached, no-cache: must be revalidated before every use
-+				return timestamp_t::infinity();
-+			}
 +			if (StringUtil::StartsWith(directive, MAX_AGE_PREFIX)) {
 +				has_freshness_lifetime =
 +				    TryParseNonNegativeSeconds(directive.substr(MAX_AGE_PREFIX.size()), freshness_lifetime);
@@ -66,7 +69,7 @@ index 0fc503a..219d81a 100644
 +		timestamp_t date;
 +		if (TryParseLastModifiedTime(headers.GetHeaderValue("Expires"), expires) &&
 +		    TryParseLastModifiedTime(headers.GetHeaderValue("Date"), date)) {
-+			freshness_lifetime = (expires.value - date.value) / MICROS_PER_SECOND;
++			freshness_lifetime = (expires.value - date.value) / Interval::MICROS_PER_SEC;
 +			has_freshness_lifetime = true;
 +		}
 +	}
@@ -86,13 +89,13 @@ index 0fc503a..219d81a 100644
 +	if (remaining <= 0) {
 +		return timestamp_t::infinity(); // Already stale: no freshness to grant
 +	}
-+	return timestamp_t(Timestamp::GetCurrentTimestamp().value + remaining * MICROS_PER_SECOND);
++	return timestamp_t(Timestamp::GetCurrentTimestamp().value + remaining * Interval::MICROS_PER_SEC);
 +}
 +
  struct HTTPFileInfoParser {
  	static optional_idx TryParseContentRange(const HTTPHeaders &headers) {
  		if (!headers.HasHeader("Content-Range")) {
-@@ -675,6 +745,7 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
+@@ -675,6 +739,7 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
  	if (response.headers.HasHeader("ETag")) {
  		etag = response.headers.GetHeaderValue("ETag");
  	}
@@ -100,7 +103,7 @@ index 0fc503a..219d81a 100644
  	if (request_session->Capture().snapshot->Params().s3_version_id_pinning &&
  	    response.headers.HasHeader("x-amz-version-id")) {
  		SetVersionId(response.headers.GetHeaderValue("x-amz-version-id"));
-@@ -716,6 +787,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
+@@ -716,6 +781,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
  	last_modified = cache_entry.last_modified;
  	length = cache_entry.length;
  	etag = cache_entry.etag;
@@ -108,7 +111,7 @@ index 0fc503a..219d81a 100644
  	SetVersionId(cache_entry.version_id);
  
  	// TODO: handle properties
-@@ -726,6 +798,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
+@@ -726,6 +792,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
  	result.length = length;
  	result.last_modified = last_modified;
  	result.etag = etag;

--- a/.github/patches/extensions/httpfs/0001-cache-metadata.patch
+++ b/.github/patches/extensions/httpfs/0001-cache-metadata.patch
@@ -1,25 +1,27 @@
-commit b9615d99c7c44ef477d3aad540c5c342db9fdb68
+commit bb8994c854cc556fafaf672906fabd636f9b6175
 Author: dentinyhao <dentinyhao@gmail.com>
 Date:   Tue Aug 4 02:50:57 2026 -0700
 
     Consider HTTP cache
 
 diff --git a/src/http/httpfs.cpp b/src/http/httpfs.cpp
-index 0fc503a..98cbca5 100644
+index 0fc503a..e2d2de0 100644
 --- a/src/http/httpfs.cpp
 +++ b/src/http/httpfs.cpp
-@@ -7,8 +7,10 @@
+@@ -7,8 +7,12 @@
  #include "duckdb/common/file_opener.hpp"
  #include "duckdb/common/helper.hpp"
  #include "duckdb/common/http_util.hpp"
++#include "duckdb/common/operator/add.hpp"
 +#include "duckdb/common/operator/cast_operators.hpp"
++#include "duckdb/common/operator/multiply.hpp"
  #include "duckdb/common/thread.hpp"
  #include "duckdb/common/types/hash.hpp"
 +#include "duckdb/common/types/interval.hpp"
  #include "duckdb/common/types/time.hpp"
  #include "duckdb/function/scalar/strftime_format.hpp"
  #include "duckdb/logging/file_system_logger.hpp"
-@@ -473,6 +475,16 @@ string HTTPFileSystem::GetVersionTag(FileHandle &handle) {
+@@ -473,6 +477,17 @@ string HTTPFileSystem::GetVersionTag(FileHandle &handle) {
  	return sfh.etag;
  }
  
@@ -30,13 +32,14 @@ index 0fc503a..98cbca5 100644
 +	metadata.last_modification_time = sfh.last_modified;
 +	metadata.file_type = FileType::FILE_TYPE_REGULAR;
 +	metadata.cache_valid_until = sfh.cache_valid_until;
++	metadata.version_tag = sfh.etag;
 +	return metadata;
 +}
 +
  bool HTTPFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
  	try {
  		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_READ, opener);
-@@ -574,6 +586,58 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
+@@ -574,6 +589,62 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
  	return true;
  }
  
@@ -45,9 +48,6 @@ index 0fc503a..98cbca5 100644
 +}
 +
 +timestamp_t HTTPFileSystem::ComputeCacheValidUntil(const HTTPHeaders &headers) {
-+	// Clamp the freshness lifetime to guard against overflow from absurd server-provided values
-+	static constexpr int64_t MAX_FRESHNESS_SECONDS = Interval::DAYS_PER_YEAR * Interval::SECS_PER_DAY;
-+
 +	// Freshness lifetime in seconds (RFC 9111): Cache-Control max-age takes precedence over Expires
 +	// TODO: handle no-store/no-cache directives; note that this function is only consulted for responses
 +	// without validators (no ETag/Last-Modified), and infinity means no freshness is granted
@@ -85,17 +85,24 @@ index 0fc503a..98cbca5 100644
 +		}
 +	}
 +
-+	const int64_t remaining = MinValue<int64_t>(freshness_lifetime - age, MAX_FRESHNESS_SECONDS);
++	const int64_t remaining = freshness_lifetime - age;
 +	if (remaining <= 0) {
 +		return timestamp_t::infinity(); // Already stale: no freshness to grant
 +	}
-+	return timestamp_t(Timestamp::GetCurrentTimestamp().value + remaining * Interval::MICROS_PER_SEC);
++	// Absurd server-provided lifetimes that would overflow the deadline grant no freshness
++	int64_t remaining_micros;
++	int64_t deadline_micros;
++	if (!TryMultiplyOperator::Operation(remaining, Interval::MICROS_PER_SEC, remaining_micros) ||
++	    !TryAddOperator::Operation(Timestamp::GetCurrentTimestamp().value, remaining_micros, deadline_micros)) {
++		return timestamp_t::infinity();
++	}
++	return timestamp_t(deadline_micros);
 +}
 +
  struct HTTPFileInfoParser {
  	static optional_idx TryParseContentRange(const HTTPHeaders &headers) {
  		if (!headers.HasHeader("Content-Range")) {
-@@ -675,6 +739,7 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
+@@ -675,6 +746,7 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
  	if (response.headers.HasHeader("ETag")) {
  		etag = response.headers.GetHeaderValue("ETag");
  	}
@@ -103,7 +110,7 @@ index 0fc503a..98cbca5 100644
  	if (request_session->Capture().snapshot->Params().s3_version_id_pinning &&
  	    response.headers.HasHeader("x-amz-version-id")) {
  		SetVersionId(response.headers.GetHeaderValue("x-amz-version-id"));
-@@ -716,6 +781,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
+@@ -716,6 +788,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
  	last_modified = cache_entry.last_modified;
  	length = cache_entry.length;
  	etag = cache_entry.etag;
@@ -111,7 +118,7 @@ index 0fc503a..98cbca5 100644
  	SetVersionId(cache_entry.version_id);
  
  	// TODO: handle properties
-@@ -726,6 +792,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
+@@ -726,6 +799,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
  	result.length = length;
  	result.last_modified = last_modified;
  	result.etag = etag;

--- a/.github/patches/extensions/httpfs/0001-cache-metadata.patch
+++ b/.github/patches/extensions/httpfs/0001-cache-metadata.patch
@@ -1,11 +1,11 @@
-commit 58cec0216987eca659dd8060183d8e41812f01fe
+commit 7213f8e17ffd9ce52420154e217127b7059e0e3c
 Author: dentinyhao <dentinyhao@gmail.com>
 Date:   Tue Aug 4 02:50:57 2026 -0700
 
     Consider HTTP cache
 
 diff --git a/src/http/httpfs.cpp b/src/http/httpfs.cpp
-index 0fc503a..8114726 100644
+index 0fc503a..2505821 100644
 --- a/src/http/httpfs.cpp
 +++ b/src/http/httpfs.cpp
 @@ -7,8 +7,13 @@
@@ -40,7 +40,7 @@ index 0fc503a..8114726 100644
  bool HTTPFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
  	try {
  		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_READ, opener);
-@@ -574,6 +590,107 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
+@@ -574,6 +590,123 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
  	return true;
  }
  
@@ -68,6 +68,7 @@ index 0fc503a..8114726 100644
 +	if (HasCacheControlDirective(headers, "no-cache")) {
 +		return timestamp_t::ninfinity();
 +	}
++	const auto response_time = Timestamp::GetCurrentTimestamp();
 +	int64_t freshness_lifetime = 0;
 +	bool has_freshness_lifetime = false;
 +	bool has_max_age = false;
@@ -107,7 +108,7 @@ index 0fc503a..8114726 100644
 +			if (headers.HasHeader("Date")) {
 +				has_reference_time = TryParseLastModifiedTime(headers.GetHeaderValue("Date"), reference_time);
 +			} else {
-+				reference_time = Timestamp::GetCurrentTimestamp();
++				reference_time = response_time;
 +			}
 +			int64_t freshness_micros;
 +			if (has_reference_time && TrySubtractOperator::Operation(expires, reference_time, freshness_micros)) {
@@ -123,23 +124,38 @@ index 0fc503a..8114726 100644
 +		return nullopt;
 +	}
 +
-+	// The response may have already spent time in intermediate caches (RFC 9111 current age)
++	// Account for both Age and the apparent age derived from Date (RFC 9111).
 +	int64_t age = 0;
 +	if (headers.HasHeader("Age")) {
 +		if (!TryParseNonNegativeSeconds(headers.GetHeaderValue("Age"), age)) {
 +			age = 0;
 +		}
 +	}
++	int64_t current_age_micros;
++	if (!TryMultiplyOperator::Operation(age, Interval::MICROS_PER_SEC, current_age_micros)) {
++		return timestamp_t::ninfinity();
++	}
++	if (headers.HasHeader("Date")) {
++		timestamp_t date;
++		if (TryParseLastModifiedTime(headers.GetHeaderValue("Date"), date)) {
++			int64_t apparent_age_micros;
++			if (!TrySubtractOperator::Operation(response_time, date, apparent_age_micros)) {
++				return timestamp_t::ninfinity();
++			}
++			current_age_micros = MaxValue<int64_t>(current_age_micros, MaxValue<int64_t>(0, apparent_age_micros));
++		}
++	}
 +
-+	const int64_t remaining = freshness_lifetime - age;
-+	if (remaining <= 0) {
++	int64_t freshness_micros;
++	if (freshness_lifetime <= 0 ||
++	    !TryMultiplyOperator::Operation(freshness_lifetime, Interval::MICROS_PER_SEC, freshness_micros) ||
++	    current_age_micros >= freshness_micros) {
 +		return timestamp_t::ninfinity();
 +	}
 +	// Absurd server-provided lifetimes that would overflow the deadline grant no freshness
-+	int64_t remaining_micros;
 +	int64_t deadline_micros;
-+	if (!TryMultiplyOperator::Operation(remaining, Interval::MICROS_PER_SEC, remaining_micros) ||
-+	    !TryAddOperator::Operation(Timestamp::GetCurrentTimestamp().value, remaining_micros, deadline_micros)) {
++	const auto remaining_micros = freshness_micros - current_age_micros;
++	if (!TryAddOperator::Operation(response_time.value, remaining_micros, deadline_micros)) {
 +		return timestamp_t::ninfinity();
 +	}
 +	return timestamp_t(deadline_micros);
@@ -148,7 +164,7 @@ index 0fc503a..8114726 100644
  struct HTTPFileInfoParser {
  	static optional_idx TryParseContentRange(const HTTPHeaders &headers) {
  		if (!headers.HasHeader("Content-Range")) {
-@@ -675,6 +792,11 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
+@@ -675,6 +808,11 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
  	if (response.headers.HasHeader("ETag")) {
  		etag = response.headers.GetHeaderValue("ETag");
  	}
@@ -160,7 +176,7 @@ index 0fc503a..8114726 100644
  	if (request_session->Capture().snapshot->Params().s3_version_id_pinning &&
  	    response.headers.HasHeader("x-amz-version-id")) {
  		SetVersionId(response.headers.GetHeaderValue("x-amz-version-id"));
-@@ -716,6 +838,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
+@@ -716,6 +854,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
  	last_modified = cache_entry.last_modified;
  	length = cache_entry.length;
  	etag = cache_entry.etag;
@@ -168,7 +184,7 @@ index 0fc503a..8114726 100644
  	SetVersionId(cache_entry.version_id);
  
  	// TODO: handle properties
-@@ -726,6 +849,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
+@@ -726,6 +865,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
  	result.length = length;
  	result.last_modified = last_modified;
  	result.etag = etag;
@@ -176,7 +192,7 @@ index 0fc503a..8114726 100644
  	result.version_id = GetVersionId();
  	// TODO: handle properties
  	return result;
-@@ -793,7 +917,7 @@ void HTTPFileHandle::InitializeFileInfo(HTTPFileSystem &hfs, optional_ptr<HTTPMe
+@@ -793,7 +933,7 @@ void HTTPFileHandle::InitializeFileInfo(HTTPFileSystem &hfs, optional_ptr<HTTPMe
  		if (should_full_download) {
  			length = hfs.FullDownload(*this, GetReadConfig(), should_write_cache)->GetSize();
  		}

--- a/.github/patches/extensions/httpfs/0001-cache-metadata.patch
+++ b/.github/patches/extensions/httpfs/0001-cache-metadata.patch
@@ -1,11 +1,11 @@
-commit 45668a8454d449d40858e1ec7b4b4e0d0d91f83d
+commit dbf1450f4db291d0ed8e05b0b2a7ae8a19de8a7d
 Author: dentinyhao <dentinyhao@gmail.com>
 Date:   Tue Aug 4 02:50:57 2026 -0700
 
     Consider HTTP cache
 
 diff --git a/src/http/httpfs.cpp b/src/http/httpfs.cpp
-index 0fc503a..25f9ebd 100644
+index 0fc503a..a13975b 100644
 --- a/src/http/httpfs.cpp
 +++ b/src/http/httpfs.cpp
 @@ -7,8 +7,13 @@
@@ -22,7 +22,7 @@ index 0fc503a..25f9ebd 100644
  #include "duckdb/common/types/time.hpp"
  #include "duckdb/function/scalar/strftime_format.hpp"
  #include "duckdb/logging/file_system_logger.hpp"
-@@ -473,6 +478,18 @@ string HTTPFileSystem::GetVersionTag(FileHandle &handle) {
+@@ -473,6 +478,17 @@ string HTTPFileSystem::GetVersionTag(FileHandle &handle) {
  	return sfh.etag;
  }
  
@@ -33,7 +33,6 @@ index 0fc503a..25f9ebd 100644
 +	metadata.last_modification_time = sfh.last_modified;
 +	metadata.file_type = FileType::FILE_TYPE_REGULAR;
 +	metadata.cache_valid_until = sfh.cache_valid_until;
-+	metadata.cache_immutable = sfh.cache_immutable;
 +	metadata.version_tag = sfh.etag;
 +	return metadata;
 +}
@@ -41,25 +40,12 @@ index 0fc503a..25f9ebd 100644
  bool HTTPFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
  	try {
  		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_READ, opener);
-@@ -574,6 +591,93 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
+@@ -574,6 +590,88 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
  	return true;
  }
  
 +static bool TryParseNonNegativeSeconds(const string &input, int64_t &result) {
 +	return TryCast::Operation<string_t, int64_t>(string_t(input), result) && result >= 0;
-+}
-+
-+static bool HasImmutableCacheControl(const HTTPHeaders &headers) {
-+	if (!headers.HasHeader("Cache-Control")) {
-+		return false;
-+	}
-+	for (auto &directive : StringUtil::Split(headers.GetHeaderValue("Cache-Control"), ',')) {
-+		StringUtil::Trim(directive);
-+		if (StringUtil::CIEquals(directive, "immutable")) {
-+			return true;
-+		}
-+	}
-+	return false;
 +}
 +
 +timestamp_t HTTPFileSystem::ComputeCacheValidUntil(const HTTPHeaders &headers) {
@@ -68,6 +54,7 @@ index 0fc503a..25f9ebd 100644
 +	// without validators (no ETag/Last-Modified), and infinity means no freshness is granted
 +	int64_t freshness_lifetime = 0;
 +	bool has_freshness_lifetime = false;
++	bool has_max_age = false;
 +	if (headers.HasHeader("Cache-Control")) {
 +		for (auto &directive_p : StringUtil::Split(headers.GetHeaderValue("Cache-Control"), ',')) {
 +			auto directive = directive_p;
@@ -81,12 +68,19 @@ index 0fc503a..25f9ebd 100644
 +			if (!StringUtil::CIEquals(name, "max-age")) {
 +				continue;
 +			}
++			if (has_max_age) {
++				return timestamp_t::infinity();
++			}
++			has_max_age = true;
 +			auto value = directive.substr(separator + 1);
 +			StringUtil::Trim(value);
 +			if (value.size() >= 2 && value.front() == '"' && value.back() == '"') {
 +				value = value.substr(1, value.size() - 2);
 +			}
-+			has_freshness_lifetime = TryParseNonNegativeSeconds(value, freshness_lifetime);
++			if (!TryParseNonNegativeSeconds(value, freshness_lifetime)) {
++				return timestamp_t::infinity();
++			}
++			has_freshness_lifetime = true;
 +		}
 +	}
 +	if (!has_freshness_lifetime && headers.HasHeader("Expires")) {
@@ -135,52 +129,48 @@ index 0fc503a..25f9ebd 100644
  struct HTTPFileInfoParser {
  	static optional_idx TryParseContentRange(const HTTPHeaders &headers) {
  		if (!headers.HasHeader("Content-Range")) {
-@@ -675,6 +779,8 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
+@@ -675,6 +773,7 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
  	if (response.headers.HasHeader("ETag")) {
  		etag = response.headers.GetHeaderValue("ETag");
  	}
 +	cache_valid_until = HTTPFileSystem::ComputeCacheValidUntil(response.headers);
-+	cache_immutable = HasImmutableCacheControl(response.headers);
  	if (request_session->Capture().snapshot->Params().s3_version_id_pinning &&
  	    response.headers.HasHeader("x-amz-version-id")) {
  		SetVersionId(response.headers.GetHeaderValue("x-amz-version-id"));
-@@ -716,6 +822,8 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
+@@ -716,6 +815,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
  	last_modified = cache_entry.last_modified;
  	length = cache_entry.length;
  	etag = cache_entry.etag;
 +	cache_valid_until = cache_entry.cache_valid_until;
-+	cache_immutable = cache_entry.cache_immutable;
  	SetVersionId(cache_entry.version_id);
  
  	// TODO: handle properties
-@@ -726,6 +834,8 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
+@@ -726,6 +826,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
  	result.length = length;
  	result.last_modified = last_modified;
  	result.etag = etag;
 +	result.cache_valid_until = cache_valid_until;
-+	result.cache_immutable = cache_immutable;
  	result.version_id = GetVersionId();
  	// TODO: handle properties
  	return result;
 diff --git a/src/include/http/http_metadata_cache.hpp b/src/include/http/http_metadata_cache.hpp
-index 2908a43..9e3ca4f 100644
+index 2908a43..64bd2e8 100644
 --- a/src/include/http/http_metadata_cache.hpp
 +++ b/src/include/http/http_metadata_cache.hpp
-@@ -19,6 +19,9 @@ struct HTTPMetadataCacheEntry {
+@@ -19,6 +19,8 @@ struct HTTPMetadataCacheEntry {
  	idx_t length;
  	timestamp_t last_modified;
  	string etag;
 +	//! Freshness deadline (inclusive); if unset (infinite), the server does not provide expiry information
 +	timestamp_t cache_valid_until = timestamp_t::infinity();
-+	bool cache_immutable = false;
  	string version_id;
  	unordered_map<string, string> properties;
  };
 diff --git a/src/include/http/httpfs.hpp b/src/include/http/httpfs.hpp
-index 1764acc..64986a2 100644
+index 1764acc..d5fe6ae 100644
 --- a/src/include/http/httpfs.hpp
 +++ b/src/include/http/httpfs.hpp
-@@ -64,6 +64,12 @@ public:
+@@ -64,6 +64,10 @@ public:
  	idx_t length;
  	timestamp_t last_modified;
  	string etag;
@@ -188,12 +178,10 @@ index 1764acc..64986a2 100644
 +	//! If unset (infinite), the server does not provide information on when cached data expires.
 +	//! Used to cache files that provide no validators (no ETag/Last-Modified).
 +	timestamp_t cache_valid_until = timestamp_t::infinity();
-+	//! Whether Cache-Control declares the response immutable during its freshness lifetime.
-+	bool cache_immutable = false;
  	bool force_full_download;
  	bool initialized = false;
  
-@@ -133,6 +139,10 @@ private:
+@@ -133,6 +137,10 @@ private:
  class HTTPFileSystem : public FileSystem {
  public:
  	static bool TryParseLastModifiedTime(const string &timestamp, timestamp_t &result);
@@ -204,7 +192,7 @@ index 1764acc..64986a2 100644
  
  	//! FileSystem overrides.
  	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override {
-@@ -155,6 +165,7 @@ public:
+@@ -155,6 +163,7 @@ public:
  	int64_t GetFileSize(FileHandle &handle) override;
  	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
  	string GetVersionTag(FileHandle &handle) override;

--- a/.github/patches/extensions/httpfs/0001-cache-metadata.patch
+++ b/.github/patches/extensions/httpfs/0001-cache-metadata.patch
@@ -1,4 +1,4 @@
-commit 7213f8e17ffd9ce52420154e217127b7059e0e3c
+commit 3f3f3fcc8563eea14fca49a3092c142b6da10219
 Author: dentinyhao <dentinyhao@gmail.com>
 Date:   Tue Aug 4 02:50:57 2026 -0700
 
@@ -202,7 +202,7 @@ index 0fc503a..2505821 100644
  		}
  	}
 diff --git a/src/include/http/http_metadata_cache.hpp b/src/include/http/http_metadata_cache.hpp
-index 2908a43..0011db0 100644
+index 2908a43..a8bc5e0 100644
 --- a/src/include/http/http_metadata_cache.hpp
 +++ b/src/include/http/http_metadata_cache.hpp
 @@ -4,6 +4,7 @@
@@ -222,6 +222,18 @@ index 2908a43..0011db0 100644
  	string version_id;
  	unordered_map<string, string> properties;
  };
+@@ -44,6 +47,11 @@ public:
+ 		if (lookup == map.end()) {
+ 			return false;
+ 		}
++		if (lookup->second.cache_valid_until &&
++		    Timestamp::GetCurrentTimestamp() > *lookup->second.cache_valid_until) {
++			map.erase(lookup);
++			return false;
++		}
+ 		ret_val = lookup->second;
+ 		return true;
+ 	};
 diff --git a/src/include/http/httpfs.hpp b/src/include/http/httpfs.hpp
 index 1764acc..8b23ecf 100644
 --- a/src/include/http/httpfs.hpp

--- a/.github/patches/extensions/httpfs/0001-cache-metadata.patch
+++ b/.github/patches/extensions/httpfs/0001-cache-metadata.patch
@@ -1,27 +1,28 @@
-commit ca0895720355475ece3f28ef6115c91822626719
+commit 45668a8454d449d40858e1ec7b4b4e0d0d91f83d
 Author: dentinyhao <dentinyhao@gmail.com>
 Date:   Tue Aug 4 02:50:57 2026 -0700
 
     Consider HTTP cache
 
 diff --git a/src/http/httpfs.cpp b/src/http/httpfs.cpp
-index 0fc503a..e2d2de0 100644
+index 0fc503a..25f9ebd 100644
 --- a/src/http/httpfs.cpp
 +++ b/src/http/httpfs.cpp
-@@ -7,8 +7,12 @@
+@@ -7,8 +7,13 @@
  #include "duckdb/common/file_opener.hpp"
  #include "duckdb/common/helper.hpp"
  #include "duckdb/common/http_util.hpp"
 +#include "duckdb/common/operator/add.hpp"
 +#include "duckdb/common/operator/cast_operators.hpp"
 +#include "duckdb/common/operator/multiply.hpp"
++#include "duckdb/common/operator/subtract.hpp"
  #include "duckdb/common/thread.hpp"
  #include "duckdb/common/types/hash.hpp"
 +#include "duckdb/common/types/interval.hpp"
  #include "duckdb/common/types/time.hpp"
  #include "duckdb/function/scalar/strftime_format.hpp"
  #include "duckdb/logging/file_system_logger.hpp"
-@@ -473,6 +477,17 @@ string HTTPFileSystem::GetVersionTag(FileHandle &handle) {
+@@ -473,6 +478,18 @@ string HTTPFileSystem::GetVersionTag(FileHandle &handle) {
  	return sfh.etag;
  }
  
@@ -32,6 +33,7 @@ index 0fc503a..e2d2de0 100644
 +	metadata.last_modification_time = sfh.last_modified;
 +	metadata.file_type = FileType::FILE_TYPE_REGULAR;
 +	metadata.cache_valid_until = sfh.cache_valid_until;
++	metadata.cache_immutable = sfh.cache_immutable;
 +	metadata.version_tag = sfh.etag;
 +	return metadata;
 +}
@@ -39,12 +41,25 @@ index 0fc503a..e2d2de0 100644
  bool HTTPFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
  	try {
  		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_READ, opener);
-@@ -574,6 +589,62 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
+@@ -574,6 +591,93 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
  	return true;
  }
  
 +static bool TryParseNonNegativeSeconds(const string &input, int64_t &result) {
 +	return TryCast::Operation<string_t, int64_t>(string_t(input), result) && result >= 0;
++}
++
++static bool HasImmutableCacheControl(const HTTPHeaders &headers) {
++	if (!headers.HasHeader("Cache-Control")) {
++		return false;
++	}
++	for (auto &directive : StringUtil::Split(headers.GetHeaderValue("Cache-Control"), ',')) {
++		StringUtil::Trim(directive);
++		if (StringUtil::CIEquals(directive, "immutable")) {
++			return true;
++		}
++	}
++	return false;
 +}
 +
 +timestamp_t HTTPFileSystem::ComputeCacheValidUntil(const HTTPHeaders &headers) {
@@ -54,23 +69,41 @@ index 0fc503a..e2d2de0 100644
 +	int64_t freshness_lifetime = 0;
 +	bool has_freshness_lifetime = false;
 +	if (headers.HasHeader("Cache-Control")) {
-+		const string MAX_AGE_PREFIX = "max-age=";
 +		for (auto &directive_p : StringUtil::Split(headers.GetHeaderValue("Cache-Control"), ',')) {
-+			auto directive = StringUtil::Lower(directive_p);
++			auto directive = directive_p;
 +			StringUtil::Trim(directive);
-+			if (StringUtil::StartsWith(directive, MAX_AGE_PREFIX)) {
-+				has_freshness_lifetime =
-+				    TryParseNonNegativeSeconds(directive.substr(MAX_AGE_PREFIX.size()), freshness_lifetime);
++			const auto separator = directive.find('=');
++			if (separator == string::npos) {
++				continue;
 +			}
++			auto name = directive.substr(0, separator);
++			StringUtil::Trim(name);
++			if (!StringUtil::CIEquals(name, "max-age")) {
++				continue;
++			}
++			auto value = directive.substr(separator + 1);
++			StringUtil::Trim(value);
++			if (value.size() >= 2 && value.front() == '"' && value.back() == '"') {
++				value = value.substr(1, value.size() - 2);
++			}
++			has_freshness_lifetime = TryParseNonNegativeSeconds(value, freshness_lifetime);
 +		}
 +	}
-+	if (!has_freshness_lifetime && headers.HasHeader("Expires") && headers.HasHeader("Date")) {
++	if (!has_freshness_lifetime && headers.HasHeader("Expires")) {
 +		timestamp_t expires;
-+		timestamp_t date;
-+		if (TryParseLastModifiedTime(headers.GetHeaderValue("Expires"), expires) &&
-+		    TryParseLastModifiedTime(headers.GetHeaderValue("Date"), date)) {
-+			freshness_lifetime = (expires.value - date.value) / Interval::MICROS_PER_SEC;
-+			has_freshness_lifetime = true;
++		if (TryParseLastModifiedTime(headers.GetHeaderValue("Expires"), expires)) {
++			timestamp_t reference_time;
++			bool has_reference_time = true;
++			if (headers.HasHeader("Date")) {
++				has_reference_time = TryParseLastModifiedTime(headers.GetHeaderValue("Date"), reference_time);
++			} else {
++				reference_time = Timestamp::GetCurrentTimestamp();
++			}
++			int64_t freshness_micros;
++			if (has_reference_time && TrySubtractOperator::Operation(expires, reference_time, freshness_micros)) {
++				freshness_lifetime = freshness_micros / Interval::MICROS_PER_SEC;
++				has_freshness_lifetime = true;
++			}
 +		}
 +	}
 +	if (!has_freshness_lifetime) {
@@ -102,48 +135,52 @@ index 0fc503a..e2d2de0 100644
  struct HTTPFileInfoParser {
  	static optional_idx TryParseContentRange(const HTTPHeaders &headers) {
  		if (!headers.HasHeader("Content-Range")) {
-@@ -675,6 +746,7 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
+@@ -675,6 +779,8 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
  	if (response.headers.HasHeader("ETag")) {
  		etag = response.headers.GetHeaderValue("ETag");
  	}
 +	cache_valid_until = HTTPFileSystem::ComputeCacheValidUntil(response.headers);
++	cache_immutable = HasImmutableCacheControl(response.headers);
  	if (request_session->Capture().snapshot->Params().s3_version_id_pinning &&
  	    response.headers.HasHeader("x-amz-version-id")) {
  		SetVersionId(response.headers.GetHeaderValue("x-amz-version-id"));
-@@ -716,6 +788,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
+@@ -716,6 +822,8 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
  	last_modified = cache_entry.last_modified;
  	length = cache_entry.length;
  	etag = cache_entry.etag;
 +	cache_valid_until = cache_entry.cache_valid_until;
++	cache_immutable = cache_entry.cache_immutable;
  	SetVersionId(cache_entry.version_id);
  
  	// TODO: handle properties
-@@ -726,6 +799,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
+@@ -726,6 +834,8 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
  	result.length = length;
  	result.last_modified = last_modified;
  	result.etag = etag;
 +	result.cache_valid_until = cache_valid_until;
++	result.cache_immutable = cache_immutable;
  	result.version_id = GetVersionId();
  	// TODO: handle properties
  	return result;
 diff --git a/src/include/http/http_metadata_cache.hpp b/src/include/http/http_metadata_cache.hpp
-index 2908a43..64bd2e8 100644
+index 2908a43..9e3ca4f 100644
 --- a/src/include/http/http_metadata_cache.hpp
 +++ b/src/include/http/http_metadata_cache.hpp
-@@ -19,6 +19,8 @@ struct HTTPMetadataCacheEntry {
+@@ -19,6 +19,9 @@ struct HTTPMetadataCacheEntry {
  	idx_t length;
  	timestamp_t last_modified;
  	string etag;
 +	//! Freshness deadline (inclusive); if unset (infinite), the server does not provide expiry information
 +	timestamp_t cache_valid_until = timestamp_t::infinity();
++	bool cache_immutable = false;
  	string version_id;
  	unordered_map<string, string> properties;
  };
 diff --git a/src/include/http/httpfs.hpp b/src/include/http/httpfs.hpp
-index 1764acc..3097fe4 100644
+index 1764acc..64986a2 100644
 --- a/src/include/http/httpfs.hpp
 +++ b/src/include/http/httpfs.hpp
-@@ -64,6 +64,10 @@ public:
+@@ -64,6 +64,12 @@ public:
  	idx_t length;
  	timestamp_t last_modified;
  	string etag;
@@ -151,20 +188,23 @@ index 1764acc..3097fe4 100644
 +	//! If unset (infinite), the server does not provide information on when cached data expires.
 +	//! Used to cache files that provide no validators (no ETag/Last-Modified).
 +	timestamp_t cache_valid_until = timestamp_t::infinity();
++	//! Whether Cache-Control declares the response immutable during its freshness lifetime.
++	bool cache_immutable = false;
  	bool force_full_download;
  	bool initialized = false;
  
-@@ -133,6 +137,9 @@ private:
+@@ -133,6 +139,10 @@ private:
  class HTTPFileSystem : public FileSystem {
  public:
  	static bool TryParseLastModifiedTime(const string &timestamp, timestamp_t &result);
 +	//! Compute the freshness deadline (inclusive) from HTTP caching headers (RFC 9111): Cache-Control max-age,
-+	//! falling back to Expires/Date, adjusted by the response's current age. Infinite if not provided.
++	//! falling back to Expires relative to Date (or receipt time when Date is absent), adjusted by the response's age.
++	//! Infinite if no freshness lifetime is provided.
 +	static timestamp_t ComputeCacheValidUntil(const HTTPHeaders &headers);
  
  	//! FileSystem overrides.
  	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override {
-@@ -155,6 +162,7 @@ public:
+@@ -155,6 +165,7 @@ public:
  	int64_t GetFileSize(FileHandle &handle) override;
  	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
  	string GetVersionTag(FileHandle &handle) override;

--- a/.github/patches/extensions/httpfs/0001-cache-metadata.patch
+++ b/.github/patches/extensions/httpfs/0001-cache-metadata.patch
@@ -1,11 +1,11 @@
-commit dbf1450f4db291d0ed8e05b0b2a7ae8a19de8a7d
+commit 2ed756997a07a99bd0061e4a545d9b66e8090c28
 Author: dentinyhao <dentinyhao@gmail.com>
 Date:   Tue Aug 4 02:50:57 2026 -0700
 
     Consider HTTP cache
 
 diff --git a/src/http/httpfs.cpp b/src/http/httpfs.cpp
-index 0fc503a..a13975b 100644
+index 0fc503a..4546969 100644
 --- a/src/http/httpfs.cpp
 +++ b/src/http/httpfs.cpp
 @@ -7,8 +7,13 @@
@@ -40,7 +40,7 @@ index 0fc503a..a13975b 100644
  bool HTTPFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
  	try {
  		auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_READ, opener);
-@@ -574,6 +590,88 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
+@@ -574,6 +590,105 @@ bool HTTPFileSystem::TryParseLastModifiedTime(const string &timestamp, timestamp
  	return true;
  }
  
@@ -48,10 +48,24 @@ index 0fc503a..a13975b 100644
 +	return TryCast::Operation<string_t, int64_t>(string_t(input), result) && result >= 0;
 +}
 +
-+timestamp_t HTTPFileSystem::ComputeCacheValidUntil(const HTTPHeaders &headers) {
++static bool HasCacheControlDirective(const HTTPHeaders &headers, const string &name) {
++	if (!headers.HasHeader("Cache-Control")) {
++		return false;
++	}
++	for (auto &directive : StringUtil::Split(headers.GetHeaderValue("Cache-Control"), ',')) {
++		StringUtil::Trim(directive);
++		const auto separator = directive.find('=');
++		const auto directive_name = separator == string::npos ? directive : directive.substr(0, separator);
++		if (StringUtil::CIEquals(directive_name, name)) {
++			return true;
++		}
++	}
++	return false;
++}
++
++optional<timestamp_t> HTTPFileSystem::ComputeCacheValidUntil(const HTTPHeaders &headers) {
 +	// Freshness lifetime in seconds (RFC 9111): Cache-Control max-age takes precedence over Expires
-+	// TODO: handle no-store/no-cache directives; note that this function is only consulted for responses
-+	// without validators (no ETag/Last-Modified), and infinity means no freshness is granted
++	// TODO: handle no-cache; unset means no freshness information, negative infinity means explicitly stale
 +	int64_t freshness_lifetime = 0;
 +	bool has_freshness_lifetime = false;
 +	bool has_max_age = false;
@@ -69,7 +83,7 @@ index 0fc503a..a13975b 100644
 +				continue;
 +			}
 +			if (has_max_age) {
-+				return timestamp_t::infinity();
++				return timestamp_t::ninfinity();
 +			}
 +			has_max_age = true;
 +			auto value = directive.substr(separator + 1);
@@ -78,7 +92,7 @@ index 0fc503a..a13975b 100644
 +				value = value.substr(1, value.size() - 2);
 +			}
 +			if (!TryParseNonNegativeSeconds(value, freshness_lifetime)) {
-+				return timestamp_t::infinity();
++				return timestamp_t::ninfinity();
 +			}
 +			has_freshness_lifetime = true;
 +		}
@@ -101,7 +115,10 @@ index 0fc503a..a13975b 100644
 +		}
 +	}
 +	if (!has_freshness_lifetime) {
-+		return timestamp_t::infinity();
++		if (has_max_age || headers.HasHeader("Expires")) {
++			return timestamp_t::ninfinity();
++		}
++		return nullopt;
 +	}
 +
 +	// The response may have already spent time in intermediate caches (RFC 9111 current age)
@@ -114,14 +131,14 @@ index 0fc503a..a13975b 100644
 +
 +	const int64_t remaining = freshness_lifetime - age;
 +	if (remaining <= 0) {
-+		return timestamp_t::infinity(); // Already stale: no freshness to grant
++		return timestamp_t::ninfinity();
 +	}
 +	// Absurd server-provided lifetimes that would overflow the deadline grant no freshness
 +	int64_t remaining_micros;
 +	int64_t deadline_micros;
 +	if (!TryMultiplyOperator::Operation(remaining, Interval::MICROS_PER_SEC, remaining_micros) ||
 +	    !TryAddOperator::Operation(Timestamp::GetCurrentTimestamp().value, remaining_micros, deadline_micros)) {
-+		return timestamp_t::infinity();
++		return timestamp_t::ninfinity();
 +	}
 +	return timestamp_t(deadline_micros);
 +}
@@ -129,15 +146,19 @@ index 0fc503a..a13975b 100644
  struct HTTPFileInfoParser {
  	static optional_idx TryParseContentRange(const HTTPHeaders &headers) {
  		if (!headers.HasHeader("Content-Range")) {
-@@ -675,6 +773,7 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
+@@ -675,6 +790,11 @@ void HTTPFileHandle::ApplyFileInfo(const HTTPResponse &response) {
  	if (response.headers.HasHeader("ETag")) {
  		etag = response.headers.GetHeaderValue("ETag");
  	}
 +	cache_valid_until = HTTPFileSystem::ComputeCacheValidUntil(response.headers);
++	cache_no_store = HasCacheControlDirective(response.headers, "no-store");
++	if (cache_no_store) {
++		cache_valid_until = timestamp_t::ninfinity();
++	}
  	if (request_session->Capture().snapshot->Params().s3_version_id_pinning &&
  	    response.headers.HasHeader("x-amz-version-id")) {
  		SetVersionId(response.headers.GetHeaderValue("x-amz-version-id"));
-@@ -716,6 +815,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
+@@ -716,6 +836,7 @@ void HTTPFileHandle::InitializeFromCacheEntry(const HTTPMetadataCacheEntry &cach
  	last_modified = cache_entry.last_modified;
  	length = cache_entry.length;
  	etag = cache_entry.etag;
@@ -145,7 +166,7 @@ index 0fc503a..a13975b 100644
  	SetVersionId(cache_entry.version_id);
  
  	// TODO: handle properties
-@@ -726,6 +826,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
+@@ -726,6 +847,7 @@ HTTPMetadataCacheEntry HTTPFileHandle::GetCacheEntry() const {
  	result.length = length;
  	result.last_modified = last_modified;
  	result.etag = etag;
@@ -153,46 +174,73 @@ index 0fc503a..a13975b 100644
  	result.version_id = GetVersionId();
  	// TODO: handle properties
  	return result;
+@@ -793,7 +915,7 @@ void HTTPFileHandle::InitializeFileInfo(HTTPFileSystem &hfs, optional_ptr<HTTPMe
+ 		if (should_full_download) {
+ 			length = hfs.FullDownload(*this, GetReadConfig(), should_write_cache)->GetSize();
+ 		}
+-		if (should_write_cache) {
++		if (should_write_cache && !cache_no_store) {
+ 			cache->Insert(path, GetCacheEntry());
+ 		}
+ 	}
 diff --git a/src/include/http/http_metadata_cache.hpp b/src/include/http/http_metadata_cache.hpp
-index 2908a43..64bd2e8 100644
+index 2908a43..0011db0 100644
 --- a/src/include/http/http_metadata_cache.hpp
 +++ b/src/include/http/http_metadata_cache.hpp
-@@ -19,6 +19,8 @@ struct HTTPMetadataCacheEntry {
+@@ -4,6 +4,7 @@
+ #include "duckdb/common/chrono.hpp"
+ #include "duckdb/common/list.hpp"
+ #include "duckdb/common/mutex.hpp"
++#include "duckdb/common/optional.hpp"
+ #include "duckdb/common/string.hpp"
+ #include "duckdb/common/types.hpp"
+ #include "duckdb/common/unordered_map.hpp"
+@@ -19,6 +20,8 @@ struct HTTPMetadataCacheEntry {
  	idx_t length;
  	timestamp_t last_modified;
  	string etag;
-+	//! Freshness deadline (inclusive); if unset (infinite), the server does not provide expiry information
-+	timestamp_t cache_valid_until = timestamp_t::infinity();
++	//! Freshness deadline (inclusive); unset means the server provides no freshness information.
++	optional<timestamp_t> cache_valid_until;
  	string version_id;
  	unordered_map<string, string> properties;
  };
 diff --git a/src/include/http/httpfs.hpp b/src/include/http/httpfs.hpp
-index 1764acc..d5fe6ae 100644
+index 1764acc..8b23ecf 100644
 --- a/src/include/http/httpfs.hpp
 +++ b/src/include/http/httpfs.hpp
-@@ -64,6 +64,10 @@ public:
+@@ -2,6 +2,7 @@
+ 
+ #include "duckdb/common/case_insensitive_map.hpp"
+ #include "duckdb/common/file_system.hpp"
++#include "duckdb/common/optional.hpp"
+ #include "http/http_state.hpp"
+ #include "duckdb/common/pair.hpp"
+ #include "duckdb/common/unordered_map.hpp"
+@@ -64,6 +65,12 @@ public:
  	idx_t length;
  	timestamp_t last_modified;
  	string etag;
 +	//! Freshness deadline (inclusive) derived from HTTP caching headers (Cache-Control/Expires).
-+	//! If unset (infinite), the server does not provide information on when cached data expires.
-+	//! Used to cache files that provide no validators (no ETag/Last-Modified).
-+	timestamp_t cache_valid_until = timestamp_t::infinity();
++	//! Unset means no freshness information; positive/negative infinity mean always valid/invalid.
++	//! Used to bound how long cached file data may be served.
++	optional<timestamp_t> cache_valid_until;
++	//! Whether the response includes Cache-Control: no-store.
++	bool cache_no_store = false;
  	bool force_full_download;
  	bool initialized = false;
  
-@@ -133,6 +137,10 @@ private:
+@@ -133,6 +140,10 @@ private:
  class HTTPFileSystem : public FileSystem {
  public:
  	static bool TryParseLastModifiedTime(const string &timestamp, timestamp_t &result);
 +	//! Compute the freshness deadline (inclusive) from HTTP caching headers (RFC 9111): Cache-Control max-age,
 +	//! falling back to Expires relative to Date (or receipt time when Date is absent), adjusted by the response's age.
-+	//! Infinite if no freshness lifetime is provided.
-+	static timestamp_t ComputeCacheValidUntil(const HTTPHeaders &headers);
++	//! Unset if no freshness lifetime is provided.
++	static optional<timestamp_t> ComputeCacheValidUntil(const HTTPHeaders &headers);
  
  	//! FileSystem overrides.
  	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override {
-@@ -155,6 +163,7 @@ public:
+@@ -155,6 +166,7 @@ public:
  	int64_t GetFileSize(FileHandle &handle) override;
  	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
  	string GetVersionTag(FileHandle &handle) override;

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -485,7 +485,6 @@ FileType FileSystem::GetFileType(FileHandle &handle) {
 }
 
 FileMetadata FileSystem::Stats(FileHandle &handle) {
-	// Synthesized from the individual accessors for file systems without a native stat call
 	FileMetadata metadata;
 	metadata.file_size = GetFileSize(handle);
 	metadata.last_modification_time = GetLastModifiedTime(handle);

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -485,7 +485,12 @@ FileType FileSystem::GetFileType(FileHandle &handle) {
 }
 
 FileMetadata FileSystem::Stats(FileHandle &handle) {
-	throw NotImplementedException("%s: Stats is not implemented!", GetName());
+	// Synthesized from the individual accessors for file systems without a native stat call
+	FileMetadata metadata;
+	metadata.file_size = GetFileSize(handle);
+	metadata.last_modification_time = GetLastModifiedTime(handle);
+	metadata.file_type = GetFileType(handle);
+	return metadata;
 }
 
 void FileSystem::Truncate(FileHandle &handle, int64_t new_size) {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -489,6 +489,7 @@ FileMetadata FileSystem::Stats(FileHandle &handle) {
 	metadata.file_size = GetFileSize(handle);
 	metadata.last_modification_time = GetLastModifiedTime(handle);
 	metadata.file_type = GetFileType(handle);
+	metadata.version_tag = GetVersionTag(handle);
 	return metadata;
 }
 

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -687,6 +687,7 @@ FileType LocalFileSystem::GetFileType(FileHandle &handle) {
 FileMetadata LocalFileSystem::Stats(FileHandle &handle) {
 	int fd = handle.Cast<UnixFileHandle>().fd;
 	auto file_metadata = StatsInternal(fd, handle.GetPath());
+	file_metadata.version_tag = VersionTagFromMetadata(file_metadata);
 	return file_metadata;
 }
 
@@ -1598,6 +1599,7 @@ FileType LocalFileSystem::GetFileType(FileHandle &handle) {
 FileMetadata LocalFileSystem::Stats(FileHandle &handle) {
 	HANDLE hFile = handle.Cast<WindowsFileHandle>().fd;
 	auto file_metadata = StatsInternal(hFile, handle.GetPath());
+	file_metadata.version_tag = VersionTagFromMetadata(file_metadata);
 	return file_metadata;
 }
 
@@ -1952,8 +1954,7 @@ void LocalFileSystem::FillFileOptions(const FileMetadata &file_metadata, unorder
 }
 
 string LocalFileSystem::GetVersionTag(FileHandle &handle) {
-	auto stats = handle.Stats();
-	return VersionTagFromMetadata(stats);
+	return handle.Stats().version_tag;
 }
 
 void LocalFileSystem::Seek(FileHandle &handle, idx_t location) {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -17,6 +17,7 @@
 #include "duckdb/common/file_buffer.hpp"
 #include "duckdb/common/file_open_flags.hpp"
 #include "duckdb/common/open_file_info.hpp"
+#include "duckdb/common/optional.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/string.hpp"
@@ -72,10 +73,9 @@ struct FileMetadata {
 	//! Optional: tag that uniquely identifies the version of the file (e.g., HTTP ETag).
 	//! Empty if the storage backend does not provide one.
 	string version_tag;
-	//! Optional: time until which (inclusive) cached data of the file may be served without revalidation,
-	//! e.g., derived from HTTP Cache-Control/Expires.
-	//! If unset (infinite), the storage backend does not provide information on when cached data expires.
-	timestamp_t cache_valid_until = timestamp_t::infinity();
+	//! Time until which (inclusive) cached data may be served without revalidation.
+	//! Unset means the backend provides no freshness information; infinities mean always valid/invalid.
+	optional<timestamp_t> cache_valid_until;
 
 	// A key-value pair of the extended file metadata, which could store any attributes.
 	unordered_map<string, Value> extended_file_info;

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -69,10 +69,12 @@ struct FileMetadata {
 	FileType file_type = FileType::FILE_TYPE_INVALID;
 	optional_idx device_id;
 	optional_idx file_id;
+	//! Optional: tag that uniquely identifies the version of the file (e.g., HTTP ETag).
+	//! Empty if the storage backend does not provide one.
+	string version_tag;
 	//! Optional: time until which cached data of the file may be served without revalidation,
 	//! e.g., derived from HTTP Cache-Control/Expires.
 	//! If unset (infinite), the storage backend does not provide information on when cached data expires.
-	//! Used by CachingFileSystem to cache files that have no version tag or last modified time.
 	timestamp_t cache_valid_until = timestamp_t::infinity();
 
 	// A key-value pair of the extended file metadata, which could store any attributes.

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -72,7 +72,7 @@ struct FileMetadata {
 	//! Optional: tag that uniquely identifies the version of the file (e.g., HTTP ETag).
 	//! Empty if the storage backend does not provide one.
 	string version_tag;
-	//! Optional: time until which cached data of the file may be served without revalidation,
+	//! Optional: time until which (inclusive) cached data of the file may be served without revalidation,
 	//! e.g., derived from HTTP Cache-Control/Expires.
 	//! If unset (infinite), the storage backend does not provide information on when cached data expires.
 	timestamp_t cache_valid_until = timestamp_t::infinity();

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -76,6 +76,8 @@ struct FileMetadata {
 	//! e.g., derived from HTTP Cache-Control/Expires.
 	//! If unset (infinite), the storage backend does not provide information on when cached data expires.
 	timestamp_t cache_valid_until = timestamp_t::infinity();
+	//! Whether the file is guaranteed not to change during its freshness lifetime.
+	bool cache_immutable = false;
 
 	// A key-value pair of the extended file metadata, which could store any attributes.
 	unordered_map<string, Value> extended_file_info;

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -69,6 +69,11 @@ struct FileMetadata {
 	FileType file_type = FileType::FILE_TYPE_INVALID;
 	optional_idx device_id;
 	optional_idx file_id;
+	//! Optional: time until which cached data of the file may be served without revalidation,
+	//! e.g., derived from HTTP Cache-Control/Expires.
+	//! If unset (infinite), the storage backend does not provide information on when cached data expires.
+	//! Used by CachingFileSystem to cache files that have no version tag or last modified time.
+	timestamp_t cache_valid_until = timestamp_t::infinity();
 
 	// A key-value pair of the extended file metadata, which could store any attributes.
 	unordered_map<string, Value> extended_file_info;

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -76,8 +76,6 @@ struct FileMetadata {
 	//! e.g., derived from HTTP Cache-Control/Expires.
 	//! If unset (infinite), the storage backend does not provide information on when cached data expires.
 	timestamp_t cache_valid_until = timestamp_t::infinity();
-	//! Whether the file is guaranteed not to change during its freshness lifetime.
-	bool cache_immutable = false;
 
 	// A key-value pair of the extended file metadata, which could store any attributes.
 	unordered_map<string, Value> extended_file_info;

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -76,6 +76,7 @@ enum class RequestType : uint8_t {
 };
 
 struct HTTPHeaders {
+	using header_values_t = vector<string>;
 	using header_map_t = case_insensitive_map_t<string>;
 
 public:
@@ -85,8 +86,12 @@ public:
 	DUCKDB_API ~HTTPHeaders();
 
 	void Insert(string key, string value);
+	//! Append another field line without combining its value.
+	void Append(string key, string value);
 	bool HasHeader(const string &key) const;
+	//! Return the first field value.
 	string GetHeaderValue(const string &key) const;
+	header_values_t GetHeaderValues(const string &key) const;
 
 	header_map_t::iterator begin() { // NOLINT: match stl API
 		return headers.begin();
@@ -112,6 +117,8 @@ public:
 
 private:
 	header_map_t headers;
+	//! HTTP responses can contain multiple field lines with the same name (i.e., Cache-Control).
+	case_insensitive_map_t<header_values_t> repeated_headers;
 };
 
 struct HTTPResponse {

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -117,8 +117,7 @@ private:
 	//! Last modified time and version tag (if FileHandle is opened)
 	timestamp_t last_modified;
 	string version_tag;
-	//! Freshness deadline for files without validators (if FileHandle is opened).
-	//! If unset (infinite), the storage backend does not provide expiry information.
+	//! Freshness deadline for files without extra validation.
 	timestamp_t cache_valid_until = timestamp_t::infinity();
 
 	//! Current position (if non-seeking reads)

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -114,8 +114,9 @@ private:
 	annotated_mutex file_handle_mutex;
 	//! File handle for the internal filesystem.
 	shared_ptr<FileHandle> file_handle;
-	//! Last modified time and version tag (if FileHandle is opened)
-	timestamp_t last_modified;
+	//! Metadata snapshot taken with a single Stats call when the file handle is opened.
+	idx_t file_size = 0;
+	timestamp_t last_modified = timestamp_t(0);
 	string version_tag;
 	//! Freshness deadline for files without extra validation.
 	timestamp_t cache_valid_until = timestamp_t::infinity();

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -87,6 +87,8 @@ private:
 	bool StripForceFullDownloadIfPresent();
 	//! Refresh the cached file if the global cache state has changed.
 	shared_ptr<CachedFile> EnsureCachedFileCurrent();
+	//! Whether cached metadata can be used without reopening the file for validation.
+	bool HasFreshImmutableMetadata();
 	//! Whether validation metadata permits using cached blocks.
 	bool CanUseCache();
 	//! Record a timed read of a local file into the throughput estimate

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -115,6 +115,9 @@ private:
 	//! Last modified time and version tag (if FileHandle is opened)
 	timestamp_t last_modified;
 	string version_tag;
+	//! Freshness deadline for files without validators (if FileHandle is opened).
+	//! If unset (infinite), the storage backend does not provide expiry information.
+	timestamp_t cache_valid_until = timestamp_t::infinity();
 
 	//! Current position (if non-seeking reads)
 	idx_t position;

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -87,8 +87,6 @@ private:
 	bool StripForceFullDownloadIfPresent();
 	//! Refresh the cached file if the global cache state has changed.
 	shared_ptr<CachedFile> EnsureCachedFileCurrent();
-	//! Whether cached metadata can be used without reopening the file for validation.
-	bool HasFreshImmutableMetadata();
 	//! Whether validation metadata permits using cached blocks.
 	bool CanUseCache();
 	//! Record a timed read of a local file into the throughput estimate

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -115,11 +115,7 @@ private:
 	//! File handle for the internal filesystem.
 	shared_ptr<FileHandle> file_handle;
 	//! Metadata snapshot taken with a single Stats call when the file handle is opened.
-	idx_t file_size = 0;
-	timestamp_t last_modified = timestamp_t(0);
-	string version_tag;
-	//! Freshness deadline for files without extra validation.
-	timestamp_t cache_valid_until = timestamp_t::infinity();
+	CacheValidationInfo validation_info;
 
 	//! Current position (if non-seeking reads)
 	idx_t position;

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system.hpp
@@ -87,6 +87,8 @@ private:
 	bool StripForceFullDownloadIfPresent();
 	//! Refresh the cached file if the global cache state has changed.
 	shared_ptr<CachedFile> EnsureCachedFileCurrent();
+	//! Whether validation metadata permits using cached blocks.
+	bool CanUseCache();
 	//! Record a timed read of a local file into the throughput estimate
 	void RecordReadThroughput(double total_seconds, idx_t bytes);
 

--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -40,8 +40,6 @@ struct CacheValidationInfo {
 	//! The deadline is inclusive: cached data may be served while the current time is at or before it.
 	//! If unset (infinite), the storage backend does not provide expiry information.
 	timestamp_t cache_valid_until = timestamp_t::infinity();
-	//! Whether the file is guaranteed not to change during its freshness lifetime.
-	bool immutable = false;
 	idx_t file_size = 0;
 };
 

--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -40,6 +40,8 @@ struct CacheValidationInfo {
 	//! The deadline is inclusive: cached data may be served while the current time is at or before it.
 	//! If unset (infinite), the storage backend does not provide expiry information.
 	timestamp_t cache_valid_until = timestamp_t::infinity();
+	//! Whether the file is guaranteed not to change during its freshness lifetime.
+	bool immutable = false;
 	idx_t file_size = 0;
 };
 

--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -30,6 +30,18 @@ class ClientContext;
 class DatabaseInstance;
 class BufferManager;
 
+//! File metadata used to determine whether cached file data is still valid.
+struct CacheValidationInfo {
+	//! Version tag (e.g., HTTP ETag). Empty if the storage backend does not provide one.
+	string version_tag;
+	//! Last modified time. Zero/non-finite if the storage backend does not provide one.
+	timestamp_t last_modified = timestamp_t(0);
+	//! Freshness deadline for files without validators (e.g., HTTP Cache-Control).
+	//! If unset (infinite), the storage backend does not provide expiry information.
+	timestamp_t cache_valid_until = timestamp_t::infinity();
+	idx_t file_size = 0;
+};
+
 class ExternalFileCache {
 public:
 	//! Get the cache block size for a given file path.
@@ -43,10 +55,6 @@ public:
 		CachedFile(string path_p, idx_t generation_p);
 
 	public:
-		//! Whether the CachedFile is still valid given the current modified/version tag/file size
-		bool IsValid(bool validate, const string &current_version_tag, timestamp_t current_last_modified,
-		             idx_t current_file_size);
-
 		const string path;
 		const idx_t generation;
 
@@ -57,12 +65,8 @@ public:
 		unordered_map<idx_t, shared_ptr<CacheBlock>> blocks DUCKDB_GUARDED_BY(map_lock);
 
 		mutable annotated_mutex meta_lock;
-		idx_t file_size DUCKDB_GUARDED_BY(meta_lock) = 0;
-		timestamp_t last_modified DUCKDB_GUARDED_BY(meta_lock) = timestamp_t(0);
-		string version_tag DUCKDB_GUARDED_BY(meta_lock);
-		//! Freshness deadline for files without validators (e.g., HTTP Cache-Control).
-		//! If unset (infinite), the storage backend does not provide expiry information.
-		timestamp_t cache_valid_until DUCKDB_GUARDED_BY(meta_lock) = timestamp_t::infinity();
+		//! Metadata for validating the cached blocks against the current file.
+		CacheValidationInfo validation_info DUCKDB_GUARDED_BY(meta_lock);
 		bool can_seek DUCKDB_GUARDED_BY(meta_lock) = false;
 		bool on_disk_file DUCKDB_GUARDED_BY(meta_lock) = false;
 	};
@@ -95,15 +99,10 @@ public:
 	DUCKDB_API static bool IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
 	                               const string &current_version_tag, timestamp_t current_last_modified);
 	//! Variant that can also validate files without validators using the freshness deadline and file size
-	DUCKDB_API static bool IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
-	                               timestamp_t cached_valid_until, idx_t cached_file_size,
-	                               const string &current_version_tag, timestamp_t current_last_modified,
-	                               idx_t current_file_size);
-	//! Whether the last modified timestamp is usable as a cache validator
-	//! (some storage backends do not provide it)
-	DUCKDB_API static bool HasUsableLastModified(timestamp_t last_modified);
+	DUCKDB_API static bool IsValid(bool validate, const CacheValidationInfo &cached,
+	                               const CacheValidationInfo &current);
 	//! Whether the version tag/last modified time provide any cache validation metadata
-	DUCKDB_API static bool HasValidationMetadata(const string &version_tag, timestamp_t last_modified);
+	DUCKDB_API static bool HasValidationMetadata(const CacheValidationInfo &info);
 
 private:
 	class ExternalFileCacheObjectCacheEntry;

--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/common/optional.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/shared_ptr_ipp.hpp"
 #include "duckdb/common/string.hpp"
@@ -32,14 +33,17 @@ class BufferManager;
 
 //! File metadata used to determine whether cached file data is still valid.
 struct CacheValidationInfo {
+	bool IsExplicitlyStale() const;
+
 	//! Version tag (e.g., HTTP ETag). Empty if the storage backend does not provide one.
 	string version_tag;
 	//! Last modified time. Zero/non-finite if the storage backend does not provide one.
 	timestamp_t last_modified = timestamp_t(0);
 	//! Freshness deadline for files without validators (e.g., HTTP Cache-Control).
 	//! The deadline is inclusive: cached data may be served while the current time is at or before it.
-	//! If unset (infinite), the storage backend does not provide expiry information.
-	timestamp_t cache_valid_until = timestamp_t::infinity();
+	//! Unset means the storage backend does not provide expiry information.
+	//! Positive/negative infinity mean always valid/invalid.
+	optional<timestamp_t> cache_valid_until;
 	idx_t file_size = 0;
 };
 

--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -43,8 +43,9 @@ public:
 		CachedFile(string path_p, idx_t generation_p);
 
 	public:
-		//! Whether the CachedFile is still valid given the current modified/version tag
-		bool IsValid(bool validate, const string &current_version_tag, timestamp_t current_last_modified);
+		//! Whether the CachedFile is still valid given the current modified/version tag/file size
+		bool IsValid(bool validate, const string &current_version_tag, timestamp_t current_last_modified,
+		             idx_t current_file_size);
 
 		const string path;
 		const idx_t generation;
@@ -59,6 +60,9 @@ public:
 		idx_t file_size DUCKDB_GUARDED_BY(meta_lock) = 0;
 		timestamp_t last_modified DUCKDB_GUARDED_BY(meta_lock) = timestamp_t(0);
 		string version_tag DUCKDB_GUARDED_BY(meta_lock);
+		//! Freshness deadline for files without validators (e.g., HTTP Cache-Control).
+		//! If unset (infinite), the storage backend does not provide expiry information.
+		timestamp_t cache_valid_until DUCKDB_GUARDED_BY(meta_lock) = timestamp_t::infinity();
 		bool can_seek DUCKDB_GUARDED_BY(meta_lock) = false;
 		bool on_disk_file DUCKDB_GUARDED_BY(meta_lock) = false;
 	};
@@ -87,8 +91,19 @@ public:
 	//! When caching is disabled, returns a transient CachedFile that is not tracked in the cached file map.
 	shared_ptr<CachedFile> GetOrCreateCachedFile(const string &path);
 
+	//! Validator-only variant (version tag/last modified), e.g., used by the Parquet metadata cache
 	DUCKDB_API static bool IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
 	                               const string &current_version_tag, timestamp_t current_last_modified);
+	//! Variant that can also validate files without validators using the freshness deadline and file size
+	DUCKDB_API static bool IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
+	                               timestamp_t cached_valid_until, idx_t cached_file_size,
+	                               const string &current_version_tag, timestamp_t current_last_modified,
+	                               idx_t current_file_size);
+	//! Whether the last modified timestamp is usable as a cache validator
+	//! (some storage backends do not provide it)
+	DUCKDB_API static bool HasUsableLastModified(timestamp_t last_modified);
+	//! Whether the version tag/last modified time provide any cache validation metadata
+	DUCKDB_API static bool HasValidationMetadata(const string &version_tag, timestamp_t last_modified);
 
 private:
 	class ExternalFileCacheObjectCacheEntry;

--- a/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache/external_file_cache.hpp
@@ -37,6 +37,7 @@ struct CacheValidationInfo {
 	//! Last modified time. Zero/non-finite if the storage backend does not provide one.
 	timestamp_t last_modified = timestamp_t(0);
 	//! Freshness deadline for files without validators (e.g., HTTP Cache-Control).
+	//! The deadline is inclusive: cached data may be served while the current time is at or before it.
 	//! If unset (infinite), the storage backend does not provide expiry information.
 	timestamp_t cache_valid_until = timestamp_t::infinity();
 	idx_t file_size = 0;
@@ -95,7 +96,6 @@ public:
 	//! When caching is disabled, returns a transient CachedFile that is not tracked in the cached file map.
 	shared_ptr<CachedFile> GetOrCreateCachedFile(const string &path);
 
-	//! Validator-only variant (version tag/last modified), e.g., used by the Parquet metadata cache
 	DUCKDB_API static bool IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
 	                               const string &current_version_tag, timestamp_t current_last_modified);
 	//! Variant that can also validate files without validators using the freshness deadline and file size

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -44,6 +44,20 @@ void HTTPHeaders::Insert(string key, string value) {
 	headers.insert(make_pair(std::move(key), std::move(value)));
 }
 
+void HTTPHeaders::Append(string key, string value) {
+	auto entry = headers.find(key);
+	if (entry == headers.end()) {
+		headers.insert(make_pair(std::move(key), std::move(value)));
+		return;
+	}
+	auto repeated_entry = repeated_headers.find(key);
+	if (repeated_entry == repeated_headers.end()) {
+		repeated_headers.insert(make_pair(std::move(key), header_values_t {entry->second, std::move(value)}));
+	} else {
+		repeated_entry->second.push_back(std::move(value));
+	}
+}
+
 bool HTTPHeaders::HasHeader(const string &key) const {
 	return headers.find(key) != headers.end();
 }
@@ -56,6 +70,14 @@ string HTTPHeaders::GetHeaderValue(const string &key) const {
 	return entry->second;
 }
 
+HTTPHeaders::header_values_t HTTPHeaders::GetHeaderValues(const string &key) const {
+	auto repeated_entry = repeated_headers.find(key);
+	if (repeated_entry != repeated_headers.end()) {
+		return repeated_entry->second;
+	}
+	return {GetHeaderValue(key)};
+}
+
 #ifndef DUCKDB_DISABLE_BUILTIN_HTTPLIB
 unique_ptr<HTTPResponse> TransformResponse(duckdb_httplib::Result &res) {
 	auto status_code = HTTPUtil::ToStatusCode(res ? res->status : 0);
@@ -65,7 +87,7 @@ unique_ptr<HTTPResponse> TransformResponse(duckdb_httplib::Result &res) {
 		result->body = response.body;
 		result->reason = response.reason;
 		for (auto &entry : response.headers) {
-			result->headers.Insert(entry.first, entry.second);
+			result->headers.Append(entry.first, entry.second);
 		}
 	} else {
 		result->request_error = to_string(res.error());
@@ -242,7 +264,7 @@ private:
 		result->body = response.body;
 		result->reason = response.reason;
 		for (auto &entry : response.headers) {
-			result->headers.Insert(entry.first, entry.second);
+			result->headers.Append(entry.first, entry.second);
 		}
 		return result;
 	}

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -197,6 +197,14 @@ shared_ptr<CachingFileHandle::CachedFile> CachingFileHandle::EnsureCachedFileCur
 	return current_cached_file;
 }
 
+bool CachingFileHandle::HasFreshImmutableMetadata() {
+	auto current_cached_file = EnsureCachedFileCurrent();
+	annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
+	const auto &info = current_cached_file->validation_info;
+	return info.immutable && info.cache_valid_until.IsFinite() &&
+	       Timestamp::GetCurrentTimestamp() <= info.cache_valid_until;
+}
+
 bool CachingFileHandle::CanUseCache() {
 	if (!Validate()) {
 		return true;
@@ -223,8 +231,10 @@ CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &ca
           ExternalFileCacheUtil::GetCacheValidationMode(path_p, context.GetClientContext(), caching_file_system_p.db)),
       cached_file(nullptr), position(0) {
 	cached_file = external_file_cache.GetOrCreateCachedFile(path_p.path);
-	if (!external_file_cache.IsEnabled() || Validate()) {
-		// If caching is disabled, or if we must validate cache entries, we always have to open the file
+	const bool should_validate = Validate();
+	const bool skip_validation = should_validate && HasFreshImmutableMetadata();
+	if (!external_file_cache.IsEnabled() || (should_validate && !skip_validation)) {
+		// Open the file unless a fresh immutable cache entry can satisfy reads without revalidation.
 		GetFileHandle();
 		return;
 	}
@@ -263,6 +273,7 @@ shared_ptr<FileHandle> CachingFileHandle::GetFileHandle() {
 	validation_info.last_modified = stats.last_modification_time;
 	validation_info.cache_valid_until = stats.cache_valid_until;
 	validation_info.version_tag = std::move(stats.version_tag);
+	validation_info.immutable = stats.cache_immutable;
 
 	{
 		annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);
@@ -394,7 +405,7 @@ string CachingFileHandle::GetPath() const {
 }
 
 idx_t CachingFileHandle::GetFileSize() {
-	if (!Validate()) {
+	if (!Validate() || HasFreshImmutableMetadata()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->validation_info.file_size;
@@ -405,7 +416,7 @@ idx_t CachingFileHandle::GetFileSize() {
 }
 
 timestamp_t CachingFileHandle::GetLastModifiedTime() {
-	if (!Validate()) {
+	if (!Validate() || HasFreshImmutableMetadata()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->validation_info.last_modified;
@@ -416,7 +427,7 @@ timestamp_t CachingFileHandle::GetLastModifiedTime() {
 }
 
 string CachingFileHandle::GetVersionTag() {
-	if (!Validate()) {
+	if (!Validate() || HasFreshImmutableMetadata()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->validation_info.version_tag;
@@ -444,7 +455,7 @@ bool CachingFileHandle::Validate() const {
 }
 
 bool CachingFileHandle::CanSeek() {
-	if (!Validate()) {
+	if (!Validate() || HasFreshImmutableMetadata()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->can_seek;
@@ -457,7 +468,7 @@ bool CachingFileHandle::IsRemoteFile() const {
 }
 
 bool CachingFileHandle::OnDiskFile() {
-	if (!Validate()) {
+	if (!Validate() || HasFreshImmutableMetadata()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->on_disk_file;

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -258,11 +258,11 @@ shared_ptr<FileHandle> CachingFileHandle::GetFileHandle() {
 	auto internal_flags = flags | FileFlags::FILE_FLAGS_PARALLEL_ACCESS;
 	file_handle = caching_file_system.file_system.OpenFile(path, internal_flags, opener);
 	// Snapshot the metadata with a single Stats call, avoiding repeated metadata lookups (e.g., fstat)
-	const auto stats = caching_file_system.file_system.Stats(*file_handle);
+	auto stats = caching_file_system.file_system.Stats(*file_handle);
 	validation_info.file_size = NumericCast<idx_t>(stats.file_size);
 	validation_info.last_modified = stats.last_modification_time;
 	validation_info.cache_valid_until = stats.cache_valid_until;
-	validation_info.version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
+	validation_info.version_tag = std::move(stats.version_tag);
 
 	{
 		annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -254,17 +254,18 @@ shared_ptr<FileHandle> CachingFileHandle::GetFileHandle() {
 		const bool first_access = (cached_file->file_size == 0);
 		if (first_access || Validate()) {
 			const idx_t current_file_size = file_handle->GetFileSize();
-			if (!ExternalFileCache::IsValid(Validate(), cached_file->version_tag, cached_file->last_modified,
-			                                cached_file->cache_valid_until, cached_file->file_size, version_tag,
-			                                last_modified, current_file_size)) {
+			const bool cache_is_valid = ExternalFileCache::IsValid(
+			    Validate(), cached_file->version_tag, cached_file->last_modified, cached_file->cache_valid_until,
+			    cached_file->file_size, version_tag, last_modified, current_file_size);
+			if (!cache_is_valid) {
 				annotated_lock_guard<annotated_mutex> map_guard(cached_file->map_lock);
 				cached_file->blocks.clear();
 				cached_file->cached_block_size.SetInvalid();
+				cached_file->cache_valid_until = cache_valid_until;
 			}
 			cached_file->file_size = current_file_size;
 			cached_file->last_modified = last_modified;
 			cached_file->version_tag = version_tag;
-			cached_file->cache_valid_until = cache_valid_until;
 			cached_file->can_seek = file_handle->CanSeek();
 			cached_file->on_disk_file = file_handle->OnDiskFile();
 		}

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -212,7 +212,7 @@ bool CachingFileHandle::CanUseCache() {
 
 	annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 	return current_cached_file->cache_valid_until.IsFinite() &&
-	       Timestamp::GetCurrentTimestamp() < current_cached_file->cache_valid_until;
+	       Timestamp::GetCurrentTimestamp() <= current_cached_file->cache_valid_until;
 }
 
 CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system_p,

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -204,14 +204,14 @@ bool CachingFileHandle::CanUseCache() {
 	auto current_cached_file = EnsureCachedFileCurrent();
 	{
 		const annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
-		if (ExternalFileCache::HasValidationMetadata(version_tag, last_modified)) {
+		if (ExternalFileCache::HasValidationMetadata(validation_info)) {
 			return true;
 		}
 	}
 
 	annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
-	return current_cached_file->cache_valid_until.IsFinite() &&
-	       Timestamp::GetCurrentTimestamp() <= current_cached_file->cache_valid_until;
+	return current_cached_file->validation_info.cache_valid_until.IsFinite() &&
+	       Timestamp::GetCurrentTimestamp() <= current_cached_file->validation_info.cache_valid_until;
 }
 
 CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system_p,
@@ -258,28 +258,28 @@ shared_ptr<FileHandle> CachingFileHandle::GetFileHandle() {
 	auto internal_flags = flags | FileFlags::FILE_FLAGS_PARALLEL_ACCESS;
 	file_handle = caching_file_system.file_system.OpenFile(path, internal_flags, opener);
 	// Snapshot the metadata with a single Stats call, avoiding repeated metadata lookups (e.g., fstat)
-	const auto metadata = caching_file_system.file_system.Stats(*file_handle);
-	file_size = NumericCast<idx_t>(metadata.file_size);
-	last_modified = metadata.last_modification_time;
-	cache_valid_until = metadata.cache_valid_until;
-	version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
+	const auto stats = caching_file_system.file_system.Stats(*file_handle);
+	validation_info.file_size = NumericCast<idx_t>(stats.file_size);
+	validation_info.last_modified = stats.last_modification_time;
+	validation_info.cache_valid_until = stats.cache_valid_until;
+	validation_info.version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
 
 	{
 		annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);
-		const bool first_access = (cached_file->file_size == 0);
+		const bool first_access = (cached_file->validation_info.file_size == 0);
 		if (first_access || Validate()) {
-			const bool cache_is_valid = ExternalFileCache::IsValid(
-			    Validate(), cached_file->version_tag, cached_file->last_modified, cached_file->cache_valid_until,
-			    cached_file->file_size, version_tag, last_modified, file_size);
+			const bool cache_is_valid =
+			    ExternalFileCache::IsValid(Validate(), cached_file->validation_info, validation_info);
 			if (!cache_is_valid) {
 				annotated_lock_guard<annotated_mutex> map_guard(cached_file->map_lock);
 				cached_file->blocks.clear();
 				cached_file->cached_block_size.SetInvalid();
-				cached_file->cache_valid_until = cache_valid_until;
 			}
-			cached_file->file_size = file_size;
-			cached_file->last_modified = last_modified;
-			cached_file->version_tag = version_tag;
+			// The freshness deadline is only adopted when the entry is (re)initialized, not refreshed while valid
+			const auto valid_until =
+			    cache_is_valid ? cached_file->validation_info.cache_valid_until : validation_info.cache_valid_until;
+			cached_file->validation_info = validation_info;
+			cached_file->validation_info.cache_valid_until = valid_until;
 			cached_file->can_seek = file_handle->CanSeek();
 			cached_file->on_disk_file = file_handle->OnDiskFile();
 		}
@@ -348,19 +348,13 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 
 	// After all tasks complete, check if the cache was invalidated by another thread.
 	if (Validate()) {
-		string current_version_tag;
-		timestamp_t current_last_modified;
-		idx_t current_file_size = 0;
+		CacheValidationInfo current_validation_info;
 		{
 			const annotated_lock_guard<annotated_mutex> file_handle_guard(file_handle_mutex);
-			current_version_tag = version_tag;
-			current_last_modified = last_modified;
-			current_file_size = file_size;
+			current_validation_info = validation_info;
 		}
 		const annotated_lock_guard<annotated_mutex> meta_guard(current_cached_file->meta_lock);
-		if (!ExternalFileCache::IsValid(true, current_cached_file->version_tag, current_cached_file->last_modified,
-		                                current_cached_file->cache_valid_until, current_cached_file->file_size,
-		                                current_version_tag, current_last_modified, current_file_size)) {
+		if (!ExternalFileCache::IsValid(true, current_cached_file->validation_info, current_validation_info)) {
 			for (auto &block : blocks) {
 				block->Reinit();
 			}
@@ -403,33 +397,33 @@ idx_t CachingFileHandle::GetFileSize() {
 	if (!Validate()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
-		return current_cached_file->file_size;
+		return current_cached_file->validation_info.file_size;
 	}
 	auto file_handle = GetFileHandle();
 	annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
-	return file_size;
+	return validation_info.file_size;
 }
 
 timestamp_t CachingFileHandle::GetLastModifiedTime() {
 	if (!Validate()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
-		return current_cached_file->last_modified;
+		return current_cached_file->validation_info.last_modified;
 	}
 	auto file_handle = GetFileHandle();
 	annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
-	return last_modified;
+	return validation_info.last_modified;
 }
 
 string CachingFileHandle::GetVersionTag() {
 	if (!Validate()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
-		return current_cached_file->version_tag;
+		return current_cached_file->validation_info.version_tag;
 	}
 	auto file_handle = GetFileHandle();
 	annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
-	return version_tag;
+	return validation_info.version_tag;
 }
 
 bool CachingFileHandle::Validate() const {

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -243,20 +243,28 @@ shared_ptr<FileHandle> CachingFileHandle::GetFileHandle() {
 	file_handle = caching_file_system.file_system.OpenFile(path, internal_flags, opener);
 	last_modified = caching_file_system.file_system.GetLastModifiedTime(*file_handle);
 	version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
+	cache_valid_until = timestamp_t::infinity();
+	if (!ExternalFileCache::HasValidationMetadata(version_tag, last_modified)) {
+		// No validators: get the freshness deadline (e.g., HTTP Cache-Control) so we can cache the file anyway
+		cache_valid_until = caching_file_system.file_system.Stats(*file_handle).cache_valid_until;
+	}
 
 	{
 		annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);
 		const bool first_access = (cached_file->file_size == 0);
 		if (first_access || Validate()) {
+			const idx_t current_file_size = file_handle->GetFileSize();
 			if (!ExternalFileCache::IsValid(Validate(), cached_file->version_tag, cached_file->last_modified,
-			                                version_tag, last_modified)) {
+			                                cached_file->cache_valid_until, cached_file->file_size, version_tag,
+			                                last_modified, current_file_size)) {
 				annotated_lock_guard<annotated_mutex> map_guard(cached_file->map_lock);
 				cached_file->blocks.clear();
 				cached_file->cached_block_size.SetInvalid();
 			}
-			cached_file->file_size = file_handle->GetFileSize();
+			cached_file->file_size = current_file_size;
 			cached_file->last_modified = last_modified;
 			cached_file->version_tag = version_tag;
+			cached_file->cache_valid_until = cache_valid_until;
 			cached_file->can_seek = file_handle->CanSeek();
 			cached_file->on_disk_file = file_handle->OnDiskFile();
 		}
@@ -273,14 +281,15 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 		return FileBufferHandleGroup();
 	}
 
-	// Only cache when file metadata is available.
-	bool no_validation_metadata = false;
+	// Only cache when file validation metadata or a freshness deadline is available.
+	bool not_cacheable = false;
 	if (Validate()) {
 		annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
-		no_validation_metadata = version_tag.empty() && (!last_modified.IsFinite() || last_modified == timestamp_t(0));
+		not_cacheable =
+		    !ExternalFileCache::HasValidationMetadata(version_tag, last_modified) && !cache_valid_until.IsFinite();
 	}
 
-	if (!external_file_cache.IsEnabled() || !external_file_cache.ShouldCacheFile(path.path) || no_validation_metadata) {
+	if (!external_file_cache.IsEnabled() || !external_file_cache.ShouldCacheFile(path.path) || not_cacheable) {
 		auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
 		ReadAndRecord(context, buf.GetDataMutable(), nr_bytes, location);
 		vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
@@ -339,9 +348,11 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 			current_version_tag = version_tag;
 			current_last_modified = last_modified;
 		}
+		const idx_t current_file_size = GetFileSize();
 		const annotated_lock_guard<annotated_mutex> meta_guard(current_cached_file->meta_lock);
 		if (!ExternalFileCache::IsValid(true, current_cached_file->version_tag, current_cached_file->last_modified,
-		                                current_version_tag, current_last_modified)) {
+		                                current_cached_file->cache_valid_until, current_cached_file->file_size,
+		                                current_version_tag, current_last_modified, current_file_size)) {
 			for (auto &block : blocks) {
 				block->Reinit();
 			}
@@ -352,16 +363,17 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 }
 
 FileBufferHandleGroup CachingFileHandle::Read(idx_t &nr_bytes) {
-	// Only cache when file metadata is available.
-	bool no_validation_metadata = false;
+	// Only cache when file validation metadata or a freshness deadline is available.
+	bool not_cacheable = false;
 	if (Validate()) {
 		annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
-		no_validation_metadata = version_tag.empty() && (!last_modified.IsFinite() || last_modified == timestamp_t(0));
+		not_cacheable =
+		    !ExternalFileCache::HasValidationMetadata(version_tag, last_modified) && !cache_valid_until.IsFinite();
 	}
 
 	// If we can't seek, we can't use the cache for these calls,
 	// because we won't be able to seek over any parts we skipped by reading from the cache
-	if (!external_file_cache.IsEnabled() || !CanSeek() || no_validation_metadata) {
+	if (!external_file_cache.IsEnabled() || !CanSeek() || not_cacheable) {
 		auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
 		auto file_handle = GetFileHandle();
 		nr_bytes = NumericCast<idx_t>(file_handle->Read(context, buf.GetDataMutable(), nr_bytes));

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -198,6 +198,23 @@ shared_ptr<CachingFileHandle::CachedFile> CachingFileHandle::EnsureCachedFileCur
 	return current_cached_file;
 }
 
+bool CachingFileHandle::CanUseCache() {
+	if (!Validate()) {
+		return true;
+	}
+	auto current_cached_file = EnsureCachedFileCurrent();
+	{
+		const annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
+		if (ExternalFileCache::HasValidationMetadata(version_tag, last_modified)) {
+			return true;
+		}
+	}
+
+	annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
+	return current_cached_file->cache_valid_until.IsFinite() &&
+	       Timestamp::GetCurrentTimestamp() < current_cached_file->cache_valid_until;
+}
+
 CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system_p,
                                      const OpenFileInfo &path_p, FileOpenFlags flags_p,
                                      optional_ptr<FileOpener> opener_p)
@@ -282,15 +299,7 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 		return FileBufferHandleGroup();
 	}
 
-	// Only cache when file validation metadata or a freshness deadline is available.
-	bool not_cacheable = false;
-	if (Validate()) {
-		annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
-		not_cacheable =
-		    !ExternalFileCache::HasValidationMetadata(version_tag, last_modified) && !cache_valid_until.IsFinite();
-	}
-
-	if (!external_file_cache.IsEnabled() || !external_file_cache.ShouldCacheFile(path.path) || not_cacheable) {
+	if (!external_file_cache.IsEnabled() || !external_file_cache.ShouldCacheFile(path.path) || !CanUseCache()) {
 		auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
 		ReadAndRecord(context, buf.GetDataMutable(), nr_bytes, location);
 		vector<FileBufferHandleGroup::MemoryHandle> mem_handles;
@@ -364,17 +373,9 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 }
 
 FileBufferHandleGroup CachingFileHandle::Read(idx_t &nr_bytes) {
-	// Only cache when file validation metadata or a freshness deadline is available.
-	bool not_cacheable = false;
-	if (Validate()) {
-		annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
-		not_cacheable =
-		    !ExternalFileCache::HasValidationMetadata(version_tag, last_modified) && !cache_valid_until.IsFinite();
-	}
-
 	// If we can't seek, we can't use the cache for these calls,
 	// because we won't be able to seek over any parts we skipped by reading from the cache
-	if (!external_file_cache.IsEnabled() || !CanSeek() || not_cacheable) {
+	if (!external_file_cache.IsEnabled() || !CanSeek() || !CanUseCache()) {
 		auto buf = AllocateUncachedReadBuffer(external_file_cache.GetBufferManager(), nr_bytes);
 		auto file_handle = GetFileHandle();
 		nr_bytes = NumericCast<idx_t>(file_handle->Read(context, buf.GetDataMutable(), nr_bytes));

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -198,20 +198,24 @@ shared_ptr<CachingFileHandle::CachedFile> CachingFileHandle::EnsureCachedFileCur
 }
 
 bool CachingFileHandle::CanUseCache() {
-	if (!Validate()) {
-		return true;
-	}
 	auto current_cached_file = EnsureCachedFileCurrent();
+	if (!Validate()) {
+		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
+		const auto &valid_until = current_cached_file->validation_info.cache_valid_until;
+		return !valid_until || Timestamp::GetCurrentTimestamp() <= *valid_until;
+	}
+	bool has_validation_metadata;
 	{
 		const annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
-		if (ExternalFileCache::HasValidationMetadata(validation_info)) {
-			return true;
-		}
+		has_validation_metadata = ExternalFileCache::HasValidationMetadata(validation_info);
 	}
 
 	annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
-	return current_cached_file->validation_info.cache_valid_until.IsFinite() &&
-	       Timestamp::GetCurrentTimestamp() <= current_cached_file->validation_info.cache_valid_until;
+	const auto &cached_validation_info = current_cached_file->validation_info;
+	if (!cached_validation_info.cache_valid_until) {
+		return has_validation_metadata;
+	}
+	return Timestamp::GetCurrentTimestamp() <= *cached_validation_info.cache_valid_until;
 }
 
 CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system_p,
@@ -275,9 +279,10 @@ shared_ptr<FileHandle> CachingFileHandle::GetFileHandle() {
 				cached_file->blocks.clear();
 				cached_file->cached_block_size.SetInvalid();
 			}
-			// The freshness deadline is only adopted when the entry is (re)initialized, not refreshed while valid
-			const auto valid_until =
-			    cache_is_valid ? cached_file->validation_info.cache_valid_until : validation_info.cache_valid_until;
+			// A successful validator check refreshes freshness. Without validators, preserve the original deadline.
+			const bool revalidated = cache_is_valid && ExternalFileCache::HasValidationMetadata(validation_info);
+			const auto valid_until = (!cache_is_valid || revalidated) ? validation_info.cache_valid_until
+			                                                          : cached_file->validation_info.cache_valid_until;
 			cached_file->validation_info = validation_info;
 			cached_file->validation_info.cache_valid_until = valid_until;
 			cached_file->can_seek = file_handle->CanSeek();

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -66,8 +66,7 @@ public:
 				lk.unlock();
 
 				try {
-					auto file_handle = caching_file_handle.GetFileHandle();
-					const idx_t file_size = file_handle->GetFileSize();
+					const idx_t file_size = caching_file_handle.GetFileSize();
 					const idx_t offset = block_idx * block_size;
 					if (offset >= file_size) {
 						lk.lock();
@@ -258,29 +257,27 @@ shared_ptr<FileHandle> CachingFileHandle::GetFileHandle() {
 	// require explicit opt-in for concurrent pread-style access (e.g., HTTPFS).
 	auto internal_flags = flags | FileFlags::FILE_FLAGS_PARALLEL_ACCESS;
 	file_handle = caching_file_system.file_system.OpenFile(path, internal_flags, opener);
-	last_modified = caching_file_system.file_system.GetLastModifiedTime(*file_handle);
+	// Snapshot the metadata with a single Stats call, avoiding repeated metadata lookups (e.g., fstat)
+	const auto metadata = caching_file_system.file_system.Stats(*file_handle);
+	file_size = NumericCast<idx_t>(metadata.file_size);
+	last_modified = metadata.last_modification_time;
+	cache_valid_until = metadata.cache_valid_until;
 	version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
-	cache_valid_until = timestamp_t::infinity();
-	if (!ExternalFileCache::HasValidationMetadata(version_tag, last_modified)) {
-		// No validators: get the freshness deadline (e.g., HTTP Cache-Control) so we can cache the file anyway
-		cache_valid_until = caching_file_system.file_system.Stats(*file_handle).cache_valid_until;
-	}
 
 	{
 		annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);
 		const bool first_access = (cached_file->file_size == 0);
 		if (first_access || Validate()) {
-			const idx_t current_file_size = file_handle->GetFileSize();
 			const bool cache_is_valid = ExternalFileCache::IsValid(
 			    Validate(), cached_file->version_tag, cached_file->last_modified, cached_file->cache_valid_until,
-			    cached_file->file_size, version_tag, last_modified, current_file_size);
+			    cached_file->file_size, version_tag, last_modified, file_size);
 			if (!cache_is_valid) {
 				annotated_lock_guard<annotated_mutex> map_guard(cached_file->map_lock);
 				cached_file->blocks.clear();
 				cached_file->cached_block_size.SetInvalid();
 				cached_file->cache_valid_until = cache_valid_until;
 			}
-			cached_file->file_size = current_file_size;
+			cached_file->file_size = file_size;
 			cached_file->last_modified = last_modified;
 			cached_file->version_tag = version_tag;
 			cached_file->can_seek = file_handle->CanSeek();
@@ -353,12 +350,13 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 	if (Validate()) {
 		string current_version_tag;
 		timestamp_t current_last_modified;
+		idx_t current_file_size = 0;
 		{
 			const annotated_lock_guard<annotated_mutex> file_handle_guard(file_handle_mutex);
 			current_version_tag = version_tag;
 			current_last_modified = last_modified;
+			current_file_size = file_size;
 		}
-		const idx_t current_file_size = GetFileSize();
 		const annotated_lock_guard<annotated_mutex> meta_guard(current_cached_file->meta_lock);
 		if (!ExternalFileCache::IsValid(true, current_cached_file->version_tag, current_cached_file->last_modified,
 		                                current_cached_file->cache_valid_until, current_cached_file->file_size,
@@ -407,7 +405,9 @@ idx_t CachingFileHandle::GetFileSize() {
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->file_size;
 	}
-	return GetFileHandle()->GetFileSize();
+	auto file_handle = GetFileHandle();
+	annotated_lock_guard<annotated_mutex> guard(file_handle_mutex);
+	return file_size;
 }
 
 timestamp_t CachingFileHandle::GetLastModifiedTime() {

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -197,14 +197,6 @@ shared_ptr<CachingFileHandle::CachedFile> CachingFileHandle::EnsureCachedFileCur
 	return current_cached_file;
 }
 
-bool CachingFileHandle::HasFreshImmutableMetadata() {
-	auto current_cached_file = EnsureCachedFileCurrent();
-	annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
-	const auto &info = current_cached_file->validation_info;
-	return info.immutable && info.cache_valid_until.IsFinite() &&
-	       Timestamp::GetCurrentTimestamp() <= info.cache_valid_until;
-}
-
 bool CachingFileHandle::CanUseCache() {
 	if (!Validate()) {
 		return true;
@@ -231,10 +223,8 @@ CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &ca
           ExternalFileCacheUtil::GetCacheValidationMode(path_p, context.GetClientContext(), caching_file_system_p.db)),
       cached_file(nullptr), position(0) {
 	cached_file = external_file_cache.GetOrCreateCachedFile(path_p.path);
-	const bool should_validate = Validate();
-	const bool skip_validation = should_validate && HasFreshImmutableMetadata();
-	if (!external_file_cache.IsEnabled() || (should_validate && !skip_validation)) {
-		// Open the file unless a fresh immutable cache entry can satisfy reads without revalidation.
+	if (!external_file_cache.IsEnabled() || Validate()) {
+		// If caching is disabled, or if we must validate cache entries, we always have to open the file
 		GetFileHandle();
 		return;
 	}
@@ -273,7 +263,6 @@ shared_ptr<FileHandle> CachingFileHandle::GetFileHandle() {
 	validation_info.last_modified = stats.last_modification_time;
 	validation_info.cache_valid_until = stats.cache_valid_until;
 	validation_info.version_tag = std::move(stats.version_tag);
-	validation_info.immutable = stats.cache_immutable;
 
 	{
 		annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);
@@ -405,7 +394,7 @@ string CachingFileHandle::GetPath() const {
 }
 
 idx_t CachingFileHandle::GetFileSize() {
-	if (!Validate() || HasFreshImmutableMetadata()) {
+	if (!Validate()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->validation_info.file_size;
@@ -416,7 +405,7 @@ idx_t CachingFileHandle::GetFileSize() {
 }
 
 timestamp_t CachingFileHandle::GetLastModifiedTime() {
-	if (!Validate() || HasFreshImmutableMetadata()) {
+	if (!Validate()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->validation_info.last_modified;
@@ -427,7 +416,7 @@ timestamp_t CachingFileHandle::GetLastModifiedTime() {
 }
 
 string CachingFileHandle::GetVersionTag() {
-	if (!Validate() || HasFreshImmutableMetadata()) {
+	if (!Validate()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->validation_info.version_tag;
@@ -455,7 +444,7 @@ bool CachingFileHandle::Validate() const {
 }
 
 bool CachingFileHandle::CanSeek() {
-	if (!Validate() || HasFreshImmutableMetadata()) {
+	if (!Validate()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->can_seek;
@@ -468,7 +457,7 @@ bool CachingFileHandle::IsRemoteFile() const {
 }
 
 bool CachingFileHandle::OnDiskFile() {
-	if (!Validate() || HasFreshImmutableMetadata()) {
+	if (!Validate()) {
 		auto current_cached_file = EnsureCachedFileCurrent();
 		annotated_lock_guard<annotated_mutex> guard(current_cached_file->meta_lock);
 		return current_cached_file->on_disk_file;

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -14,6 +14,10 @@
 
 namespace duckdb {
 
+bool CacheValidationInfo::IsExplicitlyStale() const {
+	return cache_valid_until && *cache_valid_until == timestamp_t::ninfinity();
+}
+
 class ExternalFileCache::ExternalFileCacheObjectCacheEntry : public ObjectCacheEntry {
 public:
 	ExternalFileCacheObjectCacheEntry(ExternalFileCache &cache_p, string path_p, idx_t generation_p)
@@ -246,6 +250,9 @@ bool ExternalFileCache::HasValidationMetadata(const CacheValidationInfo &info) {
 }
 
 bool ExternalFileCache::IsValid(bool validate, const CacheValidationInfo &cached, const CacheValidationInfo &current) {
+	if (cached.IsExplicitlyStale() || current.IsExplicitlyStale()) {
+		return false;
+	}
 	if (!validate) {
 		return true; // Assume valid
 	}
@@ -257,10 +264,10 @@ bool ExternalFileCache::IsValid(bool validate, const CacheValidationInfo &cached
 	if (cached.file_size != current.file_size) {
 		return false; // The file has certainly been modified
 	}
-	if (!cached.cache_valid_until.IsFinite()) {
+	if (!cached.cache_valid_until) {
 		return false; // The backend does not provide expiry information, so we cannot validate at all
 	}
-	return Timestamp::GetCurrentTimestamp() <= cached.cache_valid_until;
+	return Timestamp::GetCurrentTimestamp() <= *cached.cache_valid_until;
 }
 
 ExternalFileCache::ExternalFileCache(DatabaseInstance &db, bool enable_p)

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -204,12 +204,13 @@ ExternalFileCache::CachedFile::CachedFile(string path_p, idx_t generation_p)
 }
 
 bool ExternalFileCache::CachedFile::IsValid(bool validate, const string &current_version_tag,
-                                            timestamp_t current_last_modified) {
+                                            timestamp_t current_last_modified, idx_t current_file_size) {
 	if (!validate) {
 		return true; // Assume valid
 	}
 	annotated_lock_guard<annotated_mutex> guard(meta_lock);
-	return ExternalFileCache::IsValid(validate, version_tag, last_modified, current_version_tag, current_last_modified);
+	return ExternalFileCache::IsValid(validate, version_tag, last_modified, cache_valid_until, file_size,
+	                                  current_version_tag, current_last_modified, current_file_size);
 }
 
 bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
@@ -243,6 +244,54 @@ bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag,
 		return false;
 	}
 	return last_modified_time > LAST_MODIFIED_THRESHOLD;
+}
+
+bool ExternalFileCache::HasUsableLastModified(timestamp_t last_modified) {
+	return last_modified.IsFinite() && last_modified != timestamp_t(0);
+}
+
+bool ExternalFileCache::HasValidationMetadata(const string &version_tag, timestamp_t last_modified) {
+	return !version_tag.empty() || HasUsableLastModified(last_modified);
+}
+
+bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
+                                timestamp_t cached_valid_until, idx_t cached_file_size,
+                                const string &current_version_tag, timestamp_t current_last_modified,
+                                idx_t current_file_size) {
+	if (!validate) {
+		return true; // Assume valid
+	}
+	if (!current_version_tag.empty() || !cached_version_tag.empty()) {
+		return cached_version_tag == current_version_tag; // Validity checked by version tag
+	}
+	if (HasUsableLastModified(cached_last_modified) || HasUsableLastModified(current_last_modified)) {
+		if (cached_last_modified != current_last_modified) {
+			return false; // The file has certainly been modified
+		}
+		// The last modified time matches. However, we cannot blindly trust this,
+		// because some file systems use a low resolution clock to set the last modified time.
+		// So, we will require that the last modified time is more than 10 seconds ago.
+		static constexpr int64_t LAST_MODIFIED_THRESHOLD = 10LL * 1000LL * 1000LL;
+		const auto access_time = Timestamp::GetCurrentTimestamp();
+		if (access_time < current_last_modified) {
+			return false; // Last modified in the future?
+		}
+		int64_t last_modified_time;
+		if (!TrySubtractOperator::Operation(access_time, current_last_modified, last_modified_time)) {
+			// out of range
+			return false;
+		}
+		return last_modified_time > LAST_MODIFIED_THRESHOLD;
+	}
+	// No validators at all: cached data may be served within the freshness deadline the storage backend granted
+	// when the cache entry was created (e.g., HTTP Cache-Control), as long as the file size is unchanged.
+	if (cached_file_size != current_file_size) {
+		return false; // The file has certainly been modified
+	}
+	if (!cached_valid_until.IsFinite()) {
+		return false; // The backend does not provide expiry information, so we cannot validate at all
+	}
+	return Timestamp::GetCurrentTimestamp() < cached_valid_until;
 }
 
 ExternalFileCache::ExternalFileCache(DatabaseInstance &db, bool enable_p)

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -37,7 +37,7 @@ public:
 		idx_t file_size = 0;
 		{
 			const annotated_lock_guard<annotated_mutex> meta_guard(cached_file->meta_lock);
-			file_size = cached_file->file_size;
+			file_size = cached_file->validation_info.file_size;
 		}
 		const idx_t block_size = cache.GetCacheBlockSize(cached_file->path);
 		const idx_t num_blocks = (file_size + block_size - 1) / block_size;
@@ -174,7 +174,7 @@ vector<shared_ptr<CacheBlock>> ExternalFileCache::ReindexAndAcquireBlocks(Cached
 	idx_t file_size = 0;
 	{
 		const annotated_lock_guard<annotated_mutex> meta_guard(cached_file.meta_lock);
-		file_size = cached_file.file_size;
+		file_size = cached_file.validation_info.file_size;
 	}
 
 	const annotated_lock_guard<annotated_mutex> map_guard(cached_file.map_lock);
@@ -203,14 +203,9 @@ ExternalFileCache::CachedFile::CachedFile(string path_p, idx_t generation_p)
     : path(std::move(path_p)), generation(generation_p) {
 }
 
-bool ExternalFileCache::CachedFile::IsValid(bool validate, const string &current_version_tag,
-                                            timestamp_t current_last_modified, idx_t current_file_size) {
-	if (!validate) {
-		return true; // Assume valid
-	}
-	annotated_lock_guard<annotated_mutex> guard(meta_lock);
-	return ExternalFileCache::IsValid(validate, version_tag, last_modified, cache_valid_until, file_size,
-	                                  current_version_tag, current_last_modified, current_file_size);
+//! Whether the last modified timestamp is usable as a cache validator (some storage backends do not provide it)
+static bool HasUsableLastModified(timestamp_t last_modified) {
+	return last_modified.IsFinite() && last_modified != timestamp_t(0);
 }
 
 bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
@@ -246,52 +241,27 @@ bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag,
 	return last_modified_time > LAST_MODIFIED_THRESHOLD;
 }
 
-bool ExternalFileCache::HasUsableLastModified(timestamp_t last_modified) {
-	return last_modified.IsFinite() && last_modified != timestamp_t(0);
+bool ExternalFileCache::HasValidationMetadata(const CacheValidationInfo &info) {
+	return !info.version_tag.empty() || HasUsableLastModified(info.last_modified);
 }
 
-bool ExternalFileCache::HasValidationMetadata(const string &version_tag, timestamp_t last_modified) {
-	return !version_tag.empty() || HasUsableLastModified(last_modified);
-}
-
-bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag, timestamp_t cached_last_modified,
-                                timestamp_t cached_valid_until, idx_t cached_file_size,
-                                const string &current_version_tag, timestamp_t current_last_modified,
-                                idx_t current_file_size) {
+bool ExternalFileCache::IsValid(bool validate, const CacheValidationInfo &cached, const CacheValidationInfo &current) {
 	if (!validate) {
 		return true; // Assume valid
 	}
-	if (!current_version_tag.empty() || !cached_version_tag.empty()) {
-		return cached_version_tag == current_version_tag; // Validity checked by version tag
-	}
-	if (HasUsableLastModified(cached_last_modified) || HasUsableLastModified(current_last_modified)) {
-		if (cached_last_modified != current_last_modified) {
-			return false; // The file has certainly been modified
-		}
-		// The last modified time matches. However, we cannot blindly trust this,
-		// because some file systems use a low resolution clock to set the last modified time.
-		// So, we will require that the last modified time is more than 10 seconds ago.
-		static constexpr int64_t LAST_MODIFIED_THRESHOLD = 10LL * 1000LL * 1000LL;
-		const auto access_time = Timestamp::GetCurrentTimestamp();
-		if (access_time < current_last_modified) {
-			return false; // Last modified in the future?
-		}
-		int64_t last_modified_time;
-		if (!TrySubtractOperator::Operation(access_time, current_last_modified, last_modified_time)) {
-			// out of range
-			return false;
-		}
-		return last_modified_time > LAST_MODIFIED_THRESHOLD;
+	if (HasValidationMetadata(cached) || HasValidationMetadata(current)) {
+		return IsValid(validate, cached.version_tag, cached.last_modified, current.version_tag,
+		               current.last_modified);
 	}
 	// No validators at all: cached data may be served within the freshness deadline the storage backend granted
 	// when the cache entry was created (e.g., HTTP Cache-Control), as long as the file size is unchanged.
-	if (cached_file_size != current_file_size) {
+	if (cached.file_size != current.file_size) {
 		return false; // The file has certainly been modified
 	}
-	if (!cached_valid_until.IsFinite()) {
+	if (!cached.cache_valid_until.IsFinite()) {
 		return false; // The backend does not provide expiry information, so we cannot validate at all
 	}
-	return Timestamp::GetCurrentTimestamp() <= cached_valid_until;
+	return Timestamp::GetCurrentTimestamp() <= cached.cache_valid_until;
 }
 
 ExternalFileCache::ExternalFileCache(DatabaseInstance &db, bool enable_p)

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -207,7 +207,7 @@ ExternalFileCache::CachedFile::CachedFile(string path_p, idx_t generation_p)
     : path(std::move(path_p)), generation(generation_p) {
 }
 
-//! Whether the last modified timestamp is usable as a cache validator (some storage backends do not provide it)
+//! Whether the last modified timestamp is usable as a cache validator
 static bool HasUsableLastModified(timestamp_t last_modified) {
 	return last_modified.IsFinite() && last_modified != timestamp_t(0);
 }
@@ -224,7 +224,7 @@ bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag,
 		return false; // The file has certainly been modified
 	}
 
-	// If the modified time is not assigned (i.e., storage backend does not provide it), we can't validate it.
+	// If the modified time is not assigned, we can't validate it.
 	if (!current_last_modified.IsFinite() || !cached_last_modified.IsFinite()) {
 		return false;
 	}

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -250,8 +250,7 @@ bool ExternalFileCache::IsValid(bool validate, const CacheValidationInfo &cached
 		return true; // Assume valid
 	}
 	if (HasValidationMetadata(cached) || HasValidationMetadata(current)) {
-		return IsValid(validate, cached.version_tag, cached.last_modified, current.version_tag,
-		               current.last_modified);
+		return IsValid(validate, cached.version_tag, cached.last_modified, current.version_tag, current.last_modified);
 	}
 	// No validators at all: cached data may be served within the freshness deadline the storage backend granted
 	// when the cache entry was created (e.g., HTTP Cache-Control), as long as the file size is unchanged.

--- a/src/storage/external_file_cache/external_file_cache.cpp
+++ b/src/storage/external_file_cache/external_file_cache.cpp
@@ -291,7 +291,7 @@ bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag,
 	if (!cached_valid_until.IsFinite()) {
 		return false; // The backend does not provide expiry information, so we cannot validate at all
 	}
-	return Timestamp::GetCurrentTimestamp() < cached_valid_until;
+	return Timestamp::GetCurrentTimestamp() <= cached_valid_until;
 }
 
 ExternalFileCache::ExternalFileCache(DatabaseInstance &db, bool enable_p)

--- a/test/api/test_config.cpp
+++ b/test/api/test_config.cpp
@@ -141,6 +141,18 @@ TEST_CASE("Test user_agent", "[api]") {
 	}
 }
 
+TEST_CASE("HTTPHeaders preserves repeated field values", "[api]") {
+	HTTPHeaders headers;
+	headers.Insert("Cache-Control", "max-age=600");
+	headers.Append("cache-control", "no-store");
+
+	REQUIRE(headers.GetHeaderValue("CACHE-CONTROL") == "max-age=600");
+	const auto values = headers.GetHeaderValues("Cache-Control");
+	REQUIRE(values.size() == 2);
+	REQUIRE(values[0] == "max-age=600");
+	REQUIRE(values[1] == "no-store");
+}
+
 TEST_CASE("Test secret_directory configuration", "[api]") {
 	DBConfig config;
 

--- a/test/common/caching_test_utils.cpp
+++ b/test/common/caching_test_utils.cpp
@@ -41,8 +41,7 @@ bool SimpleTrackingFileSystem::CanSeek() {
 
 FileMetadata SimpleTrackingFileSystem::Stats(FileHandle &handle) {
 	auto metadata = LocalFileSystem::Stats(handle);
-	metadata.version_tag =
-	    StringUtil::Format("%lld:%lld", metadata.file_size, metadata.last_modification_time.value);
+	metadata.version_tag = StringUtil::Format("%lld:%lld", metadata.file_size, metadata.last_modification_time.value);
 	return metadata;
 }
 

--- a/test/common/caching_test_utils.cpp
+++ b/test/common/caching_test_utils.cpp
@@ -39,8 +39,11 @@ bool SimpleTrackingFileSystem::CanSeek() {
 	return true;
 }
 
-string SimpleTrackingFileSystem::GetVersionTag(FileHandle &handle) {
-	return StringUtil::Format("%lld:%lld", GetFileSize(handle), GetLastModifiedTime(handle).value);
+FileMetadata SimpleTrackingFileSystem::Stats(FileHandle &handle) {
+	auto metadata = LocalFileSystem::Stats(handle);
+	metadata.version_tag =
+	    StringUtil::Format("%lld:%lld", metadata.file_size, metadata.last_modification_time.value);
+	return metadata;
 }
 
 string NoValidationMetadataFileSystem::GetName() const {
@@ -55,17 +58,10 @@ bool NoValidationMetadataFileSystem::CanSeek() {
 	return true;
 }
 
-string NoValidationMetadataFileSystem::GetVersionTag(FileHandle &handle) {
-	return "";
-}
-
-timestamp_t NoValidationMetadataFileSystem::GetLastModifiedTime(FileHandle &handle) {
-	return timestamp_t(0);
-}
-
 FileMetadata NoValidationMetadataFileSystem::Stats(FileHandle &handle) {
 	auto metadata = LocalFileSystem::Stats(handle);
 	metadata.last_modification_time = timestamp_t(0);
+	metadata.version_tag.clear();
 	return metadata;
 }
 

--- a/test/common/caching_test_utils.cpp
+++ b/test/common/caching_test_utils.cpp
@@ -63,4 +63,15 @@ timestamp_t NoValidationMetadataFileSystem::GetLastModifiedTime(FileHandle &hand
 	return timestamp_t(0);
 }
 
+string FreshnessOnlyFileSystem::GetName() const {
+	return "FreshnessOnlyFileSystem";
+}
+
+FileMetadata FreshnessOnlyFileSystem::Stats(FileHandle &handle) {
+	auto metadata = LocalFileSystem::Stats(handle);
+	metadata.last_modification_time = timestamp_t(0);
+	metadata.cache_valid_until = timestamp_t(Timestamp::GetCurrentTimestamp().value + max_age_micros);
+	return metadata;
+}
+
 } // namespace duckdb

--- a/test/common/caching_test_utils.cpp
+++ b/test/common/caching_test_utils.cpp
@@ -69,8 +69,10 @@ string FreshnessOnlyFileSystem::GetName() const {
 }
 
 FileMetadata FreshnessOnlyFileSystem::Stats(FileHandle &handle) {
+	stats_count++;
 	auto metadata = NoValidationMetadataFileSystem::Stats(handle);
 	metadata.cache_valid_until = timestamp_t(Timestamp::GetCurrentTimestamp().value + max_age_micros);
+	metadata.cache_immutable = immutable;
 	return metadata;
 }
 

--- a/test/common/caching_test_utils.cpp
+++ b/test/common/caching_test_utils.cpp
@@ -63,13 +63,18 @@ timestamp_t NoValidationMetadataFileSystem::GetLastModifiedTime(FileHandle &hand
 	return timestamp_t(0);
 }
 
+FileMetadata NoValidationMetadataFileSystem::Stats(FileHandle &handle) {
+	auto metadata = LocalFileSystem::Stats(handle);
+	metadata.last_modification_time = timestamp_t(0);
+	return metadata;
+}
+
 string FreshnessOnlyFileSystem::GetName() const {
 	return "FreshnessOnlyFileSystem";
 }
 
 FileMetadata FreshnessOnlyFileSystem::Stats(FileHandle &handle) {
-	auto metadata = LocalFileSystem::Stats(handle);
-	metadata.last_modification_time = timestamp_t(0);
+	auto metadata = NoValidationMetadataFileSystem::Stats(handle);
 	metadata.cache_valid_until = timestamp_t(Timestamp::GetCurrentTimestamp().value + max_age_micros);
 	return metadata;
 }

--- a/test/common/caching_test_utils.cpp
+++ b/test/common/caching_test_utils.cpp
@@ -69,10 +69,8 @@ string FreshnessOnlyFileSystem::GetName() const {
 }
 
 FileMetadata FreshnessOnlyFileSystem::Stats(FileHandle &handle) {
-	stats_count++;
 	auto metadata = NoValidationMetadataFileSystem::Stats(handle);
 	metadata.cache_valid_until = timestamp_t(Timestamp::GetCurrentTimestamp().value + max_age_micros);
-	metadata.cache_immutable = immutable;
 	return metadata;
 }
 

--- a/test/common/caching_test_utils.hpp
+++ b/test/common/caching_test_utils.hpp
@@ -30,7 +30,7 @@ public:
 	string GetName() const override;
 	bool CanHandleFile(const string &path) override;
 	bool CanSeek() override;
-	string GetVersionTag(FileHandle &handle) override;
+	FileMetadata Stats(FileHandle &handle) override;
 };
 
 //! A file system that returns no ETag and timestamp_t(0) for Last-Modified, simulating servers that do not
@@ -40,8 +40,6 @@ public:
 	string GetName() const override;
 	bool CanHandleFile(const string &path) override;
 	bool CanSeek() override;
-	string GetVersionTag(FileHandle &handle) override;
-	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
 	FileMetadata Stats(FileHandle &handle) override;
 };
 

--- a/test/common/caching_test_utils.hpp
+++ b/test/common/caching_test_utils.hpp
@@ -44,6 +44,17 @@ public:
 	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
 };
 
+//! A file system without validators that grants a freshness deadline, simulating servers that send
+//! no ETag/Last-Modified but do send Cache-Control max-age.
+class FreshnessOnlyFileSystem : public NoValidationMetadataFileSystem {
+public:
+	string GetName() const override;
+	FileMetadata Stats(FileHandle &handle) override;
+
+	//! Freshness lifetime granted on each stat; negative values produce an already-expired deadline.
+	int64_t max_age_micros = 600 * 1000000LL;
+};
+
 //! In-memory DuckDB with the external file cache forced to also cache local files (off by default), so the external
 //! file cache tests can exercise the cache machinery on local temp files.
 DuckDB MakeCacheLocalFilesDB();

--- a/test/common/caching_test_utils.hpp
+++ b/test/common/caching_test_utils.hpp
@@ -52,8 +52,6 @@ public:
 
 	//! Freshness lifetime granted on each stat; negative values produce an already-expired deadline.
 	int64_t max_age_micros = 600 * 1000000LL;
-	bool immutable = false;
-	idx_t stats_count = 0;
 };
 
 //! In-memory DuckDB with the external file cache forced to also cache local files (off by default), so the external

--- a/test/common/caching_test_utils.hpp
+++ b/test/common/caching_test_utils.hpp
@@ -52,6 +52,8 @@ public:
 
 	//! Freshness lifetime granted on each stat; negative values produce an already-expired deadline.
 	int64_t max_age_micros = 600 * 1000000LL;
+	bool immutable = false;
+	idx_t stats_count = 0;
 };
 
 //! In-memory DuckDB with the external file cache forced to also cache local files (off by default), so the external

--- a/test/common/caching_test_utils.hpp
+++ b/test/common/caching_test_utils.hpp
@@ -42,6 +42,7 @@ public:
 	bool CanSeek() override;
 	string GetVersionTag(FileHandle &handle) override;
 	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
+	FileMetadata Stats(FileHandle &handle) override;
 };
 
 //! A file system without validators that grants a freshness deadline, simulating servers that send

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -96,8 +96,11 @@ public:
 		return true;
 	}
 
-	string GetVersionTag(FileHandle &handle) override {
-		return StringUtil::Format("%lld:%lld", GetFileSize(handle), GetLastModifiedTime(handle).value);
+	FileMetadata Stats(FileHandle &handle) override {
+		auto metadata = LocalFileSystem::Stats(handle);
+		metadata.version_tag =
+		    StringUtil::Format("%lld:%lld", metadata.file_size, metadata.last_modification_time.value);
+		return metadata;
 	}
 };
 
@@ -139,12 +142,11 @@ public:
 		return "NoMetadataFileSystem";
 	}
 
-	timestamp_t GetLastModifiedTime(FileHandle &handle) override {
-		return FileMetadata {}.last_modification_time;
-	}
-
-	string GetVersionTag(FileHandle &handle) override {
-		return "";
+	FileMetadata Stats(FileHandle &handle) override {
+		auto metadata = LocalFileSystem::Stats(handle);
+		metadata.last_modification_time = FileMetadata {}.last_modification_time;
+		metadata.version_tag.clear();
+		return metadata;
 	}
 
 	bool CanHandleFile(const string &path) override {

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -535,6 +535,30 @@ TEST_CASE("File with freshness deadline but no validators is cached and reused",
 	}
 }
 
+TEST_CASE("Fresh immutable cache entry skips revalidation", "[external_file_cache]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &db_instance = *db.instance;
+	auto fresh_fs = make_uniq<FreshnessOnlyFileSystem>();
+	fresh_fs->immutable = true;
+
+	const idx_t block_size = db_instance.GetExternalFileCache().GetCacheBlockSize(TestDirectoryPath());
+	const string content(block_size, 'A');
+	EFCTestFileGuard test_file("test_efc_immutable.bin", content);
+	CachingFileSystem cfs(*fresh_fs, db_instance);
+
+	{
+		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, block_size) == content);
+	}
+	REQUIRE(fresh_fs->stats_count == 1);
+
+	{
+		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, block_size) == content);
+	}
+	REQUIRE(fresh_fs->stats_count == 1);
+}
+
 TEST_CASE("File with freshness deadline is invalidated when the file size changes", "[external_file_cache]") {
 	DuckDB db = MakeCacheLocalFilesDB();
 	auto &db_instance = *db.instance;

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -493,6 +493,95 @@ TEST_CASE("Failed CachingFileHandle construction leaves evictable cached file en
 	REQUIRE(cache.GetCachedFileCount() == 0);
 }
 
+TEST_CASE("File with freshness deadline but no validators is cached and reused", "[external_file_cache]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+
+	auto fresh_fs = make_uniq<FreshnessOnlyFileSystem>();
+
+	const idx_t BLOCK_SIZE = cache.GetCacheBlockSize(TestDirectoryPath());
+	const string content_a(BLOCK_SIZE, 'A');
+	const string content_b(BLOCK_SIZE, 'B'); // same size as content_a
+	EFCTestFileGuard test_file("test_efc_freshness_reuse.bin", content_a);
+
+	CachingFileSystem cfs(*fresh_fs, db_instance);
+
+	// First read populates the cache.
+	{
+		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_a);
+	}
+	REQUIRE(CountCachedBlocks(cache) == 1);
+
+	// Overwrite with same-size content. Within the freshness deadline the cached content is still served,
+	// because the file provides no validators to detect the change.
+	WriteTestContent(test_file.GetPath(), content_b);
+	{
+		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_a);
+	}
+	REQUIRE(CountCachedBlocks(cache) == 1);
+}
+
+TEST_CASE("File with freshness deadline is invalidated when the file size changes", "[external_file_cache]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+
+	auto fresh_fs = make_uniq<FreshnessOnlyFileSystem>();
+
+	const idx_t BLOCK_SIZE = cache.GetCacheBlockSize(TestDirectoryPath());
+	const string content_a(BLOCK_SIZE, 'A');
+	const string content_b(BLOCK_SIZE * 2, 'B');
+	EFCTestFileGuard test_file("test_efc_freshness_size_change.bin", content_a);
+
+	CachingFileSystem cfs(*fresh_fs, db_instance);
+
+	{
+		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_a);
+	}
+	REQUIRE(CountCachedBlocks(cache) == 1);
+
+	// Overwrite with larger content: the size mismatch invalidates the cache despite the freshness deadline.
+	WriteTestContent(test_file.GetPath(), content_b);
+	{
+		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(handle->GetFileSize() == content_b.size());
+		REQUIRE(ReadFull(*handle, content_b.size()) == content_b);
+	}
+	REQUIRE(TotalCachedBytes(cache) == content_b.size());
+}
+
+TEST_CASE("Expired freshness deadline is not served from cache", "[external_file_cache]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+
+	auto fresh_fs = make_uniq<FreshnessOnlyFileSystem>();
+	fresh_fs->max_age_micros = -1000000; // deadline is always in the past
+
+	const idx_t BLOCK_SIZE = cache.GetCacheBlockSize(TestDirectoryPath());
+	const string content_a(BLOCK_SIZE, 'A');
+	const string content_b(BLOCK_SIZE, 'B'); // same size as content_a
+	EFCTestFileGuard test_file("test_efc_freshness_expired.bin", content_a);
+
+	CachingFileSystem cfs(*fresh_fs, db_instance);
+
+	{
+		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_a);
+	}
+
+	// Overwrite with same-size content: the expired deadline prevents serving stale cached data.
+	WriteTestContent(test_file.GetPath(), content_b);
+	{
+		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_b);
+	}
+}
+
 TEST_CASE("No-metadata file is not cached and always returns fresh content", "[external_file_cache]") {
 	DuckDB db = MakeCacheLocalFilesDB();
 	auto &db_instance = *db.instance;

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -517,7 +517,7 @@ TEST_CASE("File with freshness deadline but no validators is cached and reused",
 	timestamp_t original_valid_until;
 	{
 		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
-		original_valid_until = cached_file->cache_valid_until;
+		original_valid_until = cached_file->validation_info.cache_valid_until;
 	}
 
 	// Overwrite with same-size content. Within the freshness deadline the cached content is still served,
@@ -531,7 +531,7 @@ TEST_CASE("File with freshness deadline but no validators is cached and reused",
 	REQUIRE(CountCachedBlocks(cache) == 1);
 	{
 		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
-		REQUIRE(cached_file->cache_valid_until == original_valid_until);
+		REQUIRE(cached_file->validation_info.cache_valid_until == original_valid_until);
 	}
 }
 
@@ -584,7 +584,7 @@ TEST_CASE("Long-lived handle does not use cache after the freshness deadline", "
 	auto cached_file = cache.GetOrCreateCachedFile(test_file.GetPath());
 	{
 		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
-		cached_file->cache_valid_until = timestamp_t(Timestamp::GetCurrentTimestamp().value - 1);
+		cached_file->validation_info.cache_valid_until = timestamp_t(Timestamp::GetCurrentTimestamp().value - 1);
 	}
 
 	WriteTestContent(test_file.GetPath(), content_b);

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -535,30 +535,6 @@ TEST_CASE("File with freshness deadline but no validators is cached and reused",
 	}
 }
 
-TEST_CASE("Fresh immutable cache entry skips revalidation", "[external_file_cache]") {
-	DuckDB db = MakeCacheLocalFilesDB();
-	auto &db_instance = *db.instance;
-	auto fresh_fs = make_uniq<FreshnessOnlyFileSystem>();
-	fresh_fs->immutable = true;
-
-	const idx_t block_size = db_instance.GetExternalFileCache().GetCacheBlockSize(TestDirectoryPath());
-	const string content(block_size, 'A');
-	EFCTestFileGuard test_file("test_efc_immutable.bin", content);
-	CachingFileSystem cfs(*fresh_fs, db_instance);
-
-	{
-		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
-		REQUIRE(ReadFull(*handle, block_size) == content);
-	}
-	REQUIRE(fresh_fs->stats_count == 1);
-
-	{
-		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
-		REQUIRE(ReadFull(*handle, block_size) == content);
-	}
-	REQUIRE(fresh_fs->stats_count == 1);
-}
-
 TEST_CASE("File with freshness deadline is invalidated when the file size changes", "[external_file_cache]") {
 	DuckDB db = MakeCacheLocalFilesDB();
 	auto &db_instance = *db.instance;

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -19,6 +19,21 @@ using EFCTestFileGuard = CachingTestFileGuard;
 using EFCTrackingFileSystem = SimpleTrackingFileSystem;
 using EFCNoMetadataFileSystem = NoValidationMetadataFileSystem;
 
+class CachePolicyFileSystem : public SimpleTrackingFileSystem {
+public:
+	FileMetadata Stats(FileHandle &handle) override {
+		stats_count++;
+		auto metadata = SimpleTrackingFileSystem::Stats(handle);
+		metadata.version_tag = version_tag;
+		metadata.cache_valid_until = cache_valid_until;
+		return metadata;
+	}
+
+	string version_tag = "v1";
+	timestamp_t cache_valid_until = timestamp_t::infinity();
+	idx_t stats_count = 0;
+};
+
 OpenFileInfo MakeTestOpenFileInfo(const string &path) {
 	OpenFileInfo info(path);
 	info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
@@ -514,7 +529,7 @@ TEST_CASE("File with freshness deadline but no validators is cached and reused",
 	}
 	REQUIRE(CountCachedBlocks(cache) == 1);
 	auto cached_file = cache.GetOrCreateCachedFile(test_file.GetPath());
-	timestamp_t original_valid_until;
+	optional<timestamp_t> original_valid_until;
 	{
 		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
 		original_valid_until = cached_file->validation_info.cache_valid_until;
@@ -589,6 +604,60 @@ TEST_CASE("Long-lived handle does not use cache after the freshness deadline", "
 
 	WriteTestContent(test_file.GetPath(), content_b);
 	REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_b);
+}
+
+TEST_CASE("Long-lived handle with validators stops using cache after the freshness deadline", "[external_file_cache]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &cache = db.instance->GetExternalFileCache();
+	auto validating_fs = make_uniq<CachePolicyFileSystem>();
+	validating_fs->cache_valid_until = timestamp_t(Timestamp::GetCurrentTimestamp().value + 600 * 1000000LL);
+
+	const idx_t block_size = cache.GetCacheBlockSize(TestDirectoryPath());
+	const string content_a(block_size, 'A');
+	const string content_b(block_size, 'B');
+	EFCTestFileGuard test_file("test_efc_validator_freshness_long_lived_handle.bin", content_a);
+
+	CachingFileSystem cfs(*validating_fs, *db.instance);
+	auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+	REQUIRE(ReadFull(*handle, block_size) == content_a);
+	REQUIRE(validating_fs->stats_count == 1);
+
+	auto cached_file = cache.GetOrCreateCachedFile(test_file.GetPath());
+	{
+		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
+		cached_file->validation_info.cache_valid_until = timestamp_t(Timestamp::GetCurrentTimestamp().value - 1);
+	}
+	WriteTestContent(test_file.GetPath(), content_b);
+
+	REQUIRE(ReadFull(*handle, block_size) == content_b);
+	REQUIRE(validating_fs->stats_count == 1);
+}
+
+TEST_CASE("File marked as not cacheable does not retain cached blocks", "[external_file_cache]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &cache = db.instance->GetExternalFileCache();
+	auto policy_fs = make_uniq<CachePolicyFileSystem>();
+
+	const idx_t block_size = cache.GetCacheBlockSize(TestDirectoryPath());
+	const string content_a(block_size, 'A');
+	const string content_b(block_size, 'B');
+	EFCTestFileGuard test_file("test_efc_no_store.bin", content_a);
+	CachingFileSystem cfs(*policy_fs, *db.instance);
+
+	{
+		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, block_size) == content_a);
+	}
+	REQUIRE(CountCachedBlocks(cache) == 1);
+
+	WriteTestContent(test_file.GetPath(), content_b);
+	policy_fs->cache_valid_until = timestamp_t::ninfinity();
+	policy_fs->version_tag = "v2";
+	{
+		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+		REQUIRE(ReadFull(*handle, block_size) == content_b);
+	}
+	REQUIRE(CountCachedBlocks(cache) == 0);
 }
 
 TEST_CASE("Expired freshness deadline is not served from cache", "[external_file_cache]") {

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -565,6 +565,32 @@ TEST_CASE("File with freshness deadline is invalidated when the file size change
 	REQUIRE(TotalCachedBytes(cache) == content_b.size());
 }
 
+TEST_CASE("Long-lived handle does not use cache after the freshness deadline", "[external_file_cache]") {
+	DuckDB db = MakeCacheLocalFilesDB();
+	auto &db_instance = *db.instance;
+	auto &cache = db_instance.GetExternalFileCache();
+
+	auto fresh_fs = make_uniq<FreshnessOnlyFileSystem>();
+
+	const idx_t BLOCK_SIZE = cache.GetCacheBlockSize(TestDirectoryPath());
+	const string content_a(BLOCK_SIZE, 'A');
+	const string content_b(BLOCK_SIZE, 'B');
+	EFCTestFileGuard test_file("test_efc_freshness_long_lived_handle.bin", content_a);
+
+	CachingFileSystem cfs(*fresh_fs, db_instance);
+	auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
+	REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_a);
+
+	auto cached_file = cache.GetOrCreateCachedFile(test_file.GetPath());
+	{
+		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
+		cached_file->cache_valid_until = timestamp_t(Timestamp::GetCurrentTimestamp().value - 1);
+	}
+
+	WriteTestContent(test_file.GetPath(), content_b);
+	REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_b);
+}
+
 TEST_CASE("Expired freshness deadline is not served from cache", "[external_file_cache]") {
 	DuckDB db = MakeCacheLocalFilesDB();
 	auto &db_instance = *db.instance;

--- a/test/common/test_external_file_cache.cpp
+++ b/test/common/test_external_file_cache.cpp
@@ -513,15 +513,26 @@ TEST_CASE("File with freshness deadline but no validators is cached and reused",
 		REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_a);
 	}
 	REQUIRE(CountCachedBlocks(cache) == 1);
+	auto cached_file = cache.GetOrCreateCachedFile(test_file.GetPath());
+	timestamp_t original_valid_until;
+	{
+		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
+		original_valid_until = cached_file->cache_valid_until;
+	}
 
 	// Overwrite with same-size content. Within the freshness deadline the cached content is still served,
 	// because the file provides no validators to detect the change.
 	WriteTestContent(test_file.GetPath(), content_b);
+	fresh_fs->max_age_micros *= 2;
 	{
 		auto handle = cfs.OpenFile(MakeValidatingOpenFileInfo(test_file.GetPath()), FileFlags::FILE_FLAGS_READ);
 		REQUIRE(ReadFull(*handle, BLOCK_SIZE) == content_a);
 	}
 	REQUIRE(CountCachedBlocks(cache) == 1);
+	{
+		annotated_lock_guard<annotated_mutex> guard(cached_file->meta_lock);
+		REQUIRE(cached_file->cache_valid_until == original_valid_until);
+	}
 }
 
 TEST_CASE("File with freshness deadline is invalidated when the file size changes", "[external_file_cache]") {


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/24474

This PR implements most of the HTTP control policy.
As mentioned in the issue, previously we disabled the cache when it's impossible to tell version difference because HTTP response doesn't return ETAG and last modification timestamp; but HTTP does have well-documented RFC to illustrate cache control policy.

I asked my agent to summarize the cache usability rule, TLDR
- last modification timestamp and ETAG is still checked first to decide whether cache entry could be reused
- if file not changed, check whether cache expiration timestamp
- if no version information available (depending storage backend), check cache expiration timestamp

```mermaid
flowchart TD
    OPEN[Open file and snapshot Stats metadata] --> STALE{Cached or current deadline = −∞?}
    STALE -- Yes --> INVALID[Clear cached blocks]
    STALE -- No --> VALIDATE{Validation enabled?}

    VALIDATE -- No --> KEEP[Keep existing blocks]
    VALIDATE -- Yes --> ETAG{Cached or current ETag exists?}
    ETAG -- Yes --> ETAG_EQ{ETags equal?}
    ETAG_EQ -- No --> INVALID
    ETAG_EQ -- Yes --> REVALIDATED[Keep blocks and refresh deadline]

    ETAG -- No --> LM{Usable Last-Modified exists?}
    LM -- Yes --> LM_EQ{Timestamps equal and safely old?}
    LM_EQ -- No --> INVALID
    LM_EQ -- Yes --> REVALIDATED

    LM -- No --> SIZE{File sizes equal?}
    SIZE -- No --> INVALID
    SIZE -- Yes --> ORIGINAL_FRESH{Original deadline exists<br/>and now ≤ deadline?}
    ORIGINAL_FRESH -- No --> INVALID
    ORIGINAL_FRESH -- Yes --> PRESERVE[Keep blocks and original deadline]

    INVALID --> CURRENT[Read current file data]
    KEEP --> SERVE{May cached blocks be served?}
    REVALIDATED --> SERVE
    PRESERVE --> SERVE

    SERVE --> MODE{Validation enabled?}
    MODE -- No --> NO_VALIDATE_FRESH{Deadline absent or fresh?}
    NO_VALIDATE_FRESH -- Yes --> CACHE[Use cached blocks]
    NO_VALIDATE_FRESH -- No --> CURRENT

    MODE -- Yes --> HAS_DEADLINE{Cached deadline present?}
    HAS_DEADLINE -- Yes --> DEADLINE_FRESH{Now ≤ deadline?}
    DEADLINE_FRESH -- Yes --> CACHE
    DEADLINE_FRESH -- No --> CURRENT
    HAS_DEADLINE -- No --> HAS_VALIDATOR{Current ETag or usable<br/>Last-Modified?}
    HAS_VALIDATOR -- Yes --> CACHE
    HAS_VALIDATOR -- No --> CURRENT
```

```mermaid
flowchart TD
    HEADERS[Collect every Cache-Control field line<br/>and split directives outside quoted strings] --> NO_CACHE{no-cache present?}
    NO_CACHE -- Yes --> NEG[−∞: explicitly stale]
    NO_CACHE -- No --> MAXAGE{max-age present?}

    MAXAGE -- Duplicate or invalid --> NEG
    MAXAGE -- Valid --> LIFETIME[Freshness lifetime]
    MAXAGE -- No --> EXPIRES{Expires present?}
    EXPIRES -- Invalid --> NEG
    EXPIRES -- No --> UNKNOWN[nullopt: no explicit freshness]
    EXPIRES -- Valid --> REFERENCE[Expires − Date<br/>or receipt time]
    REFERENCE --> LIFETIME

    LIFETIME --> CURRENT_AGE[Current age = max Age,<br/>apparent age from Date]
    CURRENT_AGE --> EXPIRED{Lifetime ≤ current age<br/>or arithmetic overflow?}
    EXPIRED -- Yes --> NEG
    EXPIRED -- No --> DEADLINE[Receipt time + remaining lifetime]

    NEG --> POLICY[cache_valid_until]
    UNKNOWN --> POLICY
    DEADLINE --> POLICY
    NO_STORE[no-store present] --> NEG
    NO_STORE --> DONT_STORE[Do not insert HTTP metadata]
    POLICY --> META{HTTP metadata lookup}
    META -- Finite deadline expired --> EVICT[Erase metadata and refetch]
    META -- Otherwise --> REUSE[Reuse metadata]
```

ETag and Last-Modified determine whether cached content still represents the file. The tri-state deadline then determines whether that content may be served.

Priority is: **ETag → Last-Modified → file size plus freshness deadline**. The deadline is only used when neither validator exists.

Reference:
- https://datatracker.ietf.org/doc/html/rfc9111
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote read caching correctness when HTTP headers omit validators; stale same-size content can be served until the freshness deadline, which is intentional but behavior-sensitive for production object storage workloads.
> 
> **Overview**
> **External file cache** can reuse remote data when servers send **no ETag or Last-Modified** by honoring a **`cache_valid_until`** deadline (from HTTP **Cache-Control** / **Expires**), with **ETag → Last-Modified → size + freshness** still deciding invalidation. Cached entries consolidate validation in **`CacheValidationInfo`**; **`CachingFileHandle`** snapshots metadata via **`FileSystem::Stats`** and **`CanUseCache()`** gates block reuse (including after deadlines expire on long-lived handles).
> 
> **Core plumbing:** **`FileMetadata`** gains **`version_tag`** and **`cache_valid_until`**; default **`Stats`** composes size, mtime, type, and version tag instead of throwing. **`HTTPHeaders`** supports repeated field lines (**`Append`**, **`GetHeaderValues`**) so response parsing preserves multiple **Cache-Control** directives.
> 
> **httpfs** (bumped extension tag + vendored patch) computes freshness per RFC 9111 (**`ComputeCacheValidUntil`**), respects **no-store** / **no-cache**, evicts expired HTTP metadata cache entries, and exposes **`Stats`** on handles. Tests cover freshness-only backends, expiry, size changes, and explicit no-store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3b9988d646389a44640b5596a646230e66e72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

