### PR TITLE
Hjiang/division stats

### DIFF
--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1216,13 +1216,111 @@ unique_ptr<FunctionData> BindBinaryFloatingPoint(BindScalarFunctionInput &input)
 	return nullptr;
 }
 
+struct TryDivideOperator {
+	template <class T>
+	static bool Operation(T left, T right, T &result) {
+		// with a non-zero divisor, division only overflows for the minimum value divided by -1
+		if (left == NumericLimits<T>::Minimum() && right == T(-1)) {
+			return false;
+		}
+		result = DivideOperator::Operation<T, T, T>(left, right);
+		return true;
+	}
+};
+
+struct DividePropagateStatistics {
+	template <class T, class OP>
+	static bool Operation(const LogicalType &type, BaseStatistics &lstats, BaseStatistics &rstats, Value &new_min,
+	                      Value &new_max) {
+		// a divisor range that contains zero produces NULLs, and the result grows without
+		// bound as the divisor approaches zero - no statistics can be derived
+		if (NumericStats::GetMin<T>(rstats) <= T(0) && NumericStats::GetMax<T>(rstats) >= T(0)) {
+			return true;
+		}
+		// as with multiplication, the extremes depend on the signs of the inputs:
+		// evaluate all combinations of the bounds and take the minimum/maximum
+		T lvals[] {NumericStats::GetMin<T>(lstats), NumericStats::GetMax<T>(lstats)};
+		T rvals[] {NumericStats::GetMin<T>(rstats), NumericStats::GetMax<T>(rstats)};
+		T min = NumericLimits<T>::Maximum();
+		T max = NumericLimits<T>::Minimum();
+		for (idx_t l = 0; l < 2; l++) {
+			for (idx_t r = 0; r < 2; r++) {
+				T result;
+				if (!OP::Operation(lvals[l], rvals[r], result)) {
+					return true;
+				}
+				if (result < min) {
+					min = result;
+				}
+				if (result > max) {
+					max = result;
+				}
+			}
+		}
+		new_min = NumericStatsValue(type, min);
+		new_max = NumericStatsValue(type, max);
+		return false;
+	}
+};
+
+// Dedicated callback rather than PropagateNumericStats: when propagation fails the divisor
+// range may contain zero, and division by zero produces NULLs that the inputs do not have,
+// so returning validity-only statistics would be incorrect - we must return no statistics.
+unique_ptr<BaseStatistics> PropagateIntegerDivideStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	D_ASSERT(child_stats.size() == 2);
+	auto &lstats = child_stats[0];
+	auto &rstats = child_stats[1];
+	if (!NumericStats::HasMinMax(lstats) || !NumericStats::HasMinMax(rstats)) {
+		return nullptr;
+	}
+	auto &type = expr.GetReturnType();
+	Value new_min, new_max;
+	bool failed;
+	switch (type.InternalType()) {
+	case PhysicalType::INT8:
+		failed =
+		    DividePropagateStatistics::Operation<int8_t, TryDivideOperator>(type, lstats, rstats, new_min, new_max);
+		break;
+	case PhysicalType::INT16:
+		failed =
+		    DividePropagateStatistics::Operation<int16_t, TryDivideOperator>(type, lstats, rstats, new_min, new_max);
+		break;
+	case PhysicalType::INT32:
+		failed =
+		    DividePropagateStatistics::Operation<int32_t, TryDivideOperator>(type, lstats, rstats, new_min, new_max);
+		break;
+	case PhysicalType::INT64:
+		failed =
+		    DividePropagateStatistics::Operation<int64_t, TryDivideOperator>(type, lstats, rstats, new_min, new_max);
+		break;
+	case PhysicalType::INT128:
+		failed =
+		    DividePropagateStatistics::Operation<hugeint_t, TryDivideOperator>(type, lstats, rstats, new_min, new_max);
+		break;
+	default:
+		return nullptr;
+	}
+	if (failed) {
+		return nullptr;
+	}
+	auto result = NumericStats::CreateEmpty(type);
+	NumericStats::SetMin(result, new_min);
+	NumericStats::SetMax(result, new_max);
+	result.CombineValidity(lstats, rstats);
+	return result.ToUnique();
+}
+
 } // namespace
 ScalarFunctionSet OperatorFloatDivideFun::GetFunctions() {
 	ScalarFunctionSet fp_divide("/");
 	fp_divide.AddFunction(ScalarFunction({LogicalType::FLOAT, LogicalType::FLOAT}, LogicalType::FLOAT, nullptr,
-	                                     BindBinaryFloatingPoint<DivideOperator>));
+	                                     BindBinaryFloatingPoint<DivideOperator>,
+	                                     PropagateFloatingStats<DividePropagateStatistics, DivideOperator>));
 	fp_divide.AddFunction(ScalarFunction({LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr,
-	                                     BindBinaryFloatingPoint<DivideOperator>));
+	                                     BindBinaryFloatingPoint<DivideOperator>,
+	                                     PropagateFloatingStats<DividePropagateStatistics, DivideOperator>));
 	fp_divide.AddFunction(
 	    ScalarFunction({LogicalType::INTERVAL, LogicalType::DOUBLE}, LogicalType::INTERVAL,
 	                   BinaryScalarFunctionIgnoreZero<interval_t, double, interval_t, DivideOperator>));
