### PR TITLE
[WIP] date time optimization

### DIFF
--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -169,6 +169,37 @@ struct DatePart {
 		return result.ToUnique();
 	}
 
+	//! Some parts (e.g. month) are monotone as long as the input stays within a single parent period (e.g. year)
+	//! If so, evaluating the part at the endpoints gives exact bounds - otherwise fall back to the fixed [MIN, MAX]
+	template <int64_t MIN, int64_t MAX, class T, class OP, class PARENT_OP>
+	static unique_ptr<BaseStatistics> PropagatePartWithinParentStatistics(vector<BaseStatistics> &child_stats) {
+		auto &nstats = child_stats[0];
+		if (!NumericStats::HasMinMax(nstats)) {
+			return nullptr;
+		}
+		auto min = NumericStats::GetMin<T>(nstats);
+		auto max = NumericStats::GetMax<T>(nstats);
+		if (min > max) {
+			return nullptr;
+		}
+		// Infinities produce a NULL date part even though the input is not NULL,
+		// so we cannot propagate the validity (and thus the stats) in that case
+		if (!Value::IsFinite(min) || !Value::IsFinite(max)) {
+			return nullptr;
+		}
+		int64_t part_min = MIN;
+		int64_t part_max = MAX;
+		if (PARENT_OP::template Operation<T, int64_t>(min) == PARENT_OP::template Operation<T, int64_t>(max)) {
+			part_min = OP::template Operation<T, int64_t>(min);
+			part_max = OP::template Operation<T, int64_t>(max);
+		}
+		auto result = NumericStats::CreateEmpty(LogicalType::BIGINT);
+		result.CopyValidity(child_stats[0]);
+		NumericStats::SetMin(result, Value::BIGINT(part_min));
+		NumericStats::SetMax(result, Value::BIGINT(part_max));
+		return result.ToUnique();
+	}
+
 	template <typename OP>
 	struct PartOperator {
 		template <class TA, class TR, class DATA_TYPE>
@@ -210,8 +241,16 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// min/max of month operator is [1, 12]
-			return PropagateSimpleDatePartStatistics<1, 12, T>(input.child_stats);
+			// month is monotone within a single year, otherwise [1, 12]
+			return PropagatePartWithinParentStatistics<1, 12, T, MonthOperator, YearOperator>(input.child_stats);
+		}
+	};
+
+	//! Combines year and month into a single value, used as the parent period for day statistics
+	struct YearMonthOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return YearOperator::Operation<TA, TR>(input) * 12 + MonthOperator::Operation<TA, TR>(input);
 		}
 	};
 
@@ -223,8 +262,8 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// min/max of day operator is [1, 31]
-			return PropagateSimpleDatePartStatistics<1, 31, T>(input.child_stats);
+			// day is monotone within a single month, otherwise [1, 31]
+			return PropagatePartWithinParentStatistics<1, 31, T, DayOperator, YearMonthOperator>(input.child_stats);
 		}
 	};
 
@@ -309,8 +348,8 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// min/max of quarter operator is [1, 4]
-			return PropagateSimpleDatePartStatistics<1, 4, T>(input.child_stats);
+			// quarter is monotone within a single year, otherwise [1, 4]
+			return PropagatePartWithinParentStatistics<1, 4, T, QuarterOperator, YearOperator>(input.child_stats);
 		}
 	};
 
@@ -354,7 +393,8 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<1, 366, T>(input.child_stats);
+			// day of year is monotone within a single year, otherwise [1, 366]
+			return PropagatePartWithinParentStatistics<1, 366, T, DayOfYearOperator, YearOperator>(input.child_stats);
 		}
 	};
 
@@ -366,7 +406,8 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<1, 53, T>(input.child_stats);
+			// ISO week is monotone within a single ISO year, otherwise [1, 53]
+			return PropagatePartWithinParentStatistics<1, 53, T, WeekOperator, ISOYearOperator>(input.child_stats);
 		}
 	};
 
