### PR TITLE
prune list parquet

### DIFF
--- a/extension/parquet/include/parquet_statistics.hpp
+++ b/extension/parquet/include/parquet_statistics.hpp
@@ -55,9 +55,11 @@ enum class ParquetBloomFilterHashStrategy : uint8_t { STANDARD, NORMALIZED_INTER
 struct ParquetStatisticsUtils {
 	static constexpr const char *INTERVAL_BLOOM_FILTER_KEY = "duckdb.interval_bloom_filter";
 	static constexpr const char *INTERVAL_BLOOM_FILTER_VALUE = "normalized-v1";
+	static constexpr const char *LIST_ELEMENT_STATS_KEY = "duckdb.list_element_stats";
 
 	static unique_ptr<BaseStatistics> TransformColumnStatistics(const ParquetColumnSchema &reader,
 	                                                            const vector<ColumnChunk> &columns, bool can_have_nan);
+	static void WriteListElementStats(ColumnChunk &column_chunk, const BaseStatistics &list_stats);
 
 	static unique_ptr<BaseStatistics>
 	TransformParquetStatistics(const LogicalType &type, const ParquetColumnSchema &schema,

--- a/extension/parquet/include/writer/list_column_writer.hpp
+++ b/extension/parquet/include/writer/list_column_writer.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "column_writer.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
 
 namespace duckdb {
 
@@ -22,6 +23,7 @@ public:
 	idx_t col_idx;
 	unique_ptr<ColumnWriterState> child_state;
 	idx_t parent_index = 0;
+	unique_ptr<BaseStatistics> element_stats;
 };
 
 class ListColumnWriter : public ColumnWriter {

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/hugeint.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 #include "duckdb/storage/statistics/list_stats.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
@@ -606,6 +607,62 @@ ParquetStatisticsUtils::TransformParquetStatistics(const LogicalType &type, cons
 	return unknown_stats.ToUnique();
 }
 
+void ParquetStatisticsUtils::WriteListElementStats(ColumnChunk &column_chunk, const BaseStatistics &list_stats) {
+	string blob;
+	bool any = false;
+	for (idx_t i = 0; i < ListStats::MAX_ELEMENT_STATS; i++) {
+		auto stats = ListStats::TryGetElementStats(list_stats, i);
+		if (!stats || stats->GetStatsType() != StatisticsType::NUMERIC_STATS || !NumericStats::HasMinMax(*stats)) {
+			blob += ";";
+			continue;
+		}
+		any = true;
+		blob += NumericStats::Min(*stats).ToString() + "," + NumericStats::Max(*stats).ToString() + ";";
+	}
+	if (!any) {
+		return;
+	}
+	duckdb_parquet::KeyValue kv;
+	kv.__set_key(LIST_ELEMENT_STATS_KEY);
+	kv.__set_value(blob);
+	column_chunk.meta_data.key_value_metadata.push_back(std::move(kv));
+	column_chunk.meta_data.__isset.key_value_metadata = true;
+}
+
+static void LoadListElementStats(BaseStatistics &list_stats, const ColumnChunk &column_chunk) {
+	if (!column_chunk.__isset.meta_data || !column_chunk.meta_data.__isset.key_value_metadata) {
+		return;
+	}
+	auto &child_type = ListType::GetChildType(list_stats.GetType());
+	if (BaseStatistics::GetStatsType(child_type) != StatisticsType::NUMERIC_STATS) {
+		return;
+	}
+	for (auto &kv : column_chunk.meta_data.key_value_metadata) {
+		if (kv.key != ParquetStatisticsUtils::LIST_ELEMENT_STATS_KEY) {
+			continue;
+		}
+		auto entries = StringUtil::Split(kv.value, ";");
+		for (idx_t i = 0; i < entries.size() && i < ListStats::MAX_ELEMENT_STATS; i++) {
+			auto comma = entries[i].find(',');
+			if (comma == string::npos) {
+				continue;
+			}
+			auto min = Value(entries[i].substr(0, comma)).DefaultTryCastAs(child_type);
+			auto max = Value(entries[i].substr(comma + 1)).DefaultTryCastAs(child_type);
+			if (!min || !max || min->IsNull() || max->IsNull()) {
+				continue;
+			}
+			auto stats = BaseStatistics::CreateEmpty(child_type);
+			NumericStats::SetMin(stats, *min);
+			NumericStats::SetMax(stats, *max);
+			stats.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+			stats.Set(StatsInfo::CAN_HAVE_VALID_VALUES);
+			ListStats::SetElementStats(list_stats, i, stats);
+		}
+		return;
+	}
+}
+
 unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(const ParquetColumnSchema &schema,
                                                                              const vector<ColumnChunk> &columns,
                                                                              bool can_have_nan) {
@@ -622,6 +679,9 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 		auto &child_schema = schema.children[0];
 		auto child_stats = ParquetStatisticsUtils::TransformColumnStatistics(child_schema, columns, can_have_nan);
 		ListStats::SetChildStats(list_stats, std::move(child_stats));
+		if (child_schema.children.empty() && child_schema.column_index < columns.size()) {
+			LoadListElementStats(list_stats, columns[child_schema.column_index]);
+		}
 		row_group_stats = list_stats.ToUnique();
 		return row_group_stats;
 	}

--- a/extension/parquet/writer/list_column_writer.cpp
+++ b/extension/parquet/writer/list_column_writer.cpp
@@ -4,7 +4,10 @@
 
 #include "duckdb/common/vector/list_vector.hpp"
 #include "writer/list_column_writer.hpp"
+#include "writer/primitive_column_writer.hpp"
 #include "column_writer.hpp"
+#include "duckdb/storage/statistics/list_stats.hpp"
+#include "parquet_statistics.hpp"
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/helper.hpp"
@@ -31,6 +34,9 @@ using duckdb_parquet::FieldRepetitionType;
 unique_ptr<ColumnWriterState> ListColumnWriter::InitializeWriteState(duckdb_parquet::RowGroup &row_group) {
 	auto result = make_uniq<ListColumnWriterState>(row_group, row_group.columns.size());
 	result->child_state = GetChildWriter().InitializeWriteState(row_group);
+	if (Schema().type.id() == LogicalTypeId::LIST) {
+		result->element_stats = ListStats::CreateEmpty(Schema().type).ToUnique();
+	}
 	return std::move(result);
 }
 
@@ -150,6 +156,9 @@ void ListColumnWriter::BeginWrite(ColumnWriterState &state_p) {
 
 void ListColumnWriter::Write(ColumnWriterState &state_p, Vector &vector, idx_t count) {
 	auto &state = state_p.Cast<ListColumnWriterState>();
+	if (state.element_stats) {
+		ListStats::UpdateElementStats(*state.element_stats, vector, count);
+	}
 
 	auto &list_child = ListVector::GetChildMutable(vector);
 	Vector child_list(Vector::Ref(list_child));
@@ -165,6 +174,11 @@ void ListColumnWriter::PrepareWrite(ColumnWriterState &state_p) {
 void ListColumnWriter::FinalizeWrite(ColumnWriterState &state_p) {
 	auto &state = state_p.Cast<ListColumnWriterState>();
 	GetChildWriter().FinalizeWrite(*state.child_state);
+	auto *primitive_state = dynamic_cast<PrimitiveColumnWriterState *>(state.child_state.get());
+	if (state.element_stats && primitive_state) {
+		ParquetStatisticsUtils::WriteListElementStats(state.row_group.columns[primitive_state->col_idx],
+		                                               *state.element_stats);
+	}
 }
 
 ColumnWriter &ListColumnWriter::GetChildWriter() {

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -10,7 +10,9 @@
 #include "duckdb/parser/expression/bound_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/storage/statistics/list_stats.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
 
 namespace duckdb {
 
@@ -156,8 +158,19 @@ static unique_ptr<FunctionData> StringExtractBind(BindScalarFunctionInput &input
 
 static unique_ptr<BaseStatistics> ListExtractStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
-	auto &list_child_stats = ListStats::GetChildStats(child_stats[0]);
-	auto child_copy = list_child_stats.Copy();
+	if (child_stats.size() >= 2 && child_stats[1].GetStatsType() == StatisticsType::NUMERIC_STATS &&
+	    NumericStats::HasMinMax(child_stats[1]) && NumericStats::IsConstant(child_stats[1])) {
+		auto extract_index = NumericStats::Min(child_stats[1]).DefaultCastAs(LogicalType::BIGINT).GetValue<int64_t>();
+		if (extract_index > 0) {
+			if (auto element_stats =
+			        ListStats::TryGetElementStats(child_stats[0], NumericCast<idx_t>(extract_index - 1))) {
+				auto element_copy = element_stats->Copy();
+				element_copy.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+				return element_copy.ToUnique();
+			}
+		}
+	}
+	auto child_copy = ListStats::GetChildStats(child_stats[0]).Copy();
 	// list_extract always pushes a NULL, since if the offset is out of range for a list it inserts a null
 	child_copy.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
 	return child_copy.ToUnique();

--- a/src/include/duckdb/storage/statistics/list_stats.hpp
+++ b/src/include/duckdb/storage/statistics/list_stats.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/storage/statistics/stats_merge_type.hpp"
 
@@ -20,6 +21,8 @@ class Vector;
 class Value;
 
 struct ListStats {
+	static constexpr idx_t MAX_ELEMENT_STATS = 32;
+
 	DUCKDB_API static void Construct(BaseStatistics &stats);
 	DUCKDB_API static BaseStatistics CreateUnknown(LogicalType type);
 	DUCKDB_API static BaseStatistics CreateEmpty(LogicalType type);
@@ -27,6 +30,10 @@ struct ListStats {
 	DUCKDB_API static const BaseStatistics &GetChildStats(const BaseStatistics &stats);
 	DUCKDB_API static BaseStatistics &GetChildStats(BaseStatistics &stats);
 	DUCKDB_API static void SetChildStats(BaseStatistics &stats, unique_ptr<BaseStatistics> new_stats);
+
+	DUCKDB_API static optional_ptr<const BaseStatistics> TryGetElementStats(const BaseStatistics &stats, idx_t index);
+	DUCKDB_API static void SetElementStats(BaseStatistics &stats, idx_t index, const BaseStatistics &element_stats);
+	DUCKDB_API static void UpdateElementStats(BaseStatistics &stats, const Vector &vector, idx_t count);
 
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);

--- a/src/storage/statistics/list_stats.cpp
+++ b/src/storage/statistics/list_stats.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/vector/list_vector.hpp"
 #include "duckdb/storage/statistics/list_stats.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/common/helper.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/vector.hpp"
 
@@ -8,6 +9,20 @@
 #include "duckdb/common/serializer/deserializer.hpp"
 
 namespace duckdb {
+
+struct ListElementStatsExtraData : public ExtraStatsData {
+	vector<BaseStatistics> element_stats;
+};
+
+static unique_ptr<ListElementStatsExtraData> CopyElementStats(const ExtraStatsData &src) {
+	auto &extra = src.Cast<ListElementStatsExtraData>();
+	auto result = make_uniq<ListElementStatsExtraData>();
+	result->element_stats.reserve(extra.element_stats.size());
+	for (auto &stats : extra.element_stats) {
+		result->element_stats.push_back(stats.Copy());
+	}
+	return result;
+}
 
 void ListStats::Construct(BaseStatistics &stats) {
 	stats.child_stats = unsafe_unique_array<BaseStatistics>(new BaseStatistics[1]);
@@ -34,6 +49,7 @@ void ListStats::Copy(BaseStatistics &stats, const BaseStatistics &other) {
 	D_ASSERT(stats.child_stats);
 	D_ASSERT(other.child_stats);
 	stats.child_stats[0].Copy(other.child_stats[0]);
+	stats.extra_data = other.extra_data ? CopyElementStats(*other.extra_data) : nullptr;
 }
 
 const BaseStatistics &ListStats::GetChildStats(const BaseStatistics &stats) {
@@ -59,6 +75,61 @@ void ListStats::SetChildStats(BaseStatistics &stats, unique_ptr<BaseStatistics> 
 	}
 }
 
+optional_ptr<const BaseStatistics> ListStats::TryGetElementStats(const BaseStatistics &stats, idx_t index) {
+	if (!stats.extra_data) {
+		return nullptr;
+	}
+	auto &extra = stats.extra_data->Cast<ListElementStatsExtraData>();
+	return index < extra.element_stats.size() ? &extra.element_stats[index] : nullptr;
+}
+
+void ListStats::SetElementStats(BaseStatistics &stats, idx_t index, const BaseStatistics &element_stats) {
+	if (index >= MAX_ELEMENT_STATS) {
+		return;
+	}
+	if (!stats.extra_data) {
+		stats.extra_data = make_uniq<ListElementStatsExtraData>();
+	}
+	auto &extra = stats.extra_data->Cast<ListElementStatsExtraData>();
+	while (extra.element_stats.size() <= index) {
+		extra.element_stats.push_back(BaseStatistics::CreateUnknown(ListType::GetChildType(stats.GetType())));
+	}
+	extra.element_stats[index] = element_stats.Copy();
+}
+
+void ListStats::UpdateElementStats(BaseStatistics &stats, const Vector &vector, idx_t count) {
+	auto &child_type = ListType::GetChildType(stats.GetType());
+	if (BaseStatistics::GetStatsType(child_type) != StatisticsType::NUMERIC_STATS) {
+		return;
+	}
+	UnifiedVectorFormat format;
+	vector.ToUnifiedFormat(format);
+	auto entries = UnifiedVectorFormat::GetData<list_entry_t>(format);
+	auto &child = ListVector::GetChild(vector);
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = format.sel->get_index(i);
+		if (!format.validity.RowIsValid(idx)) {
+			continue;
+		}
+		auto &entry = entries[idx];
+		auto length = MinValue<idx_t>(entry.length, MAX_ELEMENT_STATS);
+		for (idx_t k = 0; k < length; k++) {
+			auto value = child.GetValue(entry.offset + k);
+			auto next = value.IsNull() ? BaseStatistics::CreateUnknown(child_type) : BaseStatistics::FromConstant(value);
+			if (value.IsNull()) {
+				next.Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+			}
+			if (auto prev = TryGetElementStats(stats, k)) {
+				auto merged = prev->Copy();
+				merged.Merge(next);
+				SetElementStats(stats, k, merged);
+			} else {
+				SetElementStats(stats, k, next);
+			}
+		}
+	}
+}
+
 void ListStats::Merge(BaseStatistics &stats, const BaseStatistics &other, StatsMergeType merge_type) {
 	if (other.GetType().id() == LogicalTypeId::VALIDITY) {
 		return;
@@ -67,6 +138,25 @@ void ListStats::Merge(BaseStatistics &stats, const BaseStatistics &other, StatsM
 	auto &child_stats = ListStats::GetChildStats(stats);
 	auto &other_child_stats = ListStats::GetChildStats(other);
 	child_stats.Merge(other_child_stats, merge_type);
+	if (!other.extra_data) {
+		return;
+	}
+	if (!stats.extra_data) {
+		stats.extra_data = CopyElementStats(*other.extra_data);
+		return;
+	}
+	auto &dst = stats.extra_data->Cast<ListElementStatsExtraData>();
+	auto &src = other.extra_data->Cast<ListElementStatsExtraData>();
+	if (dst.element_stats.size() < src.element_stats.size()) {
+		dst.element_stats.reserve(src.element_stats.size());
+	}
+	for (idx_t i = 0; i < src.element_stats.size(); i++) {
+		if (i >= dst.element_stats.size()) {
+			dst.element_stats.push_back(src.element_stats[i].Copy());
+		} else {
+			dst.element_stats[i].Merge(src.element_stats[i], merge_type);
+		}
+	}
 }
 
 void ListStats::Serialize(const BaseStatistics &stats, Serializer &serializer) {

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -243,6 +243,12 @@ void ListColumnData::Append(ColumnAppendState &state, const Vector &vector, idx_
 	// append the validity data
 	vdata.validity = append_mask;
 	validity->AppendData(state.child_appends[0], vdata, count);
+	if (state.append_stats) {
+		ListStats::UpdateElementStats(*state.append_stats, vector, count);
+	}
+	if (state.full_append_stats) {
+		ListStats::UpdateElementStats(*state.full_append_stats, vector, count);
+	}
 }
 
 void ListColumnData::FinalizeAppend(ColumnDataFinalizeAppendState &finalize_state, ColumnAppendState &state) {

--- a/test/configs/disable_optimizer.json
+++ b/test/configs/disable_optimizer.json
@@ -18,6 +18,7 @@
         "test/sql/types/geo/geometry_parquet_pushdown.test",
         "test/optimizer/statistics/statistics_filter_pruning.test",
         "test/sql/copy/parquet/parquet_expression_filter_pruning.test",
+        "test/sql/copy/parquet/list_extract_row_group_pruning.test",
         "test/sql/copy/parquet/parquet_virtual_file_row_group_number.test"
       ]
     },

--- a/test/sql/copy/parquet/list_extract_row_group_pruning.test
+++ b/test/sql/copy/parquet/list_extract_row_group_pruning.test
@@ -1,0 +1,19 @@
+# name: test/sql/copy/parquet/list_extract_row_group_pruning.test
+# description: Per-index list extract stats prune parquet row groups when another slot poisons merged child min/max
+# group: [parquet]
+
+require parquet
+
+statement ok
+COPY (SELECT [3000, i] AS l FROM range(6144) t(i))
+TO '{TEST_DIR}/list_extract_prune.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+
+query I
+SELECT count(*) FROM '{TEST_DIR}/list_extract_prune.parquet' WHERE l[2] BETWEEN 2900 AND 3100
+----
+201
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM '{TEST_DIR}/list_extract_prune.parquet' WHERE l[2] BETWEEN 2900 AND 3100
+----
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 3.*

--- a/test/sql/copy/parquet/list_extract_row_group_pruning.test
+++ b/test/sql/copy/parquet/list_extract_row_group_pruning.test
@@ -1,5 +1,5 @@
 # name: test/sql/copy/parquet/list_extract_row_group_pruning.test
-# description: Per-index list extract stats prune parquet row groups when another slot poisons merged child min/max
+# description: Filters on list[i] prune parquet row groups using that element's min/max, not every element in the list
 # group: [parquet]
 
 require parquet

--- a/test/sql/optimizer/list_extract_row_group_pruning.test
+++ b/test/sql/optimizer/list_extract_row_group_pruning.test
@@ -1,0 +1,22 @@
+# name: test/sql/optimizer/list_extract_row_group_pruning.test
+# description: Per-index list extract stats prune native row groups when another slot poisons merged child min/max
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/list_extract_row_group_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+statement ok
+CREATE TABLE lists AS SELECT [3000, i] AS l FROM range(6144) tbl(i);
+
+query I
+SELECT count(*) FROM lists WHERE l[2] BETWEEN 2900 AND 3100;
+----
+201
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM lists WHERE l[2] BETWEEN 2900 AND 3100;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*

--- a/test/sql/optimizer/list_extract_row_group_pruning.test
+++ b/test/sql/optimizer/list_extract_row_group_pruning.test
@@ -1,5 +1,5 @@
 # name: test/sql/optimizer/list_extract_row_group_pruning.test
-# description: Per-index list extract stats prune native row groups when another slot poisons merged child min/max
+# description: Filters on list[i] prune row groups using that element's min/max, not every element in the list
 # group: [optimizer]
 
 statement ok


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes zone-map/statistics used for row-group pruning; bugs could skip rows incorrectly, though pruning is meant to be conservative.
> 
> **Overview**
> Adds **per-position min/max statistics** (up to 32 elements) for lists with numeric element types, so filters like `l[2] BETWEEN …` can prune row groups using that index’s bounds instead of the flattened child column’s global min/max.
> 
> `ListStats` stores these in `extra_data`, maintains them on append and Parquet write, and merges them like other list stats. The Parquet writer serializes them to column chunk key-value metadata (`duckdb.list_element_stats`); the reader reloads them when building list statistics. **`list_extract`** propagates stats from the indexed element when the subscript is a known constant.
> 
> Tests assert that `l[2]` filters scan **1 of 3** row groups for both native tables and Parquet files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12f1102da2c7373d7e5abe7a067f13e6b65e448d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->