@@ -1237,6 +1335,10 @@ ScalarFunctionSet OperatorIntegerDivideFun::GetFunctions() {
 	for (auto &type : LogicalType::Numeric()) {
 		if (type.id() == LogicalTypeId::DECIMAL) {
 			continue;
+		} else if (TypeIsIntegral(type.InternalType())) {
+			full_divide.AddFunction(ScalarFunction({type, type}, type,
+			                                       GetBinaryFunctionIgnoreZero<DivideOperator>(type.InternalType()),
+			                                       nullptr, PropagateIntegerDivideStats));
 		} else {
 			full_divide.AddFunction(
 			    ScalarFunction({type, type}, type, GetBinaryFunctionIgnoreZero<DivideOperator>(type.InternalType())));

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1232,13 +1232,14 @@ struct DividePropagateStatistics {
 	template <class T, class OP>
 	static bool Operation(const LogicalType &type, BaseStatistics &lstats, BaseStatistics &rstats, Value &new_min,
 	                      Value &new_max) {
-		// a divisor range that contains zero produces NULLs, and the result grows without
+		D_ASSERT(NumericStats::HasMinMax(lstats) && NumericStats::HasMinMax(rstats));
+		// A divisor range that contains zero produces NULLs, and the result grows without
 		// bound as the divisor approaches zero - no statistics can be derived
 		if (NumericStats::GetMin<T>(rstats) <= T(0) && NumericStats::GetMax<T>(rstats) >= T(0)) {
 			return true;
 		}
-		// as with multiplication, the extremes depend on the signs of the inputs:
-		// evaluate all combinations of the bounds and take the minimum/maximum
+		// The extremes depend on the signs of the inputs: evaluate all combinations of the bounds and take the
+		// minimum/maximum
 		T lvals[] {NumericStats::GetMin<T>(lstats), NumericStats::GetMax<T>(lstats)};
 		T rvals[] {NumericStats::GetMin<T>(rstats), NumericStats::GetMax<T>(rstats)};
 		T min = NumericLimits<T>::Maximum();

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1252,53 +1252,14 @@ struct DividePropagateStatistics {
 	}
 };
 
-// Dedicated callback rather than PropagateNumericStats: when propagation fails the divisor
-// range may contain zero, and division by zero produces NULLs that the inputs do not have,
-// so returning validity-only statistics would be incorrect - we must return no statistics.
+// When propagation fails the divisor range may contain zero, and division by zero produces NULLs that the inputs do not
+// have: return no statistics instead of the validity-only statistics that PropagateNumericStats falls back to.
 unique_ptr<BaseStatistics> PropagateIntegerDivideStats(ClientContext &context, FunctionStatisticsInput &input) {
-	auto &child_stats = input.child_stats;
-	auto &expr = input.expr;
-	D_ASSERT(child_stats.size() == 2);
-	auto &lstats = child_stats[0];
-	auto &rstats = child_stats[1];
-	if (!NumericStats::HasMinMax(lstats) || !NumericStats::HasMinMax(rstats)) {
+	auto stats = PropagateNumericStats<TryDivideOperator, DividePropagateStatistics, DivideOperator>(context, input);
+	if (stats && !NumericStats::HasMinMax(*stats)) {
 		return nullptr;
 	}
-	auto &type = expr.GetReturnType();
-	Value new_min, new_max;
-	bool failed;
-	switch (type.InternalType()) {
-	case PhysicalType::INT8:
-		failed =
-		    DividePropagateStatistics::Operation<int8_t, TryDivideOperator>(type, lstats, rstats, new_min, new_max);
-		break;
-	case PhysicalType::INT16:
-		failed =
-		    DividePropagateStatistics::Operation<int16_t, TryDivideOperator>(type, lstats, rstats, new_min, new_max);
-		break;
-	case PhysicalType::INT32:
-		failed =
-		    DividePropagateStatistics::Operation<int32_t, TryDivideOperator>(type, lstats, rstats, new_min, new_max);
-		break;
-	case PhysicalType::INT64:
-		failed =
-		    DividePropagateStatistics::Operation<int64_t, TryDivideOperator>(type, lstats, rstats, new_min, new_max);
-		break;
-	case PhysicalType::INT128:
-		failed =
-		    DividePropagateStatistics::Operation<hugeint_t, TryDivideOperator>(type, lstats, rstats, new_min, new_max);
-		break;
-	default:
-		return nullptr;
-	}
-	if (failed) {
-		return nullptr;
-	}
-	auto result = NumericStats::CreateEmpty(type);
-	NumericStats::SetMin(result, new_min);
-	NumericStats::SetMax(result, new_max);
-	result.CombineValidity(lstats, rstats);
-	return result.ToUnique();
+	return stats;
 }
 
 } // namespace

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1216,18 +1216,6 @@ unique_ptr<FunctionData> BindBinaryFloatingPoint(BindScalarFunctionInput &input)
 	return nullptr;
 }
 
-struct TryDivideOperator {
-	template <class T>
-	static bool Operation(T left, T right, T &result) {
-		// with a non-zero divisor, division only overflows for the minimum value divided by -1
-		if (left == NumericLimits<T>::Minimum() && right == T(-1)) {
-			return false;
-		}
-		result = DivideOperator::Operation<T, T, T>(left, right);
-		return true;
-	}
-};
-
 struct DividePropagateStatistics {
 	template <class T, class OP>
 	static bool Operation(const LogicalType &type, BaseStatistics &lstats, BaseStatistics &rstats, Value &new_min,

--- a/src/include/duckdb/common/operator/numeric_binary_operators.hpp
+++ b/src/include/duckdb/common/operator/numeric_binary_operators.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/assert.hpp"
+#include "duckdb/common/limits.hpp"
 #include <cmath>
 
 namespace duckdb {
@@ -18,6 +19,19 @@ struct DivideOperator {
 	static inline TR Operation(TA left, TB right) {
 		D_ASSERT(right != 0); // this should be checked before!
 		return left / right;
+	}
+};
+
+struct TryDivideOperator {
+	template <class T>
+	static inline bool Operation(T left, T right, T &result) {
+		D_ASSERT(right != 0); // this should be checked before!
+		// with a non-zero divisor, division only overflows for the minimum value divided by -1
+		if (left == NumericLimits<T>::Minimum() && right == T(-1)) {
+			return false;
+		}
+		result = DivideOperator::Operation<T, T, T>(left, right);
+		return true;
 	}
 };
 

--- a/test/sql/optimizer/divide_zonemap_pruning.test
+++ b/test/sql/optimizer/divide_zonemap_pruning.test
@@ -1,0 +1,82 @@
+# name: test/sql/optimizer/divide_zonemap_pruning.test
+# description: Row group pruning for filters on division expressions
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/divide_zonemap_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 6144 rows -> 3 row groups of 2048 rows.
+statement ok
+CREATE TABLE divide_pruning AS
+SELECT i::INTEGER AS i
+FROM range(6144) r(i);
+
+# Integer division by a positive constant: i // 1000 = 5 only holds for
+# i in [5000, 5999], entirely inside the last row group.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM divide_pruning WHERE i // 1000 = 5;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM divide_pruning WHERE i // 1000 = 5;
+----
+1000
+
+# Float division by a positive constant: i / 100.0 < 5 only holds for i < 500.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM divide_pruning WHERE i / 100.0 < 5;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM divide_pruning WHERE i / 100.0 < 5;
+----
+500
+
+# A negative divisor flips the corners: the result range of the first two row
+# groups is above -4, so only the last row group can match.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM divide_pruning WHERE i // -1000 = -5;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM divide_pruning WHERE i // -1000 = -5;
+----
+1000
+
+# The divisor is itself a range: the outer row groups derive small quotient
+# ranges and are pruned, while the middle row group's divisor range
+# [-952, 1095] contains zero, so no statistics can be derived and it is scanned.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM divide_pruning WHERE 6144 // (i - 3000) = 123456;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM divide_pruning WHERE 6144 // (i - 3000) = 123456;
+----
+0
+
+# A constant zero divisor yields NULL for every row: no row matches.
+query I
+SELECT count(*) FROM divide_pruning WHERE i // 0 = 5;
+----
+0
+
+# The first row group contains the minimum integer: statistics derivation must
+# not evaluate INT32_MIN // -1, and pruning must not swallow the overflow error
+# raised when the row group is scanned.
+statement ok
+CREATE TABLE divide_overflow AS
+SELECT CASE WHEN i = 0 THEN -2147483648 ELSE i END::INTEGER AS i
+FROM range(6144) r(i);
+
+statement error
+SELECT count(*) FROM divide_overflow WHERE i // -1 = 42;
+----
+<REGEX>:.*Overflow in division.*

--- a/test/sql/optimizer/divide_zonemap_pruning.test
+++ b/test/sql/optimizer/divide_zonemap_pruning.test
@@ -14,8 +14,7 @@ CREATE TABLE divide_pruning AS
 SELECT i::INTEGER AS i
 FROM range(6144) r(i);
 
-# Integer division by a positive constant: i // 1000 = 5 only holds for
-# i in [5000, 5999], entirely inside the last row group.
+# Integer division by a positive constant: i // 1000 = 5 only holds for i in [5000, 5999], entirely inside the last row group.
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM divide_pruning WHERE i // 1000 = 5;
 ----
@@ -48,7 +47,9 @@ SELECT count(*) FROM divide_pruning WHERE i / -100.0 > -5;
 ----
 500
 
-# Float division with a divisor range: the middle row group's divisor range contains zero, so it cannot be pruned.
+# Float division where the divisor is itself a range: the outer row groups derive
+# small quotient ranges and are pruned, while the middle row group's divisor range
+# contains zero, so no statistics can be derived and it is scanned.
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM divide_pruning WHERE 6144.0 / (i - 3000) = 123456;
 ----

--- a/test/sql/optimizer/divide_zonemap_pruning.test
+++ b/test/sql/optimizer/divide_zonemap_pruning.test
@@ -37,6 +37,34 @@ SELECT count(*) FROM divide_pruning WHERE i / 100.0 < 5;
 ----
 500
 
+# Float division by a negative constant flips the corners: i / -100.0 > -5 only holds for i < 500.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM divide_pruning WHERE i / -100.0 > -5;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM divide_pruning WHERE i / -100.0 > -5;
+----
+500
+
+# Float division with a divisor range: the middle row group's divisor range contains zero, so it cannot be pruned.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM divide_pruning WHERE 6144.0 / (i - 3000) = 123456;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM divide_pruning WHERE 6144.0 / (i - 3000) = 123456;
+----
+0
+
+# Float division by a zero constant never matches, whether it yields NULL or infinity.
+query I
+SELECT count(*) FROM divide_pruning WHERE i / 0.0 = 123;
+----
+0
+
 # A negative divisor flips the corners: the result range of the first two row
 # groups is above -4, so only the last row group can match.
 query II
@@ -80,3 +108,21 @@ statement error
 SELECT count(*) FROM divide_overflow WHERE i // -1 = 42;
 ----
 <REGEX>:.*Overflow in division.*
+
+# A row group containing infinity: the corner evaluation hits a non-finite
+# value, so no statistics are derived for it and it is scanned rather than
+# incorrectly pruned. The finite row groups are still pruned.
+statement ok
+CREATE TABLE divide_float AS
+SELECT CASE WHEN i = 5000 THEN 'infinity'::DOUBLE ELSE i::DOUBLE END AS d
+FROM range(6144) r(i);
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM divide_float WHERE d / 2.0 > 1e308;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM divide_float WHERE d / 2.0 > 1e308;
+----
+1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches optimizer statistics for arithmetic, which can incorrectly prune row groups if bounds are wrong. Overflow and zero-divisor cases are handled conservatively, but this is still core query-planning logic.
> 
> **Overview**
> Enables zonemap/row-group pruning on filters over `/` and `//` by deriving result min/max from child numeric stats.
> 
> `DividePropagateStatistics` evaluates all bound combinations, refuses stats when the divisor range contains zero (unbounded quotients / extra NULLs), and skips overflow cases such as `INT_MIN / -1`. Integer `//` uses `TryDivideOperator` plus `PropagateIntegerDivideStats` so a failed range does not fall back to validity-only stats. Float `/` wires the same propagator through `PropagateFloatingStats`.
> 
> Tests cover constant and range divisors, sign flips, overflow, and infinities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a46c333d20fb4bcecc4ebda3440f47cf7a4f2cde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->