@@ -491,7 +532,9 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 59, T>(input.child_stats);
+			// second is monotone within a single minute, otherwise [0, 59]
+			return PropagatePartWithinParentStatistics<0, 59, T, SecondsOperator, MinuteParentOperator>(
+			    input.child_stats);
 		}
 	};
 
@@ -503,7 +546,9 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 59, T>(input.child_stats);
+			// minute is monotone within a single hour, otherwise [0, 59]
+			return PropagatePartWithinParentStatistics<0, 59, T, MinutesOperator, HourParentOperator>(
+			    input.child_stats);
 		}
 	};
 
@@ -515,7 +560,29 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 24, T>(input.child_stats);
+			// hour is monotone within a single day, otherwise [0, 24]
+			return PropagatePartWithinParentStatistics<0, 24, T, HoursOperator, DayParentOperator>(input.child_stats);
+		}
+	};
+
+	//! Parent period operators for sub-daily parts: inputs mapping to the same parent value are
+	//! guaranteed to produce monotonically non-decreasing part values
+	struct DayParentOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input);
+	};
+
+	struct HourParentOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return DayParentOperator::Operation<TA, TR>(input) * 24 + HoursOperator::Operation<TA, TR>(input);
+		}
+	};
+
+	struct MinuteParentOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return HourParentOperator::Operation<TA, TR>(input) * 60 + MinutesOperator::Operation<TA, TR>(input);
 		}
 	};
 
@@ -1343,6 +1410,43 @@ int64_t DatePart::HoursOperator::Operation(dtime_ns_t input) {
 template <>
 int64_t DatePart::HoursOperator::Operation(dtime_tz_t input) {
 	return DatePart::HoursOperator::Operation<dtime_t, int64_t>(input.time());
+}
+
+template <>
+int64_t DatePart::DayParentOperator::Operation(date_t input) {
+	return input.days;
+}
+
+template <>
+int64_t DatePart::DayParentOperator::Operation(timestamp_t input) {
+	return Timestamp::GetDate(input).days;
+}
+
+// a time-of-day value always lies within a single day
+template <>
+int64_t DatePart::DayParentOperator::Operation(dtime_t input) {
+	return 0;
+}
+
+template <>
+int64_t DatePart::DayParentOperator::Operation(dtime_ns_t input) {
+	return 0;
+}
+
+// TIME_TZ ordering mixes time and offset, so only identical values share a parent period
+template <>
+int64_t DatePart::DayParentOperator::Operation(dtime_tz_t input) {
+	return static_cast<int64_t>(input.bits);
+}
+
+template <>
+int64_t DatePart::HourParentOperator::Operation(dtime_tz_t input) {
+	return static_cast<int64_t>(input.bits);
+}
+
+template <>
+int64_t DatePart::MinuteParentOperator::Operation(dtime_tz_t input) {
+	return static_cast<int64_t>(input.bits);
 }
 
 template <>

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -179,7 +179,7 @@ struct DatePart {
 		}
 		auto min = NumericStats::GetMin<T>(nstats);
 		auto max = NumericStats::GetMax<T>(nstats);
-		// an empty or invalid range gives us no bounds to propagate
+		// an invalid range gives no bounds to propagate
 		if (min > max) {
 			return nullptr;
 		}
@@ -190,8 +190,7 @@ struct DatePart {
 		}
 		int64_t part_min = MIN;
 		int64_t part_max = MAX;
-		// If min and max fall within the same parent period (e.g. the same year for month), the part cannot
-		// wrap around, so it is non-decreasing over the entire range.
+		// within a single parent period the part cannot wrap around, so the endpoints are exact bounds
 		if (PARENT_OP::template Operation<T, int64_t>(min) == PARENT_OP::template Operation<T, int64_t>(max)) {
 			part_min = OP::template Operation<T, int64_t>(min);
 			part_max = OP::template Operation<T, int64_t>(max);
@@ -564,18 +563,13 @@ struct DatePart {
 		}
 	};
 
-	//! A parent period operator maps an input to a globally unique id of the period containing it,
-	//! e.g. DayParentOperator maps 2024-06-01 12:34 to the number of days between 1970-01-01 and 2024-06-01.
-	//! If the min and max of a range map to the same id, the whole range lies inside one period, so the
-	//! child part (e.g. hour) never resets to its lowest value inside the range and endpoint evaluation is exact.
-
 	//! Identifies the day containing the input, used as the parent period for hour statistics
 	struct DayParentOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input);
 	};
 
