### PR TITLE
date time prune row group

### DIFF
--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -169,6 +169,37 @@ struct DatePart {
 		return result.ToUnique();
 	}
 
+	//! Some parts (e.g. month) are monotone as long as the input stays within a single parent period (e.g. year)
+	//! If so, evaluating the part at the endpoints gives exact bounds - otherwise fall back to the fixed [MIN, MAX]
+	template <int64_t MIN, int64_t MAX, class T, class OP, class PARENT_OP>
+	static unique_ptr<BaseStatistics> PropagatePartWithinParentStatistics(vector<BaseStatistics> &child_stats) {
+		auto &nstats = child_stats[0];
+		if (!NumericStats::HasMinMax(nstats)) {
+			return nullptr;
+		}
+		auto min = NumericStats::GetMin<T>(nstats);
+		auto max = NumericStats::GetMax<T>(nstats);
+		if (min > max) {
+			return nullptr;
+		}
+		// Infinities produce a NULL date part even though the input is not NULL,
+		// so we cannot propagate the validity (and thus the stats) in that case
+		if (!Value::IsFinite(min) || !Value::IsFinite(max)) {
+			return nullptr;
+		}
+		int64_t part_min = MIN;
+		int64_t part_max = MAX;
+		if (PARENT_OP::template Operation<T, int64_t>(min) == PARENT_OP::template Operation<T, int64_t>(max)) {
+			part_min = OP::template Operation<T, int64_t>(min);
+			part_max = OP::template Operation<T, int64_t>(max);
+		}
+		auto result = NumericStats::CreateEmpty(LogicalType::BIGINT);
+		result.CopyValidity(child_stats[0]);
+		NumericStats::SetMin(result, Value::BIGINT(part_min));
+		NumericStats::SetMax(result, Value::BIGINT(part_max));
+		return result.ToUnique();
+	}
+
 	template <typename OP>
 	struct PartOperator {
 		template <class TA, class TR, class DATA_TYPE>
@@ -210,8 +241,16 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// min/max of month operator is [1, 12]
-			return PropagateSimpleDatePartStatistics<1, 12, T>(input.child_stats);
+			// month is monotone within a single year, otherwise [1, 12]
+			return PropagatePartWithinParentStatistics<1, 12, T, MonthOperator, YearOperator>(input.child_stats);
+		}
+	};
+
+	//! Combines year and month into a single value, used as the parent period for day statistics
+	struct YearMonthOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return YearOperator::Operation<TA, TR>(input) * 12 + MonthOperator::Operation<TA, TR>(input);
 		}
 	};
 
@@ -223,8 +262,8 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// min/max of day operator is [1, 31]
-			return PropagateSimpleDatePartStatistics<1, 31, T>(input.child_stats);
+			// day is monotone within a single month, otherwise [1, 31]
+			return PropagatePartWithinParentStatistics<1, 31, T, DayOperator, YearMonthOperator>(input.child_stats);
 		}
 	};
 
@@ -309,8 +348,8 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// min/max of quarter operator is [1, 4]
-			return PropagateSimpleDatePartStatistics<1, 4, T>(input.child_stats);
+			// quarter is monotone within a single year, otherwise [1, 4]
+			return PropagatePartWithinParentStatistics<1, 4, T, QuarterOperator, YearOperator>(input.child_stats);
 		}
 	};
 
@@ -354,7 +393,8 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<1, 366, T>(input.child_stats);
+			// day of year is monotone within a single year, otherwise [1, 366]
+			return PropagatePartWithinParentStatistics<1, 366, T, DayOfYearOperator, YearOperator>(input.child_stats);
 		}
 	};
 
@@ -366,7 +406,8 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<1, 53, T>(input.child_stats);
+			// ISO week is monotone within a single ISO year, otherwise [1, 53]
+			return PropagatePartWithinParentStatistics<1, 53, T, WeekOperator, ISOYearOperator>(input.child_stats);
 		}
 	};
 

--- a/test/sql/optimizer/date_part_row_group_pruning.test
+++ b/test/sql/optimizer/date_part_row_group_pruning.test
@@ -1,0 +1,84 @@
+# name: test/sql/optimizer/date_part_row_group_pruning.test
+# description: Row-group pruning through month/quarter/day/dayofyear/week when a row group spans a single parent period
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/date_part_prune.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 3 row groups covering January, May and September of 2024 respectively
+statement ok
+CREATE TABLE months AS
+    SELECT make_date(2024, 1 + (range // 2048)::INT * 4, 1 + ((range % 2048) * 27 // 2048)::INT) AS d
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM months WHERE month(d) = 5;
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM months WHERE month(d) = 5;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM months WHERE quarter(d) = 2;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# dayofyear: January is [1, 27], May is [122, 148], September is [245, 271]
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM months WHERE dayofyear(d) = 130;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# ISO week: January 2024 is weeks [1, 4], May is [18, 22], September is [35, 39]
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM months WHERE week(d) = 20;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# also works through a TIMESTAMP column
+statement ok
+CREATE TABLE month_ts AS SELECT d::TIMESTAMP AS ts FROM months;
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM month_ts WHERE month(ts) = 5;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# 3 row groups within June 2024 covering days [1, 9], [11, 19] and [21, 29]
+statement ok
+CREATE TABLE days AS
+    SELECT make_date(2024, 6, 1 + (range // 2048)::INT * 10 + ((range % 2048) * 9 // 2048)::INT) AS d
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM days WHERE day(d) = 15;
+----
+227
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM days WHERE day(d) = 15;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# a row group spanning multiple years must keep the full [1, 12] month range:
+# every row group here contains dates from both December 2023 and January 2024
+statement ok
+CREATE TABLE cross_year AS
+    SELECT make_date(2023 + (range % 2)::INT, 12 - (range % 2)::INT * 11, 1 + (range // 236)::INT) AS d
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM cross_year WHERE month(d) = 12;
+----
+3072
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM cross_year WHERE month(d) = 12;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Optimizer-only stats change with a conservative fallback to the previous full ranges; incorrect bounds would only affect pruning, and tests cover both prune and no-prune cases.
> 
> **Overview**
> Tighter statistics for `month`, `quarter`, `day`, `dayofyear`, and `week` so filters on those parts can prune row groups when the input range stays inside a single parent period (year, month, or ISO year).
> 
> Previously these parts always advertised the full calendar range (e.g. `[1, 12]` for month). Now, if min and max share the same parent period, bounds are taken from the endpoints; otherwise the old fixed range is kept. Infinite values still skip stats.
> 
> A SQL test checks pruning on DATE and TIMESTAMP, and that cross-year row groups still scan fully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e592c1916cd4c5f30d5f3e5c3c6ddc31c807afcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->