### PR TITLE
Hjiang/left prune

### DIFF
--- a/extension/core_functions/scalar/string/left_right.cpp
+++ b/extension/core_functions/scalar/string/left_right.cpp
@@ -65,16 +65,16 @@ static unique_ptr<BaseStatistics> LeftPropagateStats(ClientContext &context, Fun
 	}
 	auto length = length_value.GetValue<int64_t>();
 	// a negative length counts from the back of each string, so no bounds can be derived
-	if (length <= 0 || length > NumericLimits<uint32_t>::Maximum()) {
+	if (length < 0 || length > NumericLimits<uint32_t>::Maximum()) {
 		return nullptr;
 	}
-	// left(s, n) with a constant n >= 1 is a fixed-length character prefix, which preserves ordering
+	// left(s, n) with a constant n >= 0 is a fixed-length character prefix, which preserves ordering
 	return PropagateStringSliceStats(input, 0, NumericCast<idx_t>(length));
 }
 
 ScalarFunction LeftFun::GetFunction() {
 	ScalarFunction function({LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR,
-	                        LeftFunction<LeftRightUnicode>, nullptr, LeftPropagateStats);
+	                        LeftFunction<LeftRightUnicode>, /*bind=*/nullptr, LeftPropagateStats);
 	// throws if the resulting substring is out of the supported range
 	function.SetFallible();
 	return function;

--- a/extension/core_functions/scalar/string/left_right.cpp
+++ b/extension/core_functions/scalar/string/left_right.cpp
@@ -2,6 +2,9 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
 
 #include <ctype.h>
 #include <algorithm>
@@ -50,9 +53,28 @@ static void LeftFunction(DataChunk &args, ExpressionState &state, Vector &result
 	    str_vec, pos_vec, result, [&](string_t str, int64_t pos) { return LeftScalarFunction<OP>(result, str, pos); });
 }
 
+static unique_ptr<BaseStatistics> LeftPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &children = input.expr.GetChildren();
+	D_ASSERT(children.size() == 2);
+	if (children[1]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+		return nullptr;
+	}
+	auto &length_value = children[1]->Cast<BoundConstantExpression>().GetValue();
+	if (length_value.IsNull()) {
+		return nullptr;
+	}
+	auto length = length_value.GetValue<int64_t>();
+	// a negative length counts from the back of each string, so no bounds can be derived
+	if (length <= 0 || length > NumericLimits<uint32_t>::Maximum()) {
+		return nullptr;
+	}
+	// left(s, n) with a constant n >= 1 is a fixed-length character prefix, which preserves ordering
+	return PropagateStringSliceStats(input, 0, NumericCast<idx_t>(length));
+}
+
 ScalarFunction LeftFun::GetFunction() {
 	ScalarFunction function({LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR,
-	                        LeftFunction<LeftRightUnicode>);
+	                        LeftFunction<LeftRightUnicode>, nullptr, LeftPropagateStats);
 	// throws if the resulting substring is out of the supported range
 	function.SetFallible();
 	return function;

--- a/extension/core_functions/scalar/string/left_right.cpp
+++ b/extension/core_functions/scalar/string/left_right.cpp
@@ -68,8 +68,8 @@ static unique_ptr<BaseStatistics> LeftPropagateStats(ClientContext &context, Fun
 	if (length < 0 || length > NumericLimits<uint32_t>::Maximum()) {
 		return nullptr;
 	}
-	// left(s, n) with a constant n >= 0 is a fixed-length character prefix, which preserves ordering
-	return PropagateStringSliceStats(input, 0, NumericCast<idx_t>(length));
+	return PropagateStringSliceStats(input, /*start_character_index=*/0,
+	                                 /*character_count=*/NumericCast<idx_t>(length));
 }
 
 ScalarFunction LeftFun::GetFunction() {

--- a/test/sql/optimizer/left_zonemap_pruning.test
+++ b/test/sql/optimizer/left_zonemap_pruning.test
@@ -14,7 +14,6 @@ CREATE TABLE left_pruning AS
 SELECT i::INTEGER AS i, lpad(i::VARCHAR, 6, '0') AS s
 FROM range(6144) r(i);
 
-# Equality on a prefix is already rewritten into a range predicate on the column itself.
 query II
 EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 4) = '0010';
 ----
@@ -25,7 +24,6 @@ SELECT count(*) FROM left_pruning WHERE left(s, 4) = '0010';
 ----
 100
 
-# A constant-length prefix preserves the ordering of the input min/max values.
 query II
 EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 4) > '0050';
 ----