-	//! Identifies the hour containing the input (day id * 24 + hour), used as the parent period for minute statistics
+	//! Identifies the hour containing the input, used as the parent period for minute statistics
 	struct DayHourParentOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
@@ -1438,6 +1432,7 @@ int64_t DatePart::DayParentOperator::Operation(dtime_ns_t input) {
 	return 0;
 }
 
+// TIME_TZ parts are not monotone under its UTC-based ordering, so only identical values share a parent
 template <>
 int64_t DatePart::DayParentOperator::Operation(dtime_tz_t input) {
 	return NumericCast<int64_t>(input.bits);

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -249,7 +249,7 @@ struct DatePart {
 		}
 	};
 
-	//! Combines year and month into a single value, used as the parent period for day statistics
+	//! Identifies the calendar month containing the input, used as the parent period for day statistics
 	struct YearMonthParentOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
@@ -564,14 +564,18 @@ struct DatePart {
 		}
 	};
 
-	//! Parent period operators for sub-daily parts: inputs mapping to the same parent value are
-	//! guaranteed to produce monotonically non-decreasing part values
+	//! A parent period operator maps an input to a globally unique id of the period containing it,
+	//! e.g. DayParentOperator maps 2024-06-01 12:34 to the number of days between 1970-01-01 and 2024-06-01.
+	//! If the min and max of a range map to the same id, the whole range lies inside one period, so the
+	//! child part (e.g. hour) never resets to its lowest value inside the range and endpoint evaluation is exact.
+
+	//! Identifies the day containing the input, used as the parent period for hour statistics
 	struct DayParentOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input);
 	};
 
-	//! Combines day and hour into a single value, used as the parent period for minute statistics
+	//! Identifies the hour containing the input (day id * 24 + hour), used as the parent period for minute statistics
 	struct DayHourParentOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
@@ -579,7 +583,7 @@ struct DatePart {
 		}
 	};
 
-	//! Combines day, hour and minute into a single value, used as the parent period for second statistics
+	//! Identifies the minute containing the input, used as the parent period for second statistics
 	struct DayHourMinuteParentOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
@@ -1434,20 +1438,19 @@ int64_t DatePart::DayParentOperator::Operation(dtime_ns_t input) {
 	return 0;
 }
 
-// TIME_TZ ordering mixes time and offset, so only identical values share a parent period
 template <>
 int64_t DatePart::DayParentOperator::Operation(dtime_tz_t input) {
-	return static_cast<int64_t>(input.bits);
+	return NumericCast<int64_t>(input.bits);
 }
 
 template <>
 int64_t DatePart::DayHourParentOperator::Operation(dtime_tz_t input) {
-	return static_cast<int64_t>(input.bits);
+	return NumericCast<int64_t>(input.bits);
 }
 
 template <>
 int64_t DatePart::DayHourMinuteParentOperator::Operation(dtime_tz_t input) {
-	return static_cast<int64_t>(input.bits);
+	return NumericCast<int64_t>(input.bits);
 }
 
 template <>

--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -179,6 +179,7 @@ struct DatePart {
 		}
 		auto min = NumericStats::GetMin<T>(nstats);
 		auto max = NumericStats::GetMax<T>(nstats);
+		// an empty or invalid range gives us no bounds to propagate
 		if (min > max) {
 			return nullptr;
 		}
@@ -189,6 +190,8 @@ struct DatePart {
 		}
 		int64_t part_min = MIN;
 		int64_t part_max = MAX;
