### PR TITLE
Hjiang/skip parquet fileter always true

### DIFF
--- a/benchmark/micro/parquet/always_true_filter.benchmark
+++ b/benchmark/micro/parquet/always_true_filter.benchmark
@@ -1,0 +1,18 @@
+# name: benchmark/micro/parquet/always_true_filter.benchmark
+# description: Filter on a sorted column that is provably true for every parquet row group
+# group: [parquet]
+
+name Parquet Always-True Filter
+group micro
+subgroup parquet
+
+require parquet
+
+load
+COPY (SELECT (TIMESTAMP '2021-01-01' + INTERVAL (range/100) SECOND) ts, (range % 997)::INTEGER payload FROM range(30000000)) TO '${BENCHMARK_DIR}/always_true_filter.parquet' (ROW_GROUP_SIZE 500000);
+
+run
+SELECT sum(payload) FROM read_parquet('${BENCHMARK_DIR}/always_true_filter.parquet') WHERE ts >= TIMESTAMP '2020-01-01';
+
+result I
+14939901855

--- a/benchmark/micro/parquet/always_true_filter.benchmark
+++ b/benchmark/micro/parquet/always_true_filter.benchmark
@@ -1,5 +1,5 @@
 # name: benchmark/micro/parquet/always_true_filter.benchmark
-# description: Filter on a sorted column that is provably true for every parquet row group
+# description: Expression filter that is provably true for all but the first parquet row group
 # group: [parquet]
 
 name Parquet Always-True Filter
@@ -9,10 +9,10 @@ subgroup parquet
 require parquet
 
 load
-COPY (SELECT (TIMESTAMP '2021-01-01' + INTERVAL (range/100) SECOND) ts, (range % 997)::INTEGER payload FROM range(30000000)) TO '${BENCHMARK_DIR}/always_true_filter.parquet' (ROW_GROUP_SIZE 500000);
+COPY (SELECT range AS a, (range % 997)::INTEGER payload FROM range(30000000)) TO '${BENCHMARK_DIR}/always_true_filter.parquet' (ROW_GROUP_SIZE 500000);
 
 run
-SELECT sum(payload) FROM read_parquet('${BENCHMARK_DIR}/always_true_filter.parquet') WHERE ts >= TIMESTAMP '2020-01-01';
+SELECT sum(payload) FROM read_parquet('${BENCHMARK_DIR}/always_true_filter.parquet') WHERE a * 4 + 4 > 400001;
 
 result I
-14939901855
+14890206405

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -138,6 +138,9 @@ struct ParquetScanFilter {
 	ProjectionIndex filter_idx;
 	TableFilter &filter;
 	unique_ptr<TableFilterState> filter_state;
+	//! Whether the zonemap proved this filter always true for the current row group, in which case evaluating it can be
+	//! skipped
+	bool always_true = false;
 };
 
 struct ParquetPrefetchColumn {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1766,6 +1766,13 @@ void ParquetReader::PrepareRowGroupBuffer(ClientContext &context, ParquetReaderS
 				}
 			}
 
+			for (auto &scan_filter : state.scan_filters) {
+				if (MultiFileLocalIndex(scan_filter.filter_idx).GetIndex() == col_idx.GetIndex()) {
+					scan_filter.always_true = prune_result == FilterPropagateResult::FILTER_ALWAYS_TRUE;
+					break;
+				}
+			}
+
 			if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
 				// this effectively will skip this chunk
 				state.offset_in_group = group.num_rows;