@@ -93,6 +91,28 @@ SELECT count(*) FROM left_pruning WHERE left(s, (i % 2) + 4) = '0010';
 # A zero length always produces an empty string.
 query I
 SELECT count(*) FROM left_pruning WHERE left(s, 0) = '';
+----
+6144
+
+# The derived bounds for a zero length are exact ('' on both sides), so an impossible comparison prunes every row group.
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 0) > '';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 3.*
+
+query I
+SELECT count(*) FROM left_pruning WHERE left(s, 0) > '';
+----
+0
+
+# An always-true comparison still has to scan every row group.
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 0) <= '';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
+
+query I
+SELECT count(*) FROM left_pruning WHERE left(s, 0) <= '';
 ----
 6144
 

--- a/test/sql/optimizer/left_zonemap_pruning.test
+++ b/test/sql/optimizer/left_zonemap_pruning.test
@@ -1,0 +1,96 @@
+# name: test/sql/optimizer/left_zonemap_pruning.test
+# description: Prune row groups for left() with a constant length
+# group: [optimizer]
+
+# 500k rows -> 5 row groups. The string increases with the row id.
+statement ok
+CREATE TABLE left_pruning AS
+SELECT i::INTEGER AS i, lpad(i::VARCHAR, 6, '0') AS s
+FROM range(500000) r(i);
+
+# Equality on a prefix is already rewritten into a range predicate on the column itself.
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 2) = '40';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM left_pruning WHERE left(s, 2) = '40';
+----
+10000
+
+# A constant-length prefix preserves the ordering of the input min/max values.
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 3) > '495';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM left_pruning WHERE left(s, 3) > '495';
+----
+4000
+
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 4) BETWEEN '1000' AND '1099';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM left_pruning WHERE left(s, 4) BETWEEN '1000' AND '1099';
+----
+10000
+
+# Lengths beyond the string preserve the bounds unchanged.
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 20) > '495000';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM left_pruning WHERE left(s, 20) > '495000';
+----
+4999
+
+# A negative length depends on the length of each row, so no bounds are derived.
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, -4) = '40';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 5 / 5.*
+
+query I
+SELECT count(*) FROM left_pruning WHERE left(s, -4) = '40';
+----
+10000
+
+# Dynamic lengths do not propagate statistics.
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, (i % 2) + 2) = '40';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 5 / 5.*
+
+query I
+SELECT count(*) FROM left_pruning WHERE left(s, (i % 2) + 2) = '40';
+----
+5000
+
+# A zero length always produces an empty string.
+query I
+SELECT count(*) FROM left_pruning WHERE left(s, 0) = '';
+----
+500000
+
+# Prefixes are measured in characters rather than bytes.
+statement ok
+CREATE TABLE left_pruning_utf8 AS
+SELECT i::INTEGER AS i, '🦆' || lpad(i::VARCHAR, 6, '0') AS s
+FROM range(500000) r(i);
+
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning_utf8 WHERE left(s, 3) BETWEEN '🦆40' AND '🦆41';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM left_pruning_utf8 WHERE left(s, 3) BETWEEN '🦆40' AND '🦆41';
+----
+20000

--- a/test/sql/optimizer/left_zonemap_pruning.test
+++ b/test/sql/optimizer/left_zonemap_pruning.test
@@ -2,95 +2,112 @@
 # description: Prune row groups for left() with a constant length
 # group: [optimizer]
 
-# 500k rows -> 5 row groups. The string increases with the row id.
+statement ok
+ATTACH '{TEST_DIR}/left_zonemap_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 6144 rows -> 3 row groups of 2048 rows. The string increases with the row id.
 statement ok
 CREATE TABLE left_pruning AS
 SELECT i::INTEGER AS i, lpad(i::VARCHAR, 6, '0') AS s
-FROM range(500000) r(i);
+FROM range(6144) r(i);
 
 # Equality on a prefix is already rewritten into a range predicate on the column itself.
 query II
-EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 2) = '40';
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 4) = '0010';
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
 query I
-SELECT count(*) FROM left_pruning WHERE left(s, 2) = '40';
+SELECT count(*) FROM left_pruning WHERE left(s, 4) = '0010';
 ----
-10000
+100
 
 # A constant-length prefix preserves the ordering of the input min/max values.
 query II
-EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 3) > '495';
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 4) > '0050';
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
 query I
-SELECT count(*) FROM left_pruning WHERE left(s, 3) > '495';
+SELECT count(*) FROM left_pruning WHERE left(s, 4) > '0050';
 ----
-4000
+1044
 
 query II
-EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 4) BETWEEN '1000' AND '1099';
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 4) BETWEEN '0030' AND '0031';
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
 query I
-SELECT count(*) FROM left_pruning WHERE left(s, 4) BETWEEN '1000' AND '1099';
+SELECT count(*) FROM left_pruning WHERE left(s, 4) BETWEEN '0030' AND '0031';
 ----
-10000
+200
+
+# A range crossing a row group boundary scans both row groups.
+query II
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 4) BETWEEN '0020' AND '0021';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*
+
+query I
+SELECT count(*) FROM left_pruning WHERE left(s, 4) BETWEEN '0020' AND '0021';
+----
+200
 
 # Lengths beyond the string preserve the bounds unchanged.
 query II
-EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 20) > '495000';
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, 20) > '005000';
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
 query I
-SELECT count(*) FROM left_pruning WHERE left(s, 20) > '495000';
+SELECT count(*) FROM left_pruning WHERE left(s, 20) > '005000';
 ----
-4999
+1143
 
 # A negative length depends on the length of each row, so no bounds are derived.
 query II
-EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, -4) = '40';
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, -2) = '0010';
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 5 / 5.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
 
 query I
-SELECT count(*) FROM left_pruning WHERE left(s, -4) = '40';
+SELECT count(*) FROM left_pruning WHERE left(s, -2) = '0010';
 ----
-10000
+100
 
 # Dynamic lengths do not propagate statistics.
 query II
-EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, (i % 2) + 2) = '40';
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning WHERE left(s, (i % 2) + 4) = '0010';
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 5 / 5.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 3.*
 
 query I
-SELECT count(*) FROM left_pruning WHERE left(s, (i % 2) + 2) = '40';
+SELECT count(*) FROM left_pruning WHERE left(s, (i % 2) + 4) = '0010';
 ----
-5000
+50
 
 # A zero length always produces an empty string.
 query I
 SELECT count(*) FROM left_pruning WHERE left(s, 0) = '';
 ----
-500000
+6144
 
 # Prefixes are measured in characters rather than bytes.
 statement ok
 CREATE TABLE left_pruning_utf8 AS
 SELECT i::INTEGER AS i, '🦆' || lpad(i::VARCHAR, 6, '0') AS s
-FROM range(500000) r(i);
+FROM range(6144) r(i);
 
 query II
-EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning_utf8 WHERE left(s, 3) BETWEEN '🦆40' AND '🦆41';
+EXPLAIN ANALYZE SELECT sum(i) FROM left_pruning_utf8 WHERE left(s, 5) BETWEEN '🦆0030' AND '🦆0031';
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
 query I
-SELECT count(*) FROM left_pruning_utf8 WHERE left(s, 3) BETWEEN '🦆40' AND '🦆41';
+SELECT count(*) FROM left_pruning_utf8 WHERE left(s, 5) BETWEEN '🦆0030' AND '🦆0031';
 ----
-20000
+200


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Optimizer-only stats callback for LEFT; incorrect min/max would cause wrong pruning, but it reuses existing slice stats and is covered by tests.
> 
> **Overview**
> Filters on `left(col, n)` with a **constant non-negative length** can now prune row groups via zonemaps.
> 
> `LeftFun` registers `LeftPropagateStats`, which reuses `PropagateStringSliceStats` for a prefix of `n` characters. Negative, null, or non-constant lengths skip stats (same as before). Grapheme `left` is unchanged.
> 
> SQL tests cover equality/range pruning, UTF-8 character prefixes, and cases that must still scan all row groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2929b80c6de09e0680e0a45a825017678e81d152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->