+		// If min and max fall within the same parent period (e.g. the same year for month), the part cannot
+		// wrap around, so it is non-decreasing over the entire range.
 		if (PARENT_OP::template Operation<T, int64_t>(min) == PARENT_OP::template Operation<T, int64_t>(max)) {
 			part_min = OP::template Operation<T, int64_t>(min);
 			part_max = OP::template Operation<T, int64_t>(max);
@@ -241,13 +244,13 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// month is monotone within a single year, otherwise [1, 12]
+			// min/max of month operator is [1, 12]
 			return PropagatePartWithinParentStatistics<1, 12, T, MonthOperator, YearOperator>(input.child_stats);
 		}
 	};
 
 	//! Combines year and month into a single value, used as the parent period for day statistics
-	struct YearMonthOperator {
+	struct YearMonthParentOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
 			return YearOperator::Operation<TA, TR>(input) * 12 + MonthOperator::Operation<TA, TR>(input);
@@ -262,8 +265,9 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// day is monotone within a single month, otherwise [1, 31]
-			return PropagatePartWithinParentStatistics<1, 31, T, DayOperator, YearMonthOperator>(input.child_stats);
+			// min/max of day operator is [1, 31]
+			return PropagatePartWithinParentStatistics<1, 31, T, DayOperator, YearMonthParentOperator>(
+			    input.child_stats);
 		}
 	};
 
@@ -348,7 +352,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// quarter is monotone within a single year, otherwise [1, 4]
+			// min/max of quarter operator is [1, 4]
 			return PropagatePartWithinParentStatistics<1, 4, T, QuarterOperator, YearOperator>(input.child_stats);
 		}
 	};
@@ -393,7 +397,6 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// day of year is monotone within a single year, otherwise [1, 366]
 			return PropagatePartWithinParentStatistics<1, 366, T, DayOfYearOperator, YearOperator>(input.child_stats);
 		}
 	};
@@ -406,7 +409,6 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// ISO week is monotone within a single ISO year, otherwise [1, 53]
 			return PropagatePartWithinParentStatistics<1, 53, T, WeekOperator, ISOYearOperator>(input.child_stats);
 		}
 	};
@@ -532,8 +534,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// second is monotone within a single minute, otherwise [0, 59]
-			return PropagatePartWithinParentStatistics<0, 59, T, SecondsOperator, MinuteParentOperator>(
+			return PropagatePartWithinParentStatistics<0, 59, T, SecondsOperator, DayHourMinuteParentOperator>(
 			    input.child_stats);
 		}
 	};
@@ -546,8 +547,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// minute is monotone within a single hour, otherwise [0, 59]
-			return PropagatePartWithinParentStatistics<0, 59, T, MinutesOperator, HourParentOperator>(
+			return PropagatePartWithinParentStatistics<0, 59, T, MinutesOperator, DayHourParentOperator>(
 			    input.child_stats);
 		}
 	};
@@ -560,7 +560,6 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			// hour is monotone within a single day, otherwise [0, 24]
 			return PropagatePartWithinParentStatistics<0, 24, T, HoursOperator, DayParentOperator>(input.child_stats);
 		}
 	};
@@ -572,17 +571,19 @@ struct DatePart {
 		static inline TR Operation(TA input);
 	};
 
-	struct HourParentOperator {
+	//! Combines day and hour into a single value, used as the parent period for minute statistics
+	struct DayHourParentOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
 			return DayParentOperator::Operation<TA, TR>(input) * 24 + HoursOperator::Operation<TA, TR>(input);
 		}
 	};
 
