### PR TITLE
Prune parquet list type

### DIFF
--- a/extension/parquet/include/parquet_statistics.hpp
+++ b/extension/parquet/include/parquet_statistics.hpp
@@ -55,9 +55,13 @@ enum class ParquetBloomFilterHashStrategy : uint8_t { STANDARD, NORMALIZED_INTER
 struct ParquetStatisticsUtils {
 	static constexpr const char *INTERVAL_BLOOM_FILTER_KEY = "duckdb.interval_bloom_filter";
 	static constexpr const char *INTERVAL_BLOOM_FILTER_VALUE = "normalized-v1";
+	static constexpr const char *LIST_ELEMENT_STATS_KEY = "duckdb.list_element_stats";
 
 	static unique_ptr<BaseStatistics> TransformColumnStatistics(const ParquetColumnSchema &reader,
 	                                                            const vector<ColumnChunk> &columns, bool can_have_nan);
+
+	static void WriteListElementStats(ColumnChunk &column_chunk, const vector<BaseStatistics> &element_stats);
+	static void TryLoadListElementStats(BaseStatistics &list_stats, const ColumnChunk &column_chunk);
 
 	static unique_ptr<BaseStatistics>
 	TransformParquetStatistics(const LogicalType &type, const ParquetColumnSchema &schema,

--- a/extension/parquet/include/writer/list_column_writer.hpp
+++ b/extension/parquet/include/writer/list_column_writer.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "column_writer.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
 
 namespace duckdb {
 
@@ -22,6 +23,9 @@ public:
 	idx_t col_idx;
 	unique_ptr<ColumnWriterState> child_state;
 	idx_t parent_index = 0;
+	vector<BaseStatistics> element_stats;
+	LogicalType element_type;
+	bool collect_element_stats = false;
 };
 
 class ListColumnWriter : public ColumnWriter {
@@ -50,6 +54,11 @@ public:
 protected:
 	ColumnWriter &GetChildWriter();
 	const ColumnWriter &GetChildWriter() const;
+
+	void InitializeElementStats(ListColumnWriterState &state) const;
+	void CollectListElementStats(ListColumnWriterState &state, Vector &vector, idx_t count) const;
+	void CollectArrayElementStats(ListColumnWriterState &state, Vector &vector, idx_t count) const;
+	void FinalizeElementStats(ListColumnWriterState &state) const;
 };
 
 } // namespace duckdb

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -48,6 +48,9 @@
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/planner/table_filter.hpp"
+#include "duckdb/common/serializer/binary_deserializer.hpp"
+#include "duckdb/common/serializer/binary_serializer.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
 #include "duckdb/storage/statistics/geometry_stats.hpp"
 #include "duckdb/storage/statistics/numeric_stats.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
@@ -606,6 +609,120 @@ ParquetStatisticsUtils::TransformParquetStatistics(const LogicalType &type, cons
 	return unknown_stats.ToUnique();
 }
 
+static bool HasElementMinMax(const BaseStatistics &stats) {
+	switch (stats.GetStatsType()) {
+	case StatisticsType::NUMERIC_STATS:
+		return NumericStats::HasMinMax(stats);
+	case StatisticsType::STRING_STATS:
+		return StringStats::HasMinMax(stats);
+	default:
+		return false;
+	}
+}
+
+static Value GetElementMin(const BaseStatistics &stats) {
+	if (stats.GetStatsType() == StatisticsType::NUMERIC_STATS) {
+		return NumericStats::Min(stats);
+	}
+	return Value(StringStats::Min(stats));
+}
+
+static Value GetElementMax(const BaseStatistics &stats) {
+	if (stats.GetStatsType() == StatisticsType::NUMERIC_STATS) {
+		return NumericStats::Max(stats);
+	}
+	return Value(StringStats::Max(stats));
+}
+
+static string SerializeListElementStats(const vector<BaseStatistics> &element_stats) {
+	MemoryStream stream;
+	BinarySerializer serializer(stream);
+	serializer.Begin();
+	serializer.WriteProperty<uint32_t>(100, "version", 1);
+	vector<Value> mins;
+	vector<Value> maxs;
+	mins.reserve(element_stats.size());
+	maxs.reserve(element_stats.size());
+	for (auto &stats : element_stats) {
+		if (HasElementMinMax(stats)) {
+			mins.push_back(GetElementMin(stats));
+			maxs.push_back(GetElementMax(stats));
+		} else {
+			mins.emplace_back();
+			maxs.emplace_back();
+		}
+	}
+	serializer.WriteProperty(101, "mins", mins);
+	serializer.WriteProperty(102, "maxs", maxs);
+	serializer.End();
+	return string(char_ptr_cast(stream.GetData()), stream.GetPosition());
+}
+
+static void ApplyElementMinMax(BaseStatistics &stats, const Value &min, const Value &max) {
+	switch (stats.GetStatsType()) {
+	case StatisticsType::NUMERIC_STATS:
+		NumericStats::SetMin(stats, min);
+		NumericStats::SetMax(stats, max);
+		break;
+	case StatisticsType::STRING_STATS:
+		StringStats::SetMin(stats, string_t(StringValue::Get(min)), StringStatsType::EXACT_STATS);
+		StringStats::SetMax(stats, string_t(StringValue::Get(max)), StringStatsType::EXACT_STATS);
+		break;
+	default:
+		break;
+	}
+}
+
+void ParquetStatisticsUtils::WriteListElementStats(ColumnChunk &column_chunk,
+                                                   const vector<BaseStatistics> &element_stats) {
+	if (element_stats.empty()) {
+		return;
+	}
+	duckdb_parquet::KeyValue kv;
+	kv.__set_key(LIST_ELEMENT_STATS_KEY);
+	kv.__set_value(SerializeListElementStats(element_stats));
+	column_chunk.meta_data.key_value_metadata.push_back(std::move(kv));
+	column_chunk.meta_data.__isset.key_value_metadata = true;
+}
+
+void ParquetStatisticsUtils::TryLoadListElementStats(BaseStatistics &list_stats, const ColumnChunk &column_chunk) {
+	if (!column_chunk.__isset.meta_data || !column_chunk.meta_data.__isset.key_value_metadata) {
+		return;
+	}
+	for (auto &kv : column_chunk.meta_data.key_value_metadata) {
+		if (kv.key != LIST_ELEMENT_STATS_KEY) {
+			continue;
+		}
+		try {
+			vector<data_t> copy(kv.value.begin(), kv.value.end());
+			MemoryStream stream(copy.data(), copy.size());
+			BinaryDeserializer deserializer(stream);
+			deserializer.Begin();
+			auto version = deserializer.ReadProperty<uint32_t>(100, "version");
+			auto mins = deserializer.ReadProperty<vector<Value>>(101, "mins");
+			auto maxs = deserializer.ReadProperty<vector<Value>>(102, "maxs");
+			deserializer.End();
+			if (version != 1 || mins.size() != maxs.size()) {
+				return;
+			}
+			auto &child_type = ListType::GetChildType(list_stats.GetType());
+			for (idx_t i = 0; i < mins.size(); i++) {
+				if (mins[i].IsNull() || maxs[i].IsNull()) {
+					continue;
+				}
+				auto element_stats = BaseStatistics::CreateEmpty(child_type);
+				ApplyElementMinMax(element_stats, mins[i], maxs[i]);
+				element_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+				element_stats.Set(StatsInfo::CAN_HAVE_VALID_VALUES);
+				ListStats::SetElementStats(list_stats, i, element_stats);
+			}
+		} catch (const std::exception &) {
+			return;
+		}
+		return;
+	}
+}
+
 unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(const ParquetColumnSchema &schema,
                                                                              const vector<ColumnChunk> &columns,
                                                                              bool can_have_nan) {
@@ -622,6 +739,9 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 		auto &child_schema = schema.children[0];
 		auto child_stats = ParquetStatisticsUtils::TransformColumnStatistics(child_schema, columns, can_have_nan);
 		ListStats::SetChildStats(list_stats, std::move(child_stats));
+		if (child_schema.children.empty() && child_schema.column_index < columns.size()) {
+			TryLoadListElementStats(list_stats, columns[child_schema.column_index]);
+		}
 		row_group_stats = list_stats.ToUnique();
 		return row_group_stats;
 	}

--- a/extension/parquet/writer/array_column_writer.cpp
+++ b/extension/parquet/writer/array_column_writer.cpp
@@ -79,6 +79,7 @@ void ArrayColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *p
 
 void ArrayColumnWriter::Write(ColumnWriterState &state_p, Vector &vector, idx_t count) {
 	auto &state = state_p.Cast<ListColumnWriterState>();
+	CollectArrayElementStats(state, vector, count);
 	auto array_size = ArrayType::GetSize(vector.GetType());
 	auto &array_child = ArrayVector::GetChildMutable(vector);
 	GetChildWriter().Write(*state.child_state, array_child, count * array_size);

--- a/extension/parquet/writer/list_column_writer.cpp
+++ b/extension/parquet/writer/list_column_writer.cpp
@@ -2,8 +2,10 @@
 #include <string>
 #include <utility>
 
+#include "duckdb/common/vector/array_vector.hpp"
 #include "duckdb/common/vector/list_vector.hpp"
 #include "writer/list_column_writer.hpp"
+#include "writer/primitive_column_writer.hpp"
 #include "column_writer.hpp"
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/exception.hpp"
@@ -18,7 +20,12 @@
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/storage/statistics/list_stats.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
+#include "duckdb/storage/statistics/string_stats.hpp"
 #include "parquet_column_schema.hpp"
+#include "parquet_statistics.hpp"
 #include "parquet_types.h"
 
 namespace duckdb {
@@ -28,9 +35,115 @@ using namespace duckdb_parquet; // NOLINT
 using duckdb_parquet::ConvertedType;
 using duckdb_parquet::FieldRepetitionType;
 
+static bool CanCollectElementStats(const LogicalType &type) {
+	auto stats_type = BaseStatistics::GetStatsType(type);
+	return stats_type == StatisticsType::NUMERIC_STATS || stats_type == StatisticsType::STRING_STATS;
+}
+
+static bool HasElementMinMax(const BaseStatistics &stats) {
+	switch (stats.GetStatsType()) {
+	case StatisticsType::NUMERIC_STATS:
+		return NumericStats::HasMinMax(stats);
+	case StatisticsType::STRING_STATS:
+		return StringStats::HasMinMax(stats);
+	default:
+		return false;
+	}
+}
+
+static void UpdateElementStats(vector<BaseStatistics> &element_stats, const LogicalType &type, idx_t index,
+                               const Value &value) {
+	if (index >= ListStats::MAX_ELEMENT_STATS) {
+		return;
+	}
+	while (element_stats.size() <= index) {
+		element_stats.push_back(BaseStatistics::CreateUnknown(type));
+	}
+	if (value.IsNull()) {
+		element_stats[index].Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+		return;
+	}
+	auto value_stats = BaseStatistics::FromConstant(value);
+	if (element_stats[index].CanHaveNull()) {
+		value_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	}
+	if (!HasElementMinMax(element_stats[index])) {
+		element_stats[index] = std::move(value_stats);
+	} else {
+		element_stats[index].Merge(value_stats);
+	}
+}
+
+void ListColumnWriter::InitializeElementStats(ListColumnWriterState &state) const {
+	auto &type = Schema().type;
+	if (type.id() == LogicalTypeId::LIST) {
+		state.element_type = ListType::GetChildType(type);
+	} else if (type.id() == LogicalTypeId::ARRAY) {
+		state.element_type = ArrayType::GetChildType(type);
+	} else {
+		return;
+	}
+	state.collect_element_stats = CanCollectElementStats(state.element_type);
+}
+
+void ListColumnWriter::CollectListElementStats(ListColumnWriterState &state, Vector &vector, idx_t count) const {
+	if (!state.collect_element_stats) {
+		return;
+	}
+	UnifiedVectorFormat format;
+	vector.ToUnifiedFormat(format);
+	auto entries = UnifiedVectorFormat::GetData<list_entry_t>(format);
+	auto &child = ListVector::GetChild(vector);
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = format.sel->get_index(i);
+		if (!format.validity.RowIsValid(idx)) {
+			continue;
+		}
+		auto entry = entries[idx];
+		auto length = MinValue<idx_t>(entry.length, ListStats::MAX_ELEMENT_STATS);
+		for (idx_t k = 0; k < length; k++) {
+			UpdateElementStats(state.element_stats, state.element_type, k, child.GetValue(entry.offset + k));
+		}
+	}
+}
+
+void ListColumnWriter::CollectArrayElementStats(ListColumnWriterState &state, Vector &vector, idx_t count) const {
+	if (!state.collect_element_stats) {
+		return;
+	}
+	auto array_size = ArrayType::GetSize(vector.GetType());
+	auto length = MinValue<idx_t>(array_size, ListStats::MAX_ELEMENT_STATS);
+	UnifiedVectorFormat format;
+	vector.ToUnifiedFormat(format);
+	auto &child = ArrayVector::GetChild(vector);
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = format.sel->get_index(i);
+		if (!format.validity.RowIsValid(idx)) {
+			continue;
+		}
+		auto offset = idx * array_size;
+		for (idx_t k = 0; k < length; k++) {
+			UpdateElementStats(state.element_stats, state.element_type, k, child.GetValue(offset + k));
+		}
+	}
+}
+
+void ListColumnWriter::FinalizeElementStats(ListColumnWriterState &state) const {
+	if (state.element_stats.empty()) {
+		return;
+	}
+	auto *primitive_state = dynamic_cast<PrimitiveColumnWriterState *>(state.child_state.get());
+	if (!primitive_state) {
+		return;
+	}
+	ParquetStatisticsUtils::WriteListElementStats(state.row_group.columns[primitive_state->col_idx],
+	                                               state.element_stats);
+}
+
 unique_ptr<ColumnWriterState> ListColumnWriter::InitializeWriteState(duckdb_parquet::RowGroup &row_group) {
 	auto result = make_uniq<ListColumnWriterState>(row_group, row_group.columns.size());
 	result->child_state = GetChildWriter().InitializeWriteState(row_group);
+	InitializeElementStats(*result);
 	return std::move(result);
 }
 
@@ -150,6 +263,7 @@ void ListColumnWriter::BeginWrite(ColumnWriterState &state_p) {
 
 void ListColumnWriter::Write(ColumnWriterState &state_p, Vector &vector, idx_t count) {
 	auto &state = state_p.Cast<ListColumnWriterState>();
+	CollectListElementStats(state, vector, count);
 
 	auto &list_child = ListVector::GetChildMutable(vector);
 	Vector child_list(Vector::Ref(list_child));
@@ -165,6 +279,7 @@ void ListColumnWriter::PrepareWrite(ColumnWriterState &state_p) {
 void ListColumnWriter::FinalizeWrite(ColumnWriterState &state_p) {
 	auto &state = state_p.Cast<ListColumnWriterState>();
 	GetChildWriter().FinalizeWrite(*state.child_state);
+	FinalizeElementStats(state);
 }
 
 ColumnWriter &ListColumnWriter::GetChildWriter() {

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/exception/conversion_exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
@@ -11,6 +12,7 @@
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/statistics/list_stats.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
 
 namespace duckdb {
 
@@ -157,6 +159,18 @@ static unique_ptr<FunctionData> StringExtractBind(BindScalarFunctionInput &input
 static unique_ptr<BaseStatistics> ListExtractStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
 	auto &list_child_stats = ListStats::GetChildStats(child_stats[0]);
+	if (child_stats.size() >= 2 && child_stats[1].GetStatsType() == StatisticsType::NUMERIC_STATS &&
+	    NumericStats::HasMinMax(child_stats[1]) && NumericStats::IsConstant(child_stats[1])) {
+		auto extract_index = NumericStats::Min(child_stats[1]).DefaultCastAs(LogicalType::BIGINT).GetValue<int64_t>();
+		if (extract_index > 0) {
+			auto element_stats = ListStats::TryGetElementStats(child_stats[0], NumericCast<idx_t>(extract_index - 1));
+			if (element_stats) {
+				auto element_copy = element_stats->Copy();
+				element_copy.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+				return element_copy.ToUnique();
+			}
+		}
+	}
 	auto child_copy = list_child_stats.Copy();
 	// list_extract always pushes a NULL, since if the offset is out of range for a list it inserts a null
 	child_copy.Set(StatsInfo::CAN_HAVE_NULL_VALUES);

--- a/src/include/duckdb/storage/statistics/list_stats.hpp
+++ b/src/include/duckdb/storage/statistics/list_stats.hpp
@@ -34,6 +34,7 @@ struct ListStats {
 
 	DUCKDB_API static optional_ptr<const BaseStatistics> TryGetElementStats(const BaseStatistics &stats, idx_t index);
 	DUCKDB_API static void SetElementStats(BaseStatistics &stats, idx_t index, const BaseStatistics &element_stats);
+	DUCKDB_API static void UpdateElementStats(BaseStatistics &stats, const Vector &vector, idx_t count);
 
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);

--- a/src/include/duckdb/storage/statistics/list_stats.hpp
+++ b/src/include/duckdb/storage/statistics/list_stats.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/storage/statistics/stats_merge_type.hpp"
 
@@ -20,6 +21,9 @@ class Vector;
 class Value;
 
 struct ListStats {
+	//! Per-index min/max for the first N list/array elements (SQL index 1 = offset 0)
+	static constexpr idx_t MAX_ELEMENT_STATS = 32;
+
 	DUCKDB_API static void Construct(BaseStatistics &stats);
 	DUCKDB_API static BaseStatistics CreateUnknown(LogicalType type);
 	DUCKDB_API static BaseStatistics CreateEmpty(LogicalType type);
@@ -27,6 +31,9 @@ struct ListStats {
 	DUCKDB_API static const BaseStatistics &GetChildStats(const BaseStatistics &stats);
 	DUCKDB_API static BaseStatistics &GetChildStats(BaseStatistics &stats);
 	DUCKDB_API static void SetChildStats(BaseStatistics &stats, unique_ptr<BaseStatistics> new_stats);
+
+	DUCKDB_API static optional_ptr<const BaseStatistics> TryGetElementStats(const BaseStatistics &stats, idx_t index);
+	DUCKDB_API static void SetElementStats(BaseStatistics &stats, idx_t index, const BaseStatistics &element_stats);
 
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);

--- a/src/storage/statistics/list_stats.cpp
+++ b/src/storage/statistics/list_stats.cpp
@@ -9,6 +9,10 @@
 
 namespace duckdb {
 
+struct ListElementStatsExtraData : public ExtraStatsData {
+	vector<BaseStatistics> element_stats;
+};
+
 void ListStats::Construct(BaseStatistics &stats) {
 	stats.child_stats = unsafe_unique_array<BaseStatistics>(new BaseStatistics[1]);
 	BaseStatistics::Construct(stats.child_stats[0], ListType::GetChildType(stats.GetType()));
@@ -34,6 +38,17 @@ void ListStats::Copy(BaseStatistics &stats, const BaseStatistics &other) {
 	D_ASSERT(stats.child_stats);
 	D_ASSERT(other.child_stats);
 	stats.child_stats[0].Copy(other.child_stats[0]);
+	stats.extra_data.reset();
+	if (!other.extra_data) {
+		return;
+	}
+	auto &src = other.extra_data->Cast<ListElementStatsExtraData>();
+	auto dst = make_uniq<ListElementStatsExtraData>();
+	dst->element_stats.reserve(src.element_stats.size());
+	for (auto &element_stats : src.element_stats) {
+		dst->element_stats.push_back(element_stats.Copy());
+	}
+	stats.extra_data = std::move(dst);
 }
 
 const BaseStatistics &ListStats::GetChildStats(const BaseStatistics &stats) {
@@ -59,6 +74,32 @@ void ListStats::SetChildStats(BaseStatistics &stats, unique_ptr<BaseStatistics> 
 	}
 }
 
+optional_ptr<const BaseStatistics> ListStats::TryGetElementStats(const BaseStatistics &stats, idx_t index) {
+	if (stats.GetStatsType() != StatisticsType::LIST_STATS || !stats.extra_data) {
+		return nullptr;
+	}
+	auto &extra = stats.extra_data->Cast<ListElementStatsExtraData>();
+	if (index >= extra.element_stats.size()) {
+		return nullptr;
+	}
+	return extra.element_stats[index];
+}
+
+void ListStats::SetElementStats(BaseStatistics &stats, idx_t index, const BaseStatistics &element_stats) {
+	if (stats.GetStatsType() != StatisticsType::LIST_STATS || index >= MAX_ELEMENT_STATS) {
+		return;
+	}
+	if (!stats.extra_data) {
+		stats.extra_data = make_uniq<ListElementStatsExtraData>();
+	}
+	auto &extra = stats.extra_data->Cast<ListElementStatsExtraData>();
+	auto &child_type = ListType::GetChildType(stats.GetType());
+	while (extra.element_stats.size() <= index) {
+		extra.element_stats.push_back(BaseStatistics::CreateUnknown(child_type));
+	}
+	extra.element_stats[index] = element_stats.Copy();
+}
+
 void ListStats::Merge(BaseStatistics &stats, const BaseStatistics &other, StatsMergeType merge_type) {
 	if (other.GetType().id() == LogicalTypeId::VALIDITY) {
 		return;
@@ -67,6 +108,36 @@ void ListStats::Merge(BaseStatistics &stats, const BaseStatistics &other, StatsM
 	auto &child_stats = ListStats::GetChildStats(stats);
 	auto &other_child_stats = ListStats::GetChildStats(other);
 	child_stats.Merge(other_child_stats, merge_type);
+
+	if (!other.extra_data) {
+		stats.extra_data.reset();
+		return;
+	}
+	if (!stats.extra_data) {
+		auto &src = other.extra_data->Cast<ListElementStatsExtraData>();
+		auto dst = make_uniq<ListElementStatsExtraData>();
+		dst->element_stats.reserve(src.element_stats.size());
+		for (auto &element_stats : src.element_stats) {
+			dst->element_stats.push_back(element_stats.Copy());
+		}
+		stats.extra_data = std::move(dst);
+		return;
+	}
+
+	auto &dst = stats.extra_data->Cast<ListElementStatsExtraData>();
+	auto &src = other.extra_data->Cast<ListElementStatsExtraData>();
+	const auto count = dst.element_stats.size() > src.element_stats.size() ? dst.element_stats.size()
+	                                                                       : src.element_stats.size();
+	for (idx_t i = 0; i < count; i++) {
+		if (i >= dst.element_stats.size()) {
+			dst.element_stats.push_back(src.element_stats[i].Copy());
+			dst.element_stats[i].Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+		} else if (i >= src.element_stats.size()) {
+			dst.element_stats[i].Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+		} else {
+			dst.element_stats[i].Merge(src.element_stats[i], merge_type);
+		}
+	}
 }
 
 void ListStats::Serialize(const BaseStatistics &stats, Serializer &serializer) {

--- a/src/storage/statistics/list_stats.cpp
+++ b/src/storage/statistics/list_stats.cpp
@@ -1,6 +1,9 @@
 #include "duckdb/common/vector/list_vector.hpp"
 #include "duckdb/storage/statistics/list_stats.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
+#include "duckdb/storage/statistics/string_stats.hpp"
+#include "duckdb/common/helper.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/vector.hpp"
 
@@ -100,6 +103,63 @@ void ListStats::SetElementStats(BaseStatistics &stats, idx_t index, const BaseSt
 	extra.element_stats[index] = element_stats.Copy();
 }
 
+static bool HasElementMinMax(const BaseStatistics &stats) {
+	switch (stats.GetStatsType()) {
+	case StatisticsType::NUMERIC_STATS:
+		return NumericStats::HasMinMax(stats);
+	case StatisticsType::STRING_STATS:
+		return StringStats::HasMinMax(stats);
+	default:
+		return false;
+	}
+}
+
+void ListStats::UpdateElementStats(BaseStatistics &stats, const Vector &vector, idx_t count) {
+	if (stats.GetStatsType() != StatisticsType::LIST_STATS) {
+		return;
+	}
+	auto &child_type = ListType::GetChildType(stats.GetType());
+	auto child_stats_type = BaseStatistics::GetStatsType(child_type);
+	if (child_stats_type != StatisticsType::NUMERIC_STATS && child_stats_type != StatisticsType::STRING_STATS) {
+		return;
+	}
+
+	UnifiedVectorFormat format;
+	vector.ToUnifiedFormat(format);
+	auto entries = UnifiedVectorFormat::GetData<list_entry_t>(format);
+	auto &child = ListVector::GetChild(vector);
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = format.sel->get_index(i);
+		if (!format.validity.RowIsValid(idx)) {
+			continue;
+		}
+		auto entry = entries[idx];
+		auto length = MinValue<idx_t>(entry.length, MAX_ELEMENT_STATS);
+		for (idx_t k = 0; k < length; k++) {
+			auto value = child.GetValue(entry.offset + k);
+			if (value.IsNull()) {
+				auto existing = TryGetElementStats(stats, k);
+				auto element_stats = existing ? existing->Copy() : BaseStatistics::CreateUnknown(child_type);
+				element_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+				SetElementStats(stats, k, element_stats);
+				continue;
+			}
+			auto value_stats = BaseStatistics::FromConstant(value);
+			auto existing = TryGetElementStats(stats, k);
+			if (existing && existing->CanHaveNull()) {
+				value_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+			}
+			if (existing && HasElementMinMax(*existing)) {
+				auto merged = existing->Copy();
+				merged.Merge(value_stats);
+				SetElementStats(stats, k, merged);
+			} else {
+				SetElementStats(stats, k, value_stats);
+			}
+		}
+	}
+}
+
 void ListStats::Merge(BaseStatistics &stats, const BaseStatistics &other, StatsMergeType merge_type) {
 	if (other.GetType().id() == LogicalTypeId::VALIDITY) {
 		return;
@@ -110,7 +170,6 @@ void ListStats::Merge(BaseStatistics &stats, const BaseStatistics &other, StatsM
 	child_stats.Merge(other_child_stats, merge_type);
 
 	if (!other.extra_data) {
-		stats.extra_data.reset();
 		return;
 	}
 	if (!stats.extra_data) {
@@ -143,6 +202,25 @@ void ListStats::Merge(BaseStatistics &stats, const BaseStatistics &other, StatsM
 void ListStats::Serialize(const BaseStatistics &stats, Serializer &serializer) {
 	auto &child_stats = ListStats::GetChildStats(stats);
 	serializer.WriteProperty(200, "child_stats", child_stats);
+
+	vector<Value> mins;
+	vector<Value> maxs;
+	if (stats.extra_data) {
+		auto &extra = stats.extra_data->Cast<ListElementStatsExtraData>();
+		mins.reserve(extra.element_stats.size());
+		maxs.reserve(extra.element_stats.size());
+		for (auto &element_stats : extra.element_stats) {
+			if (HasElementMinMax(element_stats) && element_stats.GetStatsType() == StatisticsType::NUMERIC_STATS) {
+				mins.push_back(NumericStats::Min(element_stats));
+				maxs.push_back(NumericStats::Max(element_stats));
+			} else {
+				mins.emplace_back();
+				maxs.emplace_back();
+			}
+		}
+	}
+	serializer.WritePropertyWithDefault(201, "element_mins", mins, vector<Value>());
+	serializer.WritePropertyWithDefault(202, "element_maxs", maxs, vector<Value>());
 }
 
 void ListStats::Deserialize(Deserializer &deserializer, BaseStatistics &base) {
@@ -153,7 +231,26 @@ void ListStats::Deserialize(Deserializer &deserializer, BaseStatistics &base) {
 	// Push the logical type of the child type to the deserialization context
 	deserializer.Set<const LogicalType &>(child_type);
 	base.child_stats[0].Copy(deserializer.ReadProperty<BaseStatistics>(200, "child_stats"));
+	auto mins = deserializer.ReadPropertyWithExplicitDefault<vector<Value>>(201, "element_mins", {});
+	auto maxs = deserializer.ReadPropertyWithExplicitDefault<vector<Value>>(202, "element_maxs", {});
 	deserializer.Unset<LogicalType>();
+
+	if (mins.size() != maxs.size()) {
+		return;
+	}
+	for (idx_t i = 0; i < mins.size(); i++) {
+		if (mins[i].IsNull() || maxs[i].IsNull()) {
+			continue;
+		}
+		auto element_stats = BaseStatistics::CreateEmpty(child_type);
+		if (element_stats.GetStatsType() == StatisticsType::NUMERIC_STATS) {
+			NumericStats::SetMin(element_stats, mins[i]);
+			NumericStats::SetMax(element_stats, maxs[i]);
+		}
+		element_stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+		element_stats.Set(StatsInfo::CAN_HAVE_VALID_VALUES);
+		SetElementStats(base, i, element_stats);
+	}
 }
 
 child_list_t<Value> ListStats::ToStruct(const BaseStatistics &stats) {

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -243,6 +243,13 @@ void ListColumnData::Append(ColumnAppendState &state, const Vector &vector, idx_
 	// append the validity data
 	vdata.validity = append_mask;
 	validity->AppendData(state.child_appends[0], vdata, count);
+
+	if (state.append_stats) {
+		ListStats::UpdateElementStats(*state.append_stats, vector, count);
+	}
+	if (state.full_append_stats) {
+		ListStats::UpdateElementStats(*state.full_append_stats, vector, count);
+	}
 }
 
 void ListColumnData::FinalizeAppend(ColumnDataFinalizeAppendState &finalize_state, ColumnAppendState &state) {
@@ -387,10 +394,10 @@ public:
 	}
 
 	unique_ptr<BaseStatistics> GetStatistics() override {
-		auto stats = global_stats->Copy();
-		stats.Merge(*validity_state->GetStatistics());
-		ListStats::SetChildStats(stats, child_state->GetStatistics());
-		return stats.ToUnique();
+		auto stats = original_column.GetStatistics();
+		stats->Merge(*validity_state->GetStatistics());
+		ListStats::SetChildStats(*stats, child_state->GetStatistics());
+		return stats;
 	}
 
 	PersistentColumnData ToPersistentData() override {

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -18,6 +18,7 @@
         "test/sql/types/geo/geometry_parquet_pushdown.test",
         "test/optimizer/statistics/statistics_filter_pruning.test",
         "test/sql/copy/parquet/parquet_expression_filter_pruning.test",
+        "test/sql/copy/parquet/list_extract_row_group_pruning.test",
         "test/sql/copy/parquet/parquet_virtual_file_row_group_number.test"
       ]
     },

--- a/test/sql/copy/parquet/list_extract_row_group_pruning.test
+++ b/test/sql/copy/parquet/list_extract_row_group_pruning.test
@@ -1,0 +1,57 @@
+# name: test/sql/copy/parquet/list_extract_row_group_pruning.test
+# description: Per-index list/array extract stats prune parquet row groups when another slot poisons merged child min/max
+# group: [parquet]
+
+require parquet
+
+# Constant 3000 in slot 1 poisons merged child stats; slot 2 is the row index.
+# Row groups: [0,2048), [2048,4096), [4096,6144). Only the middle group has i in 2900..3100.
+
+statement ok
+COPY (SELECT [3000, i] AS l FROM range(6144) t(i))
+TO '{TEST_DIR}/list_extract_prune.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+
+statement ok
+COPY (SELECT [3000, i]::INTEGER[2] AS a FROM range(6144) t(i))
+TO '{TEST_DIR}/array_extract_prune.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/list_extract_prune.parquet' WHERE l[2] BETWEEN 2900 AND 3100
+----
+201
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM '{TEST_DIR}/list_extract_prune.parquet' WHERE l[2] BETWEEN 2900 AND 3100
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/array_extract_prune.parquet' WHERE a[2] BETWEEN 2900 AND 3100
+----
+201
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM '{TEST_DIR}/array_extract_prune.parquet' WHERE a[2] BETWEEN 2900 AND 3100
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 3.*
+
+# Slot 1 is the constant 3000, so every row matches and no groups can be skipped
+query I
+SELECT count(*) FROM '{TEST_DIR}/list_extract_prune.parquet' WHERE l[1] BETWEEN 2900 AND 3100
+----
+6144
+
+# Merged child stats still prune when every element is outside the range
+statement ok
+COPY (SELECT [i, i + 1, i + 2] AS l FROM range(6144) t(i))
+TO '{TEST_DIR}/list_extract_merged.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/list_extract_merged.parquet' WHERE l[1] BETWEEN 2900 AND 3100
+----
+201
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM '{TEST_DIR}/list_extract_merged.parquet' WHERE l[1] BETWEEN 2900 AND 3100
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 3.*

--- a/test/sql/optimizer/list_extract_row_group_pruning.test
+++ b/test/sql/optimizer/list_extract_row_group_pruning.test
@@ -1,0 +1,48 @@
+# name: test/sql/optimizer/list_extract_row_group_pruning.test
+# description: List extracts use child / per-index statistics for row-group pruning
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/list_extract_row_group_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# Elements move together: merged child min/max is enough
+statement ok
+CREATE TABLE lists AS
+SELECT [i::INTEGER, (i + 1)::INTEGER, (i + 2)::INTEGER] AS l
+FROM range(6144) tbl(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM lists WHERE l[1] BETWEEN 2900 AND 3100;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM lists WHERE l[1] BETWEEN 2900 AND 3100;
+----
+201
+
+# Constant 3000 in slot 1 poisons merged child stats; slot 2 is the row index.
+# Row groups: [0,2048), [2048,4096), [4096,6144). Only the middle group has i in 2900..3100.
+statement ok
+CREATE TABLE noisy_lists AS
+SELECT [3000, i] AS l
+FROM range(6144) tbl(i);
+
+query I
+SELECT count(*) FROM noisy_lists WHERE l[2] BETWEEN 2900 AND 3100;
+----
+201
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM noisy_lists WHERE l[2] BETWEEN 2900 AND 3100;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# Slot 1 is the constant 3000, so every row matches
+query I
+SELECT count(*) FROM noisy_lists WHERE l[1] BETWEEN 2900 AND 3100;
+----
+6144


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes statistics collection, merge/checkpoint behavior, and Parquet metadata used for zone-map pruning; incorrect stats could skip row groups, though behavior is covered by new pruning tests.
> 
> **Overview**
> Adds **per-position min/max statistics** for the first 32 list/array elements so filters like `l[2] BETWEEN …` can prune row groups when merged child min/max is misleading (e.g. a constant in slot 1 widening the global range).
> 
> **Storage & stats:** `ListStats` stores per-index stats in `extra_data`, updates them on list column append and checkpoint merge, and serializes them with list statistics. **`list_extract`** propagates stats from `TryGetElementStats` when the index argument is a known constant instead of always using aggregate child stats.
> 
> **Parquet:** List/array column writers collect numeric/string element stats during write and attach a binary `duckdb.list_element_stats` KV payload on the child column chunk; read path loads it into `ListStats` when building column statistics.
> 
> New SQL tests assert **1 / 3** row groups scanned for both native tables and Parquet when filtering on a non-poisoned list index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d56fa53b3de713ead1d677bf4d10d45693bf8a25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->