### PR TITLE
[WIP] filesysten layers

### DIFF
--- a/extension/json/json_reader.cpp
+++ b/extension/json/json_reader.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/common/file_open_flags.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
-#include "duckdb/storage/caching_mode.hpp"
+#include "duckdb/storage/external_file_cache/caching_file_system_layer.hpp"
 #include "json_scan.hpp"
 
 namespace duckdb {
@@ -188,8 +188,7 @@ void JSONReader::OpenJSONFile() {
 	if (!IsOpen()) {
 		auto &fs = FileSystem::GetFileSystem(context);
 		FileOpenFlags flags = FileFlags::FILE_FLAGS_READ | options.compression;
-		flags.SetCachingMode(CachingMode::CACHE_REMOTE_ONLY);
-		auto regular_file_handle = fs.OpenFile(file, flags);
+		auto regular_file_handle = fs.OpenFile(CachingFileSystemLayer::AddTo(file), flags);
 		file_handle = make_uniq<JSONFileHandle>(context, std::move(regular_file_handle), BufferAllocator::Get(context));
 	}
 	Reset();
@@ -1210,8 +1209,8 @@ void JSONReader::ReadNextBufferSeek(JSONReaderScanState &scan_state) {
 				if (!scan_state.thread_local_filehandle ||
 				    scan_state.thread_local_filehandle->GetPath() != raw_handle.GetPath()) {
 					FileOpenFlags flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_DIRECT_IO;
-					flags.SetCachingMode(CachingMode::CACHE_REMOTE_ONLY);
-					scan_state.thread_local_filehandle = scan_state.fs.OpenFile(raw_handle.GetPath(), flags);
+					auto file = CachingFileSystemLayer::AddTo(OpenFileInfo(raw_handle.GetPath()));
+					scan_state.thread_local_filehandle = scan_state.fs.OpenFile(file, flags);
 				}
 			} else if (scan_state.thread_local_filehandle) {
 				scan_state.thread_local_filehandle = nullptr;

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/common/pipe_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp"
+#include "duckdb/storage/external_file_cache/caching_file_system_layer.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/main/database.hpp"
@@ -20,6 +20,11 @@ struct FileSystemHandle {
 	}
 
 	unique_ptr<FileSystem> file_system;
+};
+
+//! The FileSystemLayerRegistry is an immutable snapshot of the registered filesystem layers.
+struct FileSystemLayerRegistry {
+	unordered_map<string, shared_ptr<FileSystemLayer>> layers;
 };
 
 //! The FileSystemRegistry holds the set of file systems that are registered.
@@ -110,8 +115,10 @@ VirtualFileSystem::VirtualFileSystem() : VirtualFileSystem(FileSystem::CreateLoc
 }
 
 VirtualFileSystem::VirtualFileSystem(unique_ptr<FileSystem> &&inner)
-    : file_system_registry(make_shared_ptr<FileSystemRegistry>(std::move(inner))) {
+    : file_system_registry(make_shared_ptr<FileSystemRegistry>(std::move(inner))),
+      file_system_layer_registry(make_shared_ptr<FileSystemLayerRegistry>()) {
 	VirtualFileSystem::RegisterSubSystem(FileCompressionType::GZIP, make_uniq<GZipFileSystem>());
+	RegisterFileSystemLayer(make_uniq<CachingFileSystemLayer>());
 }
 
 VirtualFileSystem::~VirtualFileSystem() {
@@ -156,20 +163,12 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 	flags.SetCompression(FileCompressionType::UNCOMPRESSED);
 
 	auto registry = file_system_registry.atomic_load();
-	auto &internal_filesystem = FindFileSystem(registry, file.path, opener);
+	auto &selected_file_system = FindFileSystem(registry, file.path, opener);
+	auto selected_file_system_owner = shared_ptr<FileSystem>(registry, &selected_file_system);
+	auto layered_file_system = ApplyFileSystemLayers(std::move(selected_file_system_owner), file, flags, opener);
 
 	// File handle gets created.
-	unique_ptr<FileHandle> file_handle = nullptr;
-
-	// Handle caching logic.
-	if (flags.GetCachingMode() != CachingMode::NO_CACHING) {
-		auto caching_filesystem =
-		    make_shared_ptr<CachingFileSystemWrapper>(internal_filesystem, opener, flags.GetCachingMode());
-		// caching filesystem's lifecycle is extended inside of caching file handle.
-		file_handle = caching_filesystem->OpenFile(file, flags, opener);
-	} else {
-		file_handle = internal_filesystem.OpenFile(file, flags, opener);
-	}
+	auto file_handle = layered_file_system->OpenFile(file, flags, opener);
 	if (!file_handle) {
 		return nullptr;
 	}
@@ -309,6 +308,24 @@ void VirtualFileSystem::RegisterSubSystem(FileCompressionType compression_type, 
 	file_system_registry.atomic_store(new_registry);
 }
 
+void VirtualFileSystem::RegisterFileSystemLayer(unique_ptr<FileSystemLayer> layer) {
+	if (!layer) {
+		throw InvalidInputException("Cannot register a null FileSystemLayer");
+	}
+	lock_guard<mutex> guard(registry_lock);
+	auto current_registry = file_system_layer_registry.atomic_load();
+	auto new_registry = make_shared_ptr<FileSystemLayerRegistry>(*current_registry);
+	auto name = layer->GetName();
+	if (name.empty()) {
+		throw InvalidInputException("Cannot register a FileSystemLayer with an empty name");
+	}
+	if (new_registry->layers.find(name) != new_registry->layers.end()) {
+		throw InvalidInputException("FileSystemLayer with name %s is already registered", name);
+	}
+	new_registry->layers.emplace(std::move(name), shared_ptr<FileSystemLayer>(std::move(layer)));
+	file_system_layer_registry.atomic_store(new_registry);
+}
+
 void VirtualFileSystem::UnregisterSubSystem(const string &name) {
 	auto sub_system = ExtractSubSystem(name);
 
@@ -422,6 +439,26 @@ optional_ptr<FileSystem> VirtualFileSystem::FindFileSystemInternal(FileSystemReg
 		}
 	}
 	return fs;
+}
+
+shared_ptr<FileSystem> VirtualFileSystem::ApplyFileSystemLayers(shared_ptr<FileSystem> file_system,
+                                                                const OpenFileInfo &file, FileOpenFlags flags,
+                                                                optional_ptr<FileOpener> opener) {
+	auto registry = file_system_layer_registry.atomic_load();
+	if (!file.extended_info) {
+		return file_system;
+	}
+	for (const auto &layer_options : file.extended_info->file_system_layers) {
+		auto entry = registry->layers.find(layer_options.name);
+		if (entry == registry->layers.end()) {
+			throw InvalidInputException("FileSystemLayer with name %s is not registered", layer_options.name);
+		}
+		file_system = entry->second->Wrap(std::move(file_system), layer_options, file, flags, opener);
+		if (!file_system) {
+			throw InternalException("FileSystemLayer %s returned a null filesystem", layer_options.name);
+		}
+	}
+	return file_system;
 }
 
 } // namespace duckdb

--- a/src/execution/operator/csv_scanner/buffer_manager/csv_file_handle.cpp
+++ b/src/execution/operator/csv_scanner/buffer_manager/csv_file_handle.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/compressed_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_reader_options.hpp"
+#include "duckdb/storage/external_file_cache/caching_file_system_layer.hpp"
 
 namespace duckdb {
 
@@ -21,8 +22,7 @@ CSVFileHandle::CSVFileHandle(ClientContext &context_p, unique_ptr<FileHandle> fi
 unique_ptr<FileHandle> CSVFileHandle::OpenFileHandle(FileSystem &fs, Allocator &allocator, const OpenFileInfo &file,
                                                      FileCompressionType compression) {
 	FileOpenFlags flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_PARALLEL_ACCESS | compression;
-	flags.SetCachingMode(CachingMode::CACHE_REMOTE_ONLY);
-	auto file_handle = fs.OpenFile(file, flags);
+	auto file_handle = fs.OpenFile(CachingFileSystemLayer::AddTo(file), flags);
 	if (file_handle->CanSeek()) {
 		file_handle->Reset();
 	}

--- a/src/function/table/direct_file_reader.cpp
+++ b/src/function/table/direct_file_reader.cpp
@@ -4,8 +4,7 @@
 
 #include "duckdb/common/serializer/memory_stream.hpp"
 #include "duckdb/function/table/read_file.hpp"
-#include "duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp"
-#include "duckdb/storage/caching_mode.hpp"
+#include "duckdb/storage/external_file_cache/caching_file_system_layer.hpp"
 
 namespace duckdb {
 
@@ -70,8 +69,7 @@ AsyncResult DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionSt
 		if (FileSystem::IsRemoteFile(file.path)) {
 			flags |= FileFlags::FILE_FLAGS_DIRECT_IO;
 		}
-		flags.SetCachingMode(CachingMode::CACHE_REMOTE_ONLY);
-		file_handle = fs.OpenFile(file, flags);
+		file_handle = fs.OpenFile(CachingFileSystemLayer::AddTo(file), flags);
 	} else {
 		// At least verify that the file exist
 		// The globbing behavior in remote filesystems can lead to files being listed that do not actually exist

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -10,7 +10,6 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/file_compression_type.hpp"
-#include "duckdb/storage/caching_mode.hpp"
 
 namespace duckdb {
 
@@ -54,10 +53,6 @@ public:
 		return a == FileCompressionType::UNCOMPRESSED ? b : a;
 	}
 
-	static constexpr CachingMode MergeCachingMode(CachingMode a, CachingMode b) {
-		return a == CachingMode::NO_CACHING ? b : a;
-	}
-
 	inline constexpr FileOpenFlags operator|(FileOpenFlags b) const {
 		return FileOpenFlags(flags | b.flags, MergeLock(lock, b.lock), MergeCompression(compression, b.compression));
 	}
@@ -65,7 +60,6 @@ public:
 		flags |= b.flags;
 		lock = MergeLock(lock, b.lock);
 		compression = MergeCompression(compression, b.compression);
-		caching_mode = MergeCachingMode(caching_mode, b.caching_mode);
 		return *this;
 	}
 
@@ -79,13 +73,6 @@ public:
 
 	void SetCompression(FileCompressionType new_compression) {
 		compression = new_compression;
-	}
-
-	CachingMode GetCachingMode() {
-		return caching_mode;
-	}
-	void SetCachingMode(CachingMode new_caching_mode) {
-		caching_mode = new_caching_mode;
 	}
 
 	void Verify();
@@ -139,7 +126,6 @@ public:
 private:
 	idx_t flags = 0;
 	FileLockType lock = FileLockType::NO_LOCK;
-	CachingMode caching_mode = CachingMode::NO_CACHING;
 	FileCompressionType compression = FileCompressionType::UNCOMPRESSED;
 };
 

--- a/src/include/duckdb/common/file_system_layer.hpp
+++ b/src/include/duckdb/common/file_system_layer.hpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/file_system_layer.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/file_system.hpp"
+
+namespace duckdb {
+
+//! A FileSystemLayer wraps the filesystem selected by VirtualFileSystem for an OpenFile call.
+class DUCKDB_API FileSystemLayer {
+public:
+	virtual ~FileSystemLayer() = default;
+	//! Return the name used by OpenFileInfo to request this layer.
+	virtual string GetName() const = 0;
+
+	//! Layers run in file option order, with later layers on the outside.
+	//! A wrapper must retain its inner filesystem and keep itself alive while handles dispatch through it.
+	virtual shared_ptr<FileSystem> Wrap(shared_ptr<FileSystem> file_system, const FileSystemLayerOptions &layer_options,
+	                                    const OpenFileInfo &file, FileOpenFlags flags,
+	                                    optional_ptr<FileOpener> opener) const = 0;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/open_file_info.hpp
+++ b/src/include/duckdb/common/open_file_info.hpp
@@ -14,8 +14,19 @@
 
 namespace duckdb {
 
+struct FileSystemLayerOptions {
+	FileSystemLayerOptions(string name_p, unordered_map<string, Value> options_p)
+	    : name(std::move(name_p)), options(std::move(options_p)) {
+	}
+
+	string name;
+	unordered_map<string, Value> options;
+};
+
 struct ExtendedOpenFileInfo {
 	unordered_map<string, Value> options;
+	//! Filesystem layers to apply in inner-to-outer order.
+	vector<FileSystemLayerOptions> file_system_layers;
 };
 
 struct OpenFileInfo {
@@ -28,6 +39,15 @@ struct OpenFileInfo {
 	shared_ptr<ExtendedOpenFileInfo> extended_info;
 
 public:
+	//! Return a copy with an additional filesystem layer request.
+	OpenFileInfo WithFileSystemLayer(string name, unordered_map<string, Value> options = {}) const {
+		auto result = *this;
+		result.extended_info = extended_info ? make_shared_ptr<ExtendedOpenFileInfo>(*extended_info)
+		                                     : make_shared_ptr<ExtendedOpenFileInfo>();
+		result.extended_info->file_system_layers.emplace_back(std::move(name), std::move(options));
+		return result;
+	}
+
 	bool operator<(const OpenFileInfo &rhs) const {
 		return path < rhs.path;
 	}

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -9,12 +9,14 @@
 #pragma once
 
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/file_system_layer.hpp"
 #include "duckdb/common/map.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/mutex.hpp"
 
 namespace duckdb {
 struct FileSystemRegistry;
+struct FileSystemLayerRegistry;
 
 // bunch of wrappers to allow registering protocol handlers
 class VirtualFileSystem : public FileSystem {
@@ -61,6 +63,8 @@ public:
 	void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) override;
 	void UnregisterSubSystem(const string &name) override;
 	unique_ptr<FileSystem> ExtractSubSystem(const string &name) override;
+	//! Register a layer that wraps the filesystem selected for each OpenFile call.
+	DUCKDB_API void RegisterFileSystemLayer(unique_ptr<FileSystemLayer> layer);
 
 	vector<string> ListSubSystems() override;
 
@@ -101,10 +105,13 @@ private:
 	FileSystem &FindFileSystem(shared_ptr<FileSystemRegistry> &registry, const string &path,
 	                           optional_ptr<FileOpener> file_opener);
 	optional_ptr<FileSystem> FindFileSystemInternal(FileSystemRegistry &registry, const string &path);
+	shared_ptr<FileSystem> ApplyFileSystemLayers(shared_ptr<FileSystem> file_system, const OpenFileInfo &file,
+	                                             FileOpenFlags flags, optional_ptr<FileOpener> opener);
 
 private:
 	mutex registry_lock;
 	shared_ptr<FileSystemRegistry> file_system_registry;
+	shared_ptr<FileSystemLayerRegistry> file_system_layer_registry;
 	vector<unique_ptr<FileSystem>> unregistered_file_systems;
 };
 

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system_layer.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system_layer.hpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/external_file_cache/caching_file_system_layer.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/file_system_layer.hpp"
+
+namespace duckdb {
+
+class DUCKDB_API CachingFileSystemLayer : public FileSystemLayer {
+public:
+	static constexpr const char *NAME = "external_file_cache";
+	static constexpr const char *CACHE_LOCAL_FILES = "cache_local_files";
+
+	string GetName() const override;
+	shared_ptr<FileSystem> Wrap(shared_ptr<FileSystem> file_system, const FileSystemLayerOptions &layer_options,
+	                            const OpenFileInfo &file, FileOpenFlags flags,
+	                            optional_ptr<FileOpener> opener) const override;
+
+	static OpenFileInfo AddTo(OpenFileInfo file, bool cache_local_files = false) {
+		unordered_map<string, Value> options;
+		if (cache_local_files) {
+			options[CACHE_LOCAL_FILES] = Value::BOOLEAN(true);
+		}
+		return file.WithFileSystemLayer(NAME, std::move(options));
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp
@@ -53,6 +53,8 @@ public:
 	                                    CachingMode mode = CachingMode::CACHE_REMOTE_ONLY);
 	DUCKDB_API CachingFileSystemWrapper(FileSystem &file_system, optional_ptr<FileOpener> file_opener,
 	                                    CachingMode mode = CachingMode::CACHE_REMOTE_ONLY);
+	DUCKDB_API CachingFileSystemWrapper(shared_ptr<FileSystem> file_system, optional_ptr<FileOpener> file_opener,
+	                                    CachingMode mode = CachingMode::CACHE_REMOTE_ONLY);
 	DUCKDB_API ~CachingFileSystemWrapper() override;
 
 	DUCKDB_API std::string GetName() const override;
@@ -133,6 +135,7 @@ private:
 	// Return an optional caching file handle, if certain filepath is cached.
 	CachingFileHandle *GetCachingHandleIfPossible(FileHandle &handle);
 
+	shared_ptr<FileSystem> owned_file_system;
 	CachingFileSystem caching_file_system;
 	FileSystem &underlying_file_system;
 	CachingMode caching_mode;

--- a/src/storage/external_file_cache/CMakeLists.txt
+++ b/src/storage/external_file_cache/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library_unity(
   duckdb_external_file_cache
   OBJECT
   caching_file_system.cpp
+  caching_file_system_layer.cpp
   caching_file_system_wrapper.cpp
   external_file_cache.cpp
   external_file_cache_util.cpp

--- a/src/storage/external_file_cache/caching_file_system_layer.cpp
+++ b/src/storage/external_file_cache/caching_file_system_layer.cpp
@@ -1,0 +1,23 @@
+#include "duckdb/storage/external_file_cache/caching_file_system_layer.hpp"
+
+#include "duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp"
+#include "duckdb/storage/caching_mode.hpp"
+
+namespace duckdb {
+
+string CachingFileSystemLayer::GetName() const {
+	return NAME;
+}
+
+shared_ptr<FileSystem> CachingFileSystemLayer::Wrap(shared_ptr<FileSystem> file_system,
+                                                    const FileSystemLayerOptions &layer_options, const OpenFileInfo &,
+                                                    FileOpenFlags, optional_ptr<FileOpener> opener) const {
+	auto mode = CachingMode::CACHE_REMOTE_ONLY;
+	auto cache_local_files = layer_options.options.find(CACHE_LOCAL_FILES);
+	if (cache_local_files != layer_options.options.end() && BooleanValue::Get(cache_local_files->second)) {
+		mode = CachingMode::ALWAYS_CACHE;
+	}
+	return make_shared_ptr<CachingFileSystemWrapper>(std::move(file_system), opener, mode);
+}
+
+} // namespace duckdb

--- a/src/storage/external_file_cache/caching_file_system_wrapper.cpp
+++ b/src/storage/external_file_cache/caching_file_system_wrapper.cpp
@@ -45,13 +45,21 @@ void CachingFileHandleWrapper::Close() {
 // CachingFileSystemWrapper implementation
 //===----------------------------------------------------------------------===//
 CachingFileSystemWrapper::CachingFileSystemWrapper(FileSystem &file_system, DatabaseInstance &db, CachingMode mode)
-    : caching_file_system(file_system, db), underlying_file_system(file_system), caching_mode(mode) {
+    : owned_file_system(), caching_file_system(file_system, db), underlying_file_system(file_system),
+      caching_mode(mode) {
 }
 
 CachingFileSystemWrapper::CachingFileSystemWrapper(FileSystem &file_system, optional_ptr<FileOpener> file_opener,
                                                    CachingMode mode)
-    : caching_file_system(file_system, GetDatabaseInstance(file_opener)), underlying_file_system(file_system),
-      caching_mode(mode) {
+    : owned_file_system(), caching_file_system(file_system, GetDatabaseInstance(file_opener)),
+      underlying_file_system(file_system), caching_mode(mode) {
+}
+
+CachingFileSystemWrapper::CachingFileSystemWrapper(shared_ptr<FileSystem> file_system,
+                                                   optional_ptr<FileOpener> file_opener, CachingMode mode)
+    : owned_file_system(std::move(file_system)),
+      caching_file_system(*owned_file_system, GetDatabaseInstance(file_opener)),
+      underlying_file_system(*owned_file_system), caching_mode(mode) {
 }
 
 bool CachingFileSystemWrapper::ShouldUseCache(const string &path) const {

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/vector.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/storage/external_file_cache/caching_file_system.hpp"
+#include "duckdb/storage/external_file_cache/caching_file_system_layer.hpp"
 #include "duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp"
 
 #include <thread>
@@ -512,12 +513,15 @@ TEST_CASE("Open file in opener filesystem cache modes", "[file_system][caching]"
 	string buffer(TEST_BUFFER_SIZE, '\0');
 	const auto &external_file_cache = db_instance.GetExternalFileCache();
 
-	auto run_case = [&](CachingMode mode) {
+	auto run_case = [&](bool cache_enabled) {
 		FileOpenFlags flags {FileFlags::FILE_FLAGS_READ};
-		flags.SetCachingMode(mode);
+		OpenFileInfo file(test_file.GetPath());
+		if (cache_enabled) {
+			file = CachingFileSystemLayer::AddTo(std::move(file), true);
+		}
 
 		// Perform read operation and check correctness.
-		auto handle = opener_filesystem.OpenFile(test_file.GetPath(), flags);
+		auto handle = opener_filesystem.OpenFile(file, flags);
 		handle->Read(QueryContext(), &buffer[0], test_content.length(), /*location=*/0);
 		REQUIRE(buffer.substr(0, test_content.length()) == test_content);
 
@@ -526,13 +530,13 @@ TEST_CASE("Open file in opener filesystem cache modes", "[file_system][caching]"
 	};
 
 	SECTION("cache enabled") {
-		run_case(CachingMode::ALWAYS_CACHE);
+		run_case(true);
 		// Check external cache file has something cached.
 		REQUIRE(!external_file_cache.GetCachedFileInformation().empty());
 	}
 
 	SECTION("cache disabled") {
-		run_case(CachingMode::NO_CACHING);
+		run_case(false);
 		// Check external cache file has nothing cached.
 		REQUIRE(external_file_cache.GetCachedFileInformation().empty());
 	}
@@ -550,10 +554,10 @@ TEST_CASE("Request over-sized range read", "[file_system][caching]") {
 	vfs.RegisterSubSystem(make_uniq<TrackingFileSystem>());
 
 	FileOpenFlags flags {FileFlags::FILE_FLAGS_READ};
-	flags.SetCachingMode(CachingMode::ALWAYS_CACHE);
+	auto file = CachingFileSystemLayer::AddTo(OpenFileInfo(test_file.GetPath()), true);
 
 	// Perform read operation and check correctness.
-	auto handle = opener_filesystem.OpenFile(test_file.GetPath(), flags);
+	auto handle = opener_filesystem.OpenFile(file, flags);
 	string buffer(TEST_BUFFER_SIZE, '\0');
 	const idx_t actual_read = handle->Read(QueryContext(), &buffer[0], test_content.length() + 1);
 	REQUIRE(actual_read == test_content.length());
@@ -829,7 +833,6 @@ TEST_CASE("CachingFileHandle EOF read behavior", "[file_system][caching]") {
 	file_info.extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
 
 	FileOpenFlags flags {FileFlags::FILE_FLAGS_READ};
-	flags.SetCachingMode(CachingMode::ALWAYS_CACHE);
 
 	// Seeking Read past EOF returns partial data.
 	{

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -1,6 +1,7 @@
 #include "catch.hpp"
 #include "duckdb/common/file_buffer.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/file_system_layer.hpp"
 #include "duckdb/common/fstream.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -40,6 +41,49 @@ static void create_dummy_file(string fname) {
 	outfile << "I_AM_A_DUMMY" << endl;
 	outfile.close();
 }
+
+class RecordingFileSystem : public FileSystem {
+public:
+	RecordingFileSystem(shared_ptr<FileSystem> file_system_p, shared_ptr<vector<string>> events_p, string name_p)
+	    : file_system(std::move(file_system_p)), events(std::move(events_p)), name(std::move(name_p)) {
+	}
+
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+	                                optional_ptr<FileOpener> opener = nullptr) override {
+		events->push_back("open:" + name);
+		return file_system->OpenFile(path, flags, opener);
+	}
+
+	string GetName() const override {
+		return name;
+	}
+
+private:
+	shared_ptr<FileSystem> file_system;
+	shared_ptr<vector<string>> events;
+	string name;
+};
+
+class RecordingFileSystemLayer : public FileSystemLayer {
+public:
+	RecordingFileSystemLayer(shared_ptr<vector<string>> events_p, string name_p)
+	    : events(std::move(events_p)), name(std::move(name_p)) {
+	}
+
+	string GetName() const override {
+		return name;
+	}
+
+	shared_ptr<FileSystem> Wrap(shared_ptr<FileSystem> file_system, const FileSystemLayerOptions &,
+	                            const OpenFileInfo &, FileOpenFlags, optional_ptr<FileOpener>) const override {
+		events->push_back("wrap:" + name + ":" + file_system->GetName());
+		return make_shared_ptr<RecordingFileSystem>(std::move(file_system), events, name);
+	}
+
+private:
+	shared_ptr<vector<string>> events;
+	string name;
+};
 
 TEST_CASE("Make sure the file:// protocol works as expected", "[file_system]") {
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
@@ -238,6 +282,25 @@ TEST_CASE("Test RemoveFiles", "[file_system]") {
 	REQUIRE(!fs->FileExists(file4));
 
 	fs->RemoveDirectory(dname);
+}
+
+TEST_CASE("VirtualFileSystem applies layers after routing", "[file_system][layer]") {
+	auto events = make_shared_ptr<vector<string>>();
+	VirtualFileSystem vfs;
+	vfs.RegisterFileSystemLayer(make_uniq<RecordingFileSystemLayer>(events, "first"));
+	vfs.RegisterFileSystemLayer(make_uniq<RecordingFileSystemLayer>(events, "second"));
+
+	auto path = TestCreatePath("test_file_system_layers.txt");
+	create_dummy_file(path);
+	FileOpenFlags flags {FileFlags::FILE_FLAGS_READ};
+	auto file = OpenFileInfo(path).WithFileSystemLayer("first").WithFileSystemLayer("second");
+	auto handle = vfs.OpenFile(file, flags);
+
+	vector<string> expected {"wrap:first:LocalFileSystem", "wrap:second:first", "open:second", "open:first"};
+	REQUIRE(*events == expected);
+
+	handle.reset();
+	vfs.RemoveFile(path, nullptr);
 }
 
 TEST_CASE("extract subsystem", "[file_system]") {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the VirtualFileSystem OpenFile path and how CSV/JSON/read_file enable the external file cache. Incorrect layer ownership or opt-in would skip or double-apply caching.
> 
> **Overview**
> Adds a **FileSystemLayer** abstraction so `VirtualFileSystem` can wrap the routed filesystem on each `OpenFile`, instead of baking caching into `FileOpenFlags`.
> 
> Layers are registered by name (copy-on-write registry, same pattern as subsystems). `OpenFileInfo` carries an ordered list of layer requests; later layers wrap earlier ones. Caching is no longer a flag: callers opt in with `CachingFileSystemLayer::AddTo(...)`. The cache layer is registered by default and still defaults to remote-only, with an optional `cache_local_files` option.
> 
> CSV, JSON, and `read_file` now request that layer instead of `SetCachingMode`. `CachingFileSystemWrapper` can own the inner `shared_ptr<FileSystem>` so wrappers stay alive with their handles. Tests cover wrap order and the new opt-in path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b394eb79203c5cda1468b45d93da96fc25e4cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->