@@ -2242,6 +2249,12 @@ idx_t ParquetReader::EvaluateFilters(ParquetReaderScanState &state, DataChunk &r
 
 		auto &result_vector = result.data[local_idx.GetIndex()];
 		ColumnReaderInput reader_input(scan_count, define_ptr, repeat_ptr);
+		if (scan_filter.always_true) {
+			// Zonemap proved that every row in this row group passes the filter: decode the column without evaluating
+			// the filter
+			child_reader.Select(reader_input, result_vector, state.sel, filter_count);
+			continue;
+		}
 		child_reader.Filter(reader_input, result_vector, scan_filter.filter, *scan_filter.filter_state, state.sel,
 		                    filter_count, is_first_filter);
 		if (log_prefetch) {

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -438,3 +438,57 @@ FROM '{TEST_DIR}/expr_prune_string_length.parquet'
 WHERE octet_length(b) > 30
 ----
 analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 1 / 3.*
+
+# Filters that are always true for entire row groups: the reader may skip evaluating such a
+# filter for those row groups (the data is still read - this is not pruning). These queries pin
+# the results down so that optimization cannot change them.
+
+# 10 row groups of 10240 sorted rows; s is NULL only for i in [85000, 85999] (row group 8 only)
+statement ok
+COPY (
+	SELECT range AS i,
+	       (range % 97)::INTEGER AS payload,
+	       CASE WHEN range BETWEEN 85000 AND 85999 THEN NULL ELSE 'val_' || range END AS s
+	FROM range(102400)
+) TO '{TEST_DIR}/expr_prune_always_true.parquet' (ROW_GROUP_SIZE 10240)
+
+# i < 50000: row groups 0-3 always true, row group 4 partial, row groups 5-9 always false.
+# sum(payload) cannot be answered from metadata, so the scan and the filter remain.
+statement ok
+CALL enable_logging('PhysicalOperator')
+
+query II
+SELECT count(*), sum(payload) FROM '{TEST_DIR}/expr_prune_always_true.parquet' WHERE i < 50000
+----
+50000	2398830
+
+statement ok
+CALL disable_logging()
+
+# the always-true row groups are read, not skipped
+query II
+SELECT event, count(*) FROM duckdb_logs_parsed('PhysicalOperator') WHERE class='ParquetReader' GROUP BY event ORDER BY event
+----
+ReadRowGroup	5
+SkipRowGroup	5
+
+statement ok
+CALL truncate_duckdb_logs()
+
+# an always-true filter combined with one that must still be evaluated for every row group
+query II
+SELECT count(*), sum(payload) FROM '{TEST_DIR}/expr_prune_always_true.parquet' WHERE i < 50000 AND payload < 50
+----
+25795	631865
+
+# IS NOT NULL: always true for the row groups without NULLs, must be evaluated for row group 8
+query II
+SELECT count(*), sum(payload) FROM '{TEST_DIR}/expr_prune_always_true.parquet' WHERE s IS NOT NULL
+----
+101400	4866325
+
+# always-true range filter combined with IS NOT NULL on a filter-only column
+query II
+SELECT count(*), sum(payload) FROM '{TEST_DIR}/expr_prune_always_true.parquet' WHERE i >= 30000 AND s IS NOT NULL
+----
+71400	3427270

--- a/test/sql/copy/parquet/parquet_prefetch_row_group_outcome.test
+++ b/test/sql/copy/parquet/parquet_prefetch_row_group_outcome.test
@@ -104,6 +104,8 @@ SELECT sum(a + b + c + g)
 FROM read_parquet('{TEST_DIR}/rgo.parquet')
 WHERE a > 100 AND b > 100 AND c = 50
 
+# from row group 1 onwards the filters on a and b are always true per the zonemap,
+# so they are never evaluated and only c contributes to minimal_filters
 query ITTTT
 SELECT row_group_id, fully_filtered, strategy, prefetch_groups, minimal_filters
 FROM duckdb_logs_parsed('ParquetPrefetch')
@@ -111,11 +113,11 @@ WHERE file_path LIKE '%rgo.parquet'
 ORDER BY row_group_id
 ----
 0	true	whole_group	[[a, b, c, g]]	[a, b, c]
-1	true	prefetch_filters	[[a, b, c], [g]]	[a, b, c]
-2	true	prefetch_filters	[[a, b, c], [g]]	[a, b, c]
-3	true	prefetch_filters	[[a, b, c], [g]]	[a, b, c]
-4	true	prefetch_filters	[[a, b, c], [g]]	[a, b, c]
-5	true	prefetch_filters	[[a, b, c], [g]]	[a, b, c]
+1	true	prefetch_filters	[[a, b, c], [g]]	[c]
+2	true	prefetch_filters	[[a, b, c], [g]]	[c]
+3	true	prefetch_filters	[[a, b, c], [g]]	[c]
+4	true	prefetch_filters	[[a, b, c], [g]]	[c]
+5	true	prefetch_filters	[[a, b, c], [g]]	[c]
 
 statement ok
 CALL truncate_duckdb_logs()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Parquet filter evaluation, so a wrong always-true flag would return extra rows. Scope is small and covered by result-pinning tests.
> 
> **Overview**
> When a Parquet zonemap proves a predicate is **always true** for a row group, the reader now **skips evaluating that filter** and only decodes the column (`Select` instead of `Filter`). Always-false groups are still skipped as before; always-true groups are still read.
> 
> This avoids per-row filter work (and changes prefetch `minimal_filters` so unused always-true predicates are not counted). Tests pin mixed always-true / partial / always-false groups, `IS NOT NULL`, and combined filters; a microbenchmark covers a large always-true expression filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733e0fd168bfee178df5cadce47e586adace8a49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->