### PR TITLE
list segment pruning

### DIFF
--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -122,6 +122,7 @@ public:
 	ColumnSegmentTree &GetSegmentTree() {
 		return data;
 	}
+	unique_ptr<BaseStatistics> GetSegmentStatistics(idx_t row_start, idx_t row_end);
 	void SetCount(idx_t new_count) {
 		this->count = new_count;
 	}

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -120,6 +120,8 @@ struct ColumnScanState {
 	bool initialized = false;
 	//! If this segment has already been checked for skipping purposes
 	bool segment_checked = false;
+	//! Optional row target for zonemap checks on nested child segments
+	optional_idx zonemap_target_row;
 	//! We initialize one SegmentScanState per segment, however, if scanning a DataChunk requires us to scan over more
 	//! than one Segment, we need to keep the scan states of the previous segments around
 	vector<unique_ptr<SegmentScanState>> previous_states;

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/storage/table/column_checkpoint_state.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 
 namespace duckdb {
 
@@ -29,7 +30,35 @@ void ArrayColumnData::SetDataType(ColumnDataType data_type) {
 
 FilterPropagateResult ArrayColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
                                                     optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
-	return CheckValidityZonemap(state, filter, checked_segment, *validity);
+	if (IsDirectNullCheckFilter(filter)) {
+		return CheckValidityZonemap(state, filter, checked_segment, *validity);
+	}
+	checked_segment = nullptr;
+	if (child_column->type.IsNested()) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	auto row_start = state.child_states[0].offset_in_column;
+	auto row_end = MinValue<idx_t>(row_start + STANDARD_VECTOR_SIZE, count.load());
+	if (row_start >= row_end) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	auto array_size = ArrayType::GetSize(type);
+	auto child_stats = child_column->GetSegmentStatistics(row_start * array_size, row_end * array_size);
+	if (!child_stats) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	auto array_stats = ArrayStats::CreateUnknown(type);
+	ArrayStats::SetChildStats(array_stats, std::move(child_stats));
+	auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "ArrayColumnData::CheckZonemap");
+	auto context = state.context.GetClientContext();
+	auto result =
+	    context ? expr_filter.CheckStatistics(*context, array_stats) : expr_filter.CheckStatistics(array_stats);
+	if (result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+		state.zonemap_target_row = row_end;
+	}
+	return result;
 }
 
 void ArrayColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -512,6 +512,30 @@ unique_ptr<BaseStatistics> ColumnData::GetStatistics() const {
 	return stats->statistics.ToUnique();
 }
 
+unique_ptr<BaseStatistics> ColumnData::GetSegmentStatistics(idx_t row_start, idx_t row_end) {
+	if (type.IsNested()) {
+		return nullptr;
+	}
+	auto column_count = count.load();
+	if (row_start >= row_end || row_start >= column_count) {
+		return BaseStatistics::CreateEmpty(type).ToUnique();
+	}
+	row_end = MinValue<idx_t>(row_end, column_count);
+
+	auto result = BaseStatistics::CreateEmpty(type).ToUnique();
+	auto segment_lock = data.Lock();
+	if (data.IsEmpty(segment_lock)) {
+		return nullptr;
+	}
+	auto segment = data.GetSegment(segment_lock, row_start);
+	lock_guard<mutex> stats_guard(stats_lock);
+	while (segment && segment->GetRowStart() < row_end) {
+		result->Merge(segment->GetNode().GetStats());
+		segment = data.GetNextSegment(segment_lock, *segment);
+	}
+	return result;
+}
+
 void ColumnData::MergeStatistics(const BaseStatistics &other) {
 	if (!stats) {
 		throw InternalException("ColumnData::MergeStatistics called on a column without stats");

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/storage/table/column_checkpoint_state.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 
 namespace duckdb {
 
@@ -29,7 +30,35 @@ void ListColumnData::SetDataType(ColumnDataType data_type) {
 
 FilterPropagateResult ListColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter,
                                                    optional_ptr<SegmentNode<ColumnSegment>> &checked_segment) {
-	return CheckValidityZonemap(state, filter, checked_segment, *validity);
+	if (IsDirectNullCheckFilter(filter)) {
+		return CheckValidityZonemap(state, filter, checked_segment, *validity);
+	}
+	checked_segment = nullptr;
+	if (child_column->type.IsNested()) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	auto row_start = state.offset_in_column;
+	auto row_end = MinValue<idx_t>(row_start + STANDARD_VECTOR_SIZE, count.load());
+	if (row_start >= row_end) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	auto child_start = state.last_offset;
+	auto child_end = FetchListOffset(row_end - 1);
+	auto child_stats = child_column->GetSegmentStatistics(child_start, child_end);
+	if (!child_stats) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	auto list_stats = ListStats::CreateUnknown(type);
+	ListStats::SetChildStats(list_stats, std::move(child_stats));
+	auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "ListColumnData::CheckZonemap");
+	auto context = state.context.GetClientContext();
+	auto result = context ? expr_filter.CheckStatistics(*context, list_stats) : expr_filter.CheckStatistics(list_stats);
+	if (result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+		state.zonemap_target_row = row_end;
+	}
+	return result;
 }
 
 void ListColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -758,23 +758,27 @@ bool RowGroup::CheckZonemapSegments(CollectionScanState &state) {
 		auto &column_data = GetColumn(base_column_idx);
 
 		optional_ptr<SegmentNode<ColumnSegment>> current_segment;
-		auto prune_result = column_data.CheckZonemap(state.column_scans[column_idx], filter, current_segment);
+		auto &column_scan = state.column_scans[column_idx];
+		column_scan.zonemap_target_row = optional_idx();
+		auto prune_result = column_data.CheckZonemap(column_scan, filter, current_segment);
 		if (prune_result != FilterPropagateResult::FILTER_ALWAYS_FALSE) {
 			continue;
 		}
 
 		// check zone map segment.
-		if (!current_segment) {
+		idx_t target_row;
+		if (column_scan.zonemap_target_row.IsValid()) {
+			target_row = column_scan.zonemap_target_row.GetIndex();
+		} else if (current_segment) {
+			target_row = current_segment->GetRowStart() + current_segment->GetNode().count;
+		} else {
 			// no segment to skip
 			continue;
 		}
-		auto row_start = current_segment->GetRowStart();
-		idx_t target_row = row_start + current_segment->GetNode().count;
 		if (target_row >= state.max_row) {
 			target_row = state.max_row;
 		}
-		D_ASSERT(target_row >= row_start);
-		D_ASSERT(target_row <= row_start + this->count);
+		D_ASSERT(target_row <= this->start + this->count);
 		// current_segment->GetRowStart() is already row-group-relative, and state.vector_index uses the same
 		// coordinate space. Subtracting row_start here incorrectly makes the target segment-local.
 		idx_t target_vector_index = target_row / STANDARD_VECTOR_SIZE;

--- a/test/sql/optimizer/list_array_segment_pruning.test
+++ b/test/sql/optimizer/list_array_segment_pruning.test
@@ -1,0 +1,69 @@
+# name: test/sql/optimizer/list_array_segment_pruning.test
+# description: Segment pruning for LIST and ARRAY extracts
+# group: [optimizer]
+
+require json
+
+require no_force_storage
+
+require vector_size 2048
+
+statement ok
+SET threads = 1
+
+statement ok
+SET initial_column_segment_size = 2048
+
+statement ok
+SET wal_autocheckpoint = '1TB'
+
+statement ok
+CREATE TABLE nested_values AS
+SELECT [i, i + 1]::BIGINT[2] AS array_col, [i]::BIGINT[] AS list_col
+FROM range(100000) t(i)
+
+statement ok
+PRAGMA enable_profiling = 'json'
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/array_segment_pruning_profile.json'
+
+statement ok
+SET tracked_metrics = ['query.total_rows_scanned']
+
+query I
+SELECT count(*) FROM nested_values WHERE array_col[1] >= 99000
+----
+1000
+
+statement ok
+PRAGMA disable_profiling
+
+query I
+SELECT query.total_rows_scanned BETWEEN 1 AND 99999
+FROM '{TEST_DIR}/array_segment_pruning_profile.json'
+----
+true
+
+statement ok
+PRAGMA enable_profiling = 'json'
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/list_segment_pruning_profile.json'
+
+statement ok
+SET tracked_metrics = ['query.total_rows_scanned']
+
+query I
+SELECT count(*) FROM nested_values WHERE list_col[1] >= 99000
+----
+1000
+
+statement ok
+PRAGMA disable_profiling
+
+query I
+SELECT query.total_rows_scanned BETWEEN 1 AND 99999
+FROM '{TEST_DIR}/list_segment_pruning_profile.json'
+----
+true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes scan skipping in the storage layer; incorrect statistics propagation could skip rows that should match, though it reuses existing expression-filter statistics checks and adds profiling-based regression tests.
> 
> **Overview**
> **Extends table-scan segment pruning** so filters on **LIST/ARRAY element extracts** (e.g. `list_col[1]`, `array_col[1]`) can skip vectors when child-element statistics prove the predicate impossible, not just when checking nullability on the parent validity column.
> 
> `ColumnData` gains **`GetSegmentStatistics(row_start, row_end)`**, which merges zonemap stats across segments for a row range (skipped for nested types). **`ArrayColumnData`** and **`ListColumnData`** override **`CheckZonemap`**: direct `IS NULL` / `IS NOT NULL` still use validity; other pushed-down expression filters build **array/list stats from the child column’s segment statistics** (list uses list offsets for the child row span) and run **`ExpressionFilter::CheckStatistics`**. When the result is **`FILTER_ALWAYS_FALSE`**, they set **`ColumnScanState::zonemap_target_row`** because there is no parent segment to advance.
> 
> **`RowGroup::CheckZonemapSegments`** resets that field per filter and, on always-false pruning, uses **`zonemap_target_row`** when set instead of relying only on **`current_segment`**—so nested columns can skip to the right vector boundary.
> 
> New optimizer test **`list_array_segment_pruning.test`** checks that selective filters on array/list first elements scan **well under 100k rows** while still returning the correct counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdc0feed8bb07a44783697511c142e635047a544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->