-	struct MinuteParentOperator {
+	//! Combines day, hour and minute into a single value, used as the parent period for second statistics
+	struct DayHourMinuteParentOperator {
 		template <class TA, class TR>
 		static inline TR Operation(TA input) {
-			return HourParentOperator::Operation<TA, TR>(input) * 60 + MinutesOperator::Operation<TA, TR>(input);
+			return DayHourParentOperator::Operation<TA, TR>(input) * 60 + MinutesOperator::Operation<TA, TR>(input);
 		}
 	};
 
@@ -1440,12 +1441,12 @@ int64_t DatePart::DayParentOperator::Operation(dtime_tz_t input) {
 }
 
 template <>
-int64_t DatePart::HourParentOperator::Operation(dtime_tz_t input) {
+int64_t DatePart::DayHourParentOperator::Operation(dtime_tz_t input) {
 	return static_cast<int64_t>(input.bits);
 }
 
 template <>
-int64_t DatePart::MinuteParentOperator::Operation(dtime_tz_t input) {
+int64_t DatePart::DayHourMinuteParentOperator::Operation(dtime_tz_t input) {
 	return static_cast<int64_t>(input.bits);
 }
 

--- a/test/sql/function/time/test_extract_stats.test
+++ b/test/sql/function/time/test_extract_stats.test
@@ -17,7 +17,7 @@ CREATE TABLE expected_result AS FROM (VALUES
 	('milliseconds', 0, 59999),
 	('second', 0, 59),
 	('minute', 0, 59),
-	('hour', 0, 24),
+	('hour', 0, 20),
 	('epoch', 0, 86400)
 	) t(component, min, max)
 

--- a/test/sql/optimizer/date_part_row_group_pruning.test
+++ b/test/sql/optimizer/date_part_row_group_pruning.test
@@ -29,6 +29,27 @@ EXPLAIN ANALYZE SELECT count(*) FROM months WHERE month(d) = 5;
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
+# range predicates on a date part also prune
+query I
+SELECT count(*) FROM months WHERE month(d) BETWEEN 6 AND 9;
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM months WHERE month(d) BETWEEN 6 AND 9;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*
+
+query I
+SELECT count(*) FROM months WHERE month(d) >= 10;
+----
+1024
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM months WHERE month(d) >= 10;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
 # quarters per row group: [1, 1], [2, 2] and [3, 4]
 query I
 SELECT count(*) FROM months WHERE quarter(d) = 4;

--- a/test/sql/optimizer/date_part_row_group_pruning.test
+++ b/test/sql/optimizer/date_part_row_group_pruning.test
@@ -1,0 +1,207 @@
+# name: test/sql/optimizer/date_part_row_group_pruning.test
+# description: Row-group pruning through date/time parts when a row group spans a single parent period
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/date_part_prune.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+#################### date parts ####################
+
+# 3 row groups covering months [1, 2], [5, 6] and [9, 10] of 2024:
+# each row group spans two part values so the filters below cannot be folded away entirely
+statement ok
+CREATE TABLE months AS
+    SELECT make_date(2024,
+                     1 + (range // 2048)::INT * 4 + ((range % 2048) // 1024)::INT,
+                     1 + ((range % 1024) * 27 // 1024)::INT) AS d
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM months WHERE month(d) = 5;
+----
+1024
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM months WHERE month(d) = 5;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# quarters per row group: [1, 1], [2, 2] and [3, 4]
+query I
+SELECT count(*) FROM months WHERE quarter(d) = 4;
+----
+1024
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM months WHERE quarter(d) = 4;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# dayofyear 130 is May 9: only the second row group ([122, 179]) can contain it
+query I
+SELECT count(*) FROM months WHERE dayofyear(d) = 130;
+----
+38
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM months WHERE dayofyear(d) = 130;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# ISO week 20 is May 13-19: only the second row group ([18, 26]) can contain it
+query I
+SELECT count(*) FROM months WHERE week(d) = 20;
+----
+265
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM months WHERE week(d) = 20;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# also works through a TIMESTAMP column
+statement ok
+CREATE TABLE month_ts AS SELECT d::TIMESTAMP AS ts FROM months;
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM month_ts WHERE month(ts) = 5;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# 3 row groups within June 2024 covering days [1, 9], [11, 19] and [21, 29]
+statement ok
+CREATE TABLE days AS
+    SELECT make_date(2024, 6, 1 + (range // 2048)::INT * 10 + ((range % 2048) * 9 // 2048)::INT) AS d
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM days WHERE day(d) = 15;
+----
+227
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM days WHERE day(d) = 15;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# a row group spanning multiple years must keep the full [1, 12] month range:
+# every row group here contains dates from both December 2023 and January 2024
+statement ok
+CREATE TABLE cross_year AS
+    SELECT make_date(2023 + (range % 2)::INT, 12 - (range % 2)::INT * 11, 1 + (range // 236)::INT) AS d
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM cross_year WHERE month(d) = 12;
+----
+3072
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM cross_year WHERE month(d) = 12;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+#################### time parts ####################
+
+# 3 row groups within 2024-06-01 covering hours [9, 10], [12, 13] and [15, 16]
+statement ok
+CREATE TABLE hours_ts AS
+    SELECT TIMESTAMP '2024-06-01 09:00:00'
+           + INTERVAL ((range // 2048) * 3 + (range % 2048) // 1024) HOUR
+           + INTERVAL ((range % 1024) * 59 // 1024) MINUTE AS ts
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM hours_ts WHERE hour(ts) = 12;
+----
+1024
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM hours_ts WHERE hour(ts) = 12;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# hour of a TIME column is monotone over the whole domain
+statement ok
+CREATE TABLE times AS SELECT ts::TIME AS t FROM hours_ts;
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM times WHERE hour(t) = 12;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# 3 row groups within hour 12 covering minutes [0, 8], [20, 28] and [40, 48]
+statement ok
+CREATE TABLE minutes_ts AS
+    SELECT TIMESTAMP '2024-06-01 12:00:00'
+           + INTERVAL ((range // 2048) * 20) MINUTE
+           + INTERVAL ((range % 2048) * 9 // 2048) MINUTE AS ts
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM minutes_ts WHERE minute(ts) = 25;
+----
+228
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM minutes_ts WHERE minute(ts) = 25;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# 3 row groups within one minute covering seconds [0, 8], [20, 28] and [40, 48]
+statement ok
+CREATE TABLE seconds_ts AS
+    SELECT TIMESTAMP '2024-06-01 12:30:00'
+           + INTERVAL ((range // 2048) * 20) SECOND
+           + INTERVAL ((range % 2048) * 9 // 2048) SECOND AS ts
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM seconds_ts WHERE second(ts) = 25;
+----
+228
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM seconds_ts WHERE second(ts) = 25;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+# a row group spanning midnight must keep the full [0, 24] hour range:
+# every row group here contains timestamps from both 23:30 and 00:30 the next day
+statement ok
+CREATE TABLE cross_midnight AS
+    SELECT TIMESTAMP '2024-06-01 23:30:00'
+           + INTERVAL ((range % 2) * 60) MINUTE
+           + INTERVAL (range // 236) SECOND AS ts
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM cross_midnight WHERE hour(ts) = 23;
+----
+3072
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM cross_midnight WHERE hour(ts) = 23;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+# pre-epoch timestamps (negative microseconds) must resolve parent periods correctly
+statement ok
+CREATE TABLE pre_epoch AS
+    SELECT TIMESTAMP '1965-06-01 09:00:00'
+           + INTERVAL ((range // 2048) * 3 + (range % 2048) // 1024) HOUR
+           + INTERVAL ((range % 1024) * 59 // 1024) MINUTE AS ts
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM pre_epoch WHERE hour(ts) = 12;
+----
+1024
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM pre_epoch WHERE hour(ts) = 12;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*

--- a/test/sql/optimizer/date_part_row_group_pruning.test
+++ b/test/sql/optimizer/date_part_row_group_pruning.test
@@ -66,6 +66,11 @@ analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 statement ok
 CREATE TABLE month_ts AS SELECT d::TIMESTAMP AS ts FROM months;
 
+query I
+SELECT count(*) FROM month_ts WHERE month(ts) = 5;
+----
+1024
+
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM month_ts WHERE month(ts) = 5;
 ----
@@ -104,6 +109,68 @@ EXPLAIN ANALYZE SELECT count(*) FROM cross_year WHERE month(d) = 12;
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
 
+# quarter/dayofyear/week fall back to their fixed ranges on the same cross-year data
+query I
+SELECT count(*) FROM cross_year WHERE quarter(d) = 4;
+----
+3072
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM cross_year WHERE quarter(d) = 4;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+# dayofyear 339 is Dec 5 in the non-leap year 2023
+query I
+SELECT count(*) FROM cross_year WHERE dayofyear(d) = 339;
+----
+118
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM cross_year WHERE dayofyear(d) = 339;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+# ISO week 52 of 2023 is Dec 25-31
+query I
+SELECT count(*) FROM cross_year WHERE week(d) = 52;
+----
+240
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM cross_year WHERE week(d) = 52;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+# cross-year also cannot prune through a TIMESTAMP column
+statement ok
+CREATE TABLE cross_year_ts AS SELECT d::TIMESTAMP AS ts FROM cross_year;
+
+query I
+SELECT count(*) FROM cross_year_ts WHERE month(ts) = 12;
+----
+3072
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM cross_year_ts WHERE month(ts) = 12;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+# a row group spanning a month boundary must keep the full [1, 31] day range
+statement ok
+CREATE TABLE cross_month AS
+    SELECT (DATE '2024-06-30' + (range % 2)::INT) AS d FROM range(6144);
+
+query I
+SELECT count(*) FROM cross_month WHERE day(d) = 30;
+----
+3072
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM cross_month WHERE day(d) = 30;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
 #################### time parts ####################
 
 # 3 row groups within 2024-06-01 covering hours [9, 10], [12, 13] and [15, 16]
@@ -127,6 +194,11 @@ analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 # hour of a TIME column is monotone over the whole domain
 statement ok
 CREATE TABLE times AS SELECT ts::TIME AS t FROM hours_ts;
+
+query I
+SELECT count(*) FROM times WHERE hour(t) = 12;
+----
+1024
 
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM times WHERE hour(t) = 12;
@@ -185,6 +257,38 @@ SELECT count(*) FROM cross_midnight WHERE hour(ts) = 23;
 
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM cross_midnight WHERE hour(ts) = 23;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+# a row group spanning an hour boundary must keep the full [0, 59] minute range
+statement ok
+CREATE TABLE cross_hour AS
+    SELECT TIMESTAMP '2024-06-01 12:59:30' + INTERVAL ((range % 2) * 60) SECOND AS ts
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM cross_hour WHERE minute(ts) = 59;
+----
+3072
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM cross_hour WHERE minute(ts) = 59;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+# a row group spanning a minute boundary must keep the full [0, 59] second range
+statement ok
+CREATE TABLE cross_minute AS
+    SELECT TIMESTAMP '2024-06-01 12:30:59' + INTERVAL (range % 2) SECOND AS ts
+    FROM range(6144);
+
+query I
+SELECT count(*) FROM cross_minute WHERE second(ts) = 59;
+----
+3072
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM cross_minute WHERE second(ts) = 59;
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes statistics used for zone-map pruning; incorrect parent-period checks could skip valid row groups. Covered by new pruning tests including wrap-around and pre-epoch cases.
> 
> **Overview**
> Improves `date_part` statistics so filters on wrapping parts (month, day, quarter, week, hour, minute, second, …) can prune row groups when the input min/max lie in a single parent period (year, month, day, hour, minute).
> 
> If the range crosses a parent boundary (year, midnight, hour, etc.), stats still fall back to the full legal range. `TIME_TZ` is treated conservatively because UTC ordering is not monotone. Also tightens expected hour stats in the extract-stats test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52127f3dbc12f60985f9de3a64b14f486860747e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->