### PR TITLE
Hjiang/aggregate propagation

### DIFF
--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -259,7 +259,7 @@ struct TimeTZAverageOperation : public BaseSumOperation<AverageSetOperation, Add
 	}
 };
 
-AggregateFunction GetAverageAggregateInternal(PhysicalType type) {
+AggregateFunction GetAverageAggregate(PhysicalType type) {
 	switch (type) {
 	case PhysicalType::INT16: {
 		return AggregateFunction::UnaryAggregate<AvgState<int64_t>, int16_t, double, IntegerAverageOperation>(
@@ -284,15 +284,6 @@ AggregateFunction GetAverageAggregateInternal(PhysicalType type) {
 	default:
 		throw InternalException("Unimplemented average aggregate");
 	}
-}
-
-AggregateFunction GetAverageAggregate(PhysicalType type) {
-	auto function = GetAverageAggregateInternal(type);
-	// the average always lies within the range of the input values
-	// note: the DOUBLE overload does not use this function - summing doubles can overflow to
-	// infinity, in which case the result escapes the input range
-	function.SetStatisticsCallback(AggregateFunction::PropagateInputRangeStats);
-	return function;
 }
 
 unique_ptr<FunctionData> BindDecimalAvg(BindAggregateFunctionInput &input) {

--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -259,7 +259,7 @@ struct TimeTZAverageOperation : public BaseSumOperation<AverageSetOperation, Add
 	}
 };
 
-AggregateFunction GetAverageAggregate(PhysicalType type) {
+AggregateFunction GetAverageAggregateInternal(PhysicalType type) {
 	switch (type) {
 	case PhysicalType::INT16: {
 		return AggregateFunction::UnaryAggregate<AvgState<int64_t>, int16_t, double, IntegerAverageOperation>(
@@ -284,6 +284,15 @@ AggregateFunction GetAverageAggregate(PhysicalType type) {
 	default:
 		throw InternalException("Unimplemented average aggregate");
 	}
+}
+
+AggregateFunction GetAverageAggregate(PhysicalType type) {
+	auto function = GetAverageAggregateInternal(type);
+	// the average always lies within the range of the input values
+	// note: the DOUBLE overload does not use this function - summing doubles can overflow to
+	// infinity, in which case the result escapes the input range
+	function.SetStatisticsCallback(AggregateFunction::PropagateInputRangeStats);
+	return function;
 }
 
 unique_ptr<FunctionData> BindDecimalAvg(BindAggregateFunctionInput &input) {

--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -582,6 +582,7 @@ unique_ptr<FunctionData> BindDecimalArgMinMax(BindAggregateFunctionInput &input)
 	auto name = function.GetName();
 	function.ReplaceImplementation(GetDecimalArgMinMaxFunction<OP>(by_type, decimal_type, NULL_HANDLING));
 	function.SetName(std::move(name));
+	function.SetStatisticsCallback(AggregateFunction::PropagateInputValueStats);
 	function.SetReturnType(decimal_type);
 
 	auto function_data = make_uniq<ArgMinMaxFunctionData>(NULL_HANDLING);
@@ -918,10 +919,19 @@ void AddArgMinMaxNFunction(AggregateFunctionSet &set) {
 // Function Registration
 //------------------------------------------------------------------------------
 
+static void SetArgMinMaxStatisticsCallback(AggregateFunctionSet &fun) {
+	// the result is always one of the values of the first argument; the "arg_min(a, b, n)"
+	// variants return a LIST, for which the callback bails out at propagation time
+	for (auto &function : fun.functions) {
+		function.SetStatisticsCallback(AggregateFunction::PropagateInputValueStats);
+	}
+}
+
 AggregateFunctionSet ArgMinFun::GetFunctions() {
 	AggregateFunctionSet fun;
 	AddArgMinMaxFunctions<LessThan, OrderType::ASCENDING>(fun, ArgMinMaxNullHandling::IGNORE_ANY_NULL);
 	AddArgMinMaxNFunction<ArgMinMaxNullHandling::IGNORE_ANY_NULL, true, LessThan>(fun);
+	SetArgMinMaxStatisticsCallback(fun);
 	return fun;
 }
 
@@ -929,6 +939,7 @@ AggregateFunctionSet ArgMaxFun::GetFunctions() {
 	AggregateFunctionSet fun;
 	AddArgMinMaxFunctions<GreaterThan, OrderType::DESCENDING>(fun, ArgMinMaxNullHandling::IGNORE_ANY_NULL);
 	AddArgMinMaxNFunction<ArgMinMaxNullHandling::IGNORE_ANY_NULL, false, GreaterThan>(fun);
+	SetArgMinMaxStatisticsCallback(fun);
 	return fun;
 }
 

--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -920,8 +920,6 @@ void AddArgMinMaxNFunction(AggregateFunctionSet &set) {
 //------------------------------------------------------------------------------
 
 static void SetArgMinMaxStatisticsCallback(AggregateFunctionSet &fun) {
-	// the result is always one of the values of the first argument; the "arg_min(a, b, n)"
-	// variants return a LIST, for which the callback bails out at propagation time
 	for (auto &function : fun.functions) {
 		function.SetStatisticsCallback(AggregateFunction::PropagateInputValueStats);
 	}

--- a/extension/core_functions/aggregate/holistic/mode.cpp
+++ b/extension/core_functions/aggregate/holistic/mode.cpp
@@ -631,6 +631,7 @@ unique_ptr<FunctionData> BindModeAggregate(BindAggregateFunctionInput &input) {
 	function.ReplaceImplementation(GetModeAggregate(arguments[0]->GetReturnType()));
 	function.SetName("mode");
 	function.SetRewriteCallback(RewriteMode, AggregateRewritePolicy::MANDATORY);
+	function.SetStatisticsCallback(AggregateFunction::PropagateInputValueStats);
 	return nullptr;
 }
 

--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -491,7 +491,6 @@ struct ListDiscreteQuantile {
 
 AggregateFunction GetDiscreteQuantile(const LogicalType &type) {
 	auto fun = GetDiscreteQuantileTemplated<ScalarDiscreteQuantile>(type);
-	// a discrete quantile is always one of the input values
 	fun.SetStatisticsCallback(AggregateFunction::PropagateInputValueStats);
 	return fun;
 }
@@ -592,7 +591,6 @@ struct ListContinuousQuantile {
 
 AggregateFunction GetContinuousQuantile(const LogicalType &type) {
 	auto fun = GetContinuousQuantileTemplated<ScalarContinuousQuantile>(type);
-	// a continuous quantile interpolates between two input values, staying within their range
 	fun.SetStatisticsCallback(AggregateFunction::PropagateInputRangeStats);
 	return fun;
 }

--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -591,7 +591,7 @@ struct ListContinuousQuantile {
 
 AggregateFunction GetContinuousQuantile(const LogicalType &type) {
 	auto fun = GetContinuousQuantileTemplated<ScalarContinuousQuantile>(type);
-	fun.SetStatisticsCallback(AggregateFunction::PropagateInputRangeStats);
+	fun.SetStatisticsCallback(AggregateFunction::PropagateInputValueStats);
 	return fun;
 }
 

--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -490,7 +490,10 @@ struct ListDiscreteQuantile {
 };
 
 AggregateFunction GetDiscreteQuantile(const LogicalType &type) {
-	return GetDiscreteQuantileTemplated<ScalarDiscreteQuantile>(type);
+	auto fun = GetDiscreteQuantileTemplated<ScalarDiscreteQuantile>(type);
+	// a discrete quantile is always one of the input values
+	fun.SetStatisticsCallback(AggregateFunction::PropagateInputValueStats);
+	return fun;
 }
 
 AggregateFunction GetDiscreteQuantileList(const LogicalType &type) {
@@ -588,7 +591,10 @@ struct ListContinuousQuantile {
 };
 
 AggregateFunction GetContinuousQuantile(const LogicalType &type) {
-	return GetContinuousQuantileTemplated<ScalarContinuousQuantile>(type);
+	auto fun = GetContinuousQuantileTemplated<ScalarContinuousQuantile>(type);
+	// a continuous quantile interpolates between two input values, staying within their range
+	fun.SetStatisticsCallback(AggregateFunction::PropagateInputRangeStats);
+	return fun;
 }
 
 AggregateFunction GetContinuousQuantileList(const LogicalType &type) {

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -489,6 +489,7 @@ unique_ptr<FunctionData> BindDecimalFirst(BindAggregateFunctionInput &input) {
 	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	function.SetDirectRewriteCallback(RewriteOrderedFirst<LAST, SKIP_NULLS>);
 	function.SetSingleValueIdentity(true);
+	function.SetStatisticsCallback(AggregateFunction::PropagateInputValueStats);
 	function.SetReturnType(decimal_type);
 	return nullptr;
 }
@@ -513,6 +514,7 @@ unique_ptr<FunctionData> BindFirst(BindAggregateFunctionInput &input) {
 	function.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	function.SetDirectRewriteCallback(RewriteOrderedFirst<LAST, SKIP_NULLS>);
 	function.SetSingleValueIdentity(true);
+	function.SetStatisticsCallback(AggregateFunction::PropagateInputValueStats);
 	return nullptr;
 }
 
@@ -533,6 +535,7 @@ AggregateFunction FirstFunctionGetter::GetFunction(const LogicalType &type) {
 	fun.SetName("first");
 	fun.SetDirectRewriteCallback(RewriteOrderedFirst<false, false>);
 	fun.SetSingleValueIdentity(true);
+	fun.SetStatisticsCallback(AggregateFunction::PropagateInputValueStats);
 	return fun;
 }
 
@@ -541,6 +544,7 @@ AggregateFunction LastFunctionGetter::GetFunction(const LogicalType &type) {
 	fun.SetName("last");
 	fun.SetDirectRewriteCallback(RewriteOrderedFirst<true, false>);
 	fun.SetSingleValueIdentity(true);
+	fun.SetStatisticsCallback(AggregateFunction::PropagateInputValueStats);
 	return fun;
 }
 

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -398,6 +398,7 @@ unique_ptr<FunctionData> BindMinMax(BindAggregateFunctionInput &input) {
 	minmax_func.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	minmax_func.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
 	minmax_func.SetSingleValueIdentity(true);
+	minmax_func.SetStatisticsCallback(AggregateFunction::PropagateInputValueStats);
 
 	auto expr = minmax_func.Bind(context, std::move(arguments));
 	arguments = std::move(expr->GetChildrenMutable());

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -8,29 +8,22 @@
 
 namespace duckdb {
 
-static unique_ptr<BaseStatistics> PropagateStatsFromInput(BoundAggregateExpression &expr,
-                                                          AggregateStatisticsInput &input, bool allow_cast) {
-	if (input.child_stats.empty()) {
-		return nullptr;
-	}
-	if (expr.StateExportMode() == AggregateStateExportMode::STATE_EXPORT) {
-		// the expression returns the internal aggregate state instead of a value
+unique_ptr<BaseStatistics> AggregateFunction::PropagateInputValueStats(ClientContext &context,
+                                                                       BoundAggregateExpression &expr,
+                                                                       AggregateStatisticsInput &input) {
+	if (input.child_stats.empty() || expr.StateExportMode() == AggregateStateExportMode::STATE_EXPORT) {
 		return nullptr;
 	}
 	auto &child_stats = input.child_stats[0];
 	auto &return_type = expr.GetReturnType();
-	unique_ptr<BaseStatistics> result;
-	if (child_stats.GetType() == return_type) {
-		result = child_stats.ToUnique();
-	} else if (allow_cast) {
-		result = StatisticsPropagator::TryPropagateCast(child_stats, child_stats.GetType(), return_type);
-	}
+	auto result = child_stats.GetType() == return_type
+	                  ? child_stats.ToUnique()
+	                  : StatisticsPropagator::TryPropagateCast(child_stats, child_stats.GetType(), return_type);
 	if (!result) {
 		return nullptr;
 	}
-	// the result is NULL when the aggregate sees no valid rows: an empty input for ungrouped
-	// aggregates, a FILTER clause that discards every row of a group, or a group in which every
-	// value of any argument is NULL (e.g. arg_min over an all-NULL "by" column)
+	// the result is NULL when the aggregate sees no valid rows (empty ungrouped input, all rows
+	// filtered out, or a group in which every value of any argument is NULL)
 	if (input.input_may_be_empty || expr.GetFilter()) {
 		result->Set(StatsInfo::CAN_HAVE_NULL_VALUES);
 	}
@@ -41,18 +34,6 @@ static unique_ptr<BaseStatistics> PropagateStatsFromInput(BoundAggregateExpressi
 		}
 	}
 	return result;
-}
-
-unique_ptr<BaseStatistics> AggregateFunction::PropagateInputValueStats(ClientContext &context,
-                                                                       BoundAggregateExpression &expr,
-                                                                       AggregateStatisticsInput &input) {
-	return PropagateStatsFromInput(expr, input, false);
-}
-
-unique_ptr<BaseStatistics> AggregateFunction::PropagateInputRangeStats(ClientContext &context,
-                                                                       BoundAggregateExpression &expr,
-                                                                       AggregateStatisticsInput &input) {
-	return PropagateStatsFromInput(expr, input, true);
 }
 
 AggregateInputData::AggregateInputData(const BoundAggregateExpression &expr, ArenaAllocator &allocator_p,

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -2,9 +2,58 @@
 
 #include "duckdb/execution/operator/aggregate/aggregate_object.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
 
 namespace duckdb {
+
+static unique_ptr<BaseStatistics> PropagateStatsFromInput(BoundAggregateExpression &expr,
+                                                          AggregateStatisticsInput &input, bool allow_cast) {
+	if (input.child_stats.empty()) {
+		return nullptr;
+	}
+	if (expr.StateExportMode() == AggregateStateExportMode::STATE_EXPORT) {
+		// the expression returns the internal aggregate state instead of a value
+		return nullptr;
+	}
+	auto &child_stats = input.child_stats[0];
+	auto &return_type = expr.GetReturnType();
+	unique_ptr<BaseStatistics> result;
+	if (child_stats.GetType() == return_type) {
+		result = child_stats.ToUnique();
+	} else if (allow_cast) {
+		result = StatisticsPropagator::TryPropagateCast(child_stats, child_stats.GetType(), return_type);
+	}
+	if (!result) {
+		return nullptr;
+	}
+	// the result is NULL when the aggregate sees no valid rows: an empty input for ungrouped
+	// aggregates, a FILTER clause that discards every row of a group, or a group in which every
+	// value of any argument is NULL (e.g. arg_min over an all-NULL "by" column)
+	if (input.input_may_be_empty || expr.GetFilter()) {
+		result->Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+	}
+	for (auto &stats : input.child_stats) {
+		if (stats.CanHaveNull()) {
+			result->Set(StatsInfo::CAN_HAVE_NULL_VALUES);
+			break;
+		}
+	}
+	return result;
+}
+
+unique_ptr<BaseStatistics> AggregateFunction::PropagateInputValueStats(ClientContext &context,
+                                                                       BoundAggregateExpression &expr,
+                                                                       AggregateStatisticsInput &input) {
+	return PropagateStatsFromInput(expr, input, false);
+}
+
+unique_ptr<BaseStatistics> AggregateFunction::PropagateInputRangeStats(ClientContext &context,
+                                                                       BoundAggregateExpression &expr,
+                                                                       AggregateStatisticsInput &input) {
+	return PropagateStatsFromInput(expr, input, true);
+}
 
 AggregateInputData::AggregateInputData(const BoundAggregateExpression &expr, ArenaAllocator &allocator_p,
                                        AggregateCombineType combine_type_p)

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -607,13 +607,9 @@ public:
 
 	unique_ptr<BoundAggregateExpression> Bind(ClientContext &context, vector<unique_ptr<Expression>> arguments) const;
 
-	//! Statistics callback for aggregates whose result is always one of the values of their first
-	//! argument (e.g. min, max, first): the output inherits the input column statistics
-	static unique_ptr<BaseStatistics> PropagateInputValueStats(ClientContext &context, BoundAggregateExpression &expr,
-	                                                           AggregateStatisticsInput &input);
 	//! Statistics callback for aggregates whose result always lies within the range of their first
-	//! argument (e.g. avg, median): as above, but casts the min/max bounds if the types differ
-	static unique_ptr<BaseStatistics> PropagateInputRangeStats(ClientContext &context, BoundAggregateExpression &expr,
+	//! argument (e.g. min, max, first, median): the output inherits the input column statistics
+	static unique_ptr<BaseStatistics> PropagateInputValueStats(ClientContext &context, BoundAggregateExpression &expr,
 	                                                           AggregateStatisticsInput &input);
 
 	AggregateFunction &SetStructStateExport(aggregate_get_state_type_t get_state_type_callback) {

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -607,6 +607,15 @@ public:
 
 	unique_ptr<BoundAggregateExpression> Bind(ClientContext &context, vector<unique_ptr<Expression>> arguments) const;
 
+	//! Statistics callback for aggregates whose result is always one of the values of their first
+	//! argument (e.g. min, max, first): the output inherits the input column statistics
+	static unique_ptr<BaseStatistics> PropagateInputValueStats(ClientContext &context, BoundAggregateExpression &expr,
+	                                                           AggregateStatisticsInput &input);
+	//! Statistics callback for aggregates whose result always lies within the range of their first
+	//! argument (e.g. avg, median): as above, but casts the min/max bounds if the types differ
+	static unique_ptr<BaseStatistics> PropagateInputRangeStats(ClientContext &context, BoundAggregateExpression &expr,
+	                                                           AggregateStatisticsInput &input);
+
 	AggregateFunction &SetStructStateExport(aggregate_get_state_type_t get_state_type_callback) {
 		callbacks.get_state_type = get_state_type_callback;
 		return *this;

--- a/src/include/duckdb/function/aggregate_state.hpp
+++ b/src/include/duckdb/function/aggregate_state.hpp
@@ -161,6 +161,9 @@ struct AggregateStatisticsInput {
 	optional_ptr<FunctionData> bind_data;
 	vector<BaseStatistics> &child_stats;
 	optional_ptr<NodeStatistics> node_stats;
+	//! Whether the aggregate can be evaluated over zero input rows (e.g. an ungrouped aggregate
+	//! over an empty table), in which case value-returning aggregates produce NULL
+	bool input_may_be_empty = true;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/aggregate_state.hpp
+++ b/src/include/duckdb/function/aggregate_state.hpp
@@ -161,8 +161,7 @@ struct AggregateStatisticsInput {
 	optional_ptr<FunctionData> bind_data;
 	vector<BaseStatistics> &child_stats;
 	optional_ptr<NodeStatistics> node_stats;
-	//! Whether the aggregate can be evaluated over zero input rows (e.g. an ungrouped aggregate
-	//! over an empty table), in which case value-returning aggregates produce NULL
+	//! Whether the aggregate can see zero input rows (e.g. ungrouped over an empty table)
 	bool input_may_be_empty = true;
 };
 

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -153,6 +153,9 @@ private:
 	unordered_map<TableIndex, CTEStatistics> cte_stats_map;
 	//! Node stats for the current node
 	unique_ptr<NodeStatistics> node_stats;
+	//! Whether the aggregate expressions currently being propagated can see zero input rows
+	//! (no GROUP BY, or a grouping set that aggregates over the entire, possibly empty, input)
+	bool aggregate_input_may_be_empty = true;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -154,7 +154,6 @@ private:
 	//! Node stats for the current node
 	unique_ptr<NodeStatistics> node_stats;
 	//! Whether the aggregate expressions currently being propagated can see zero input rows
-	//! (no GROUP BY, or a grouping set that aggregates over the entire, possibly empty, input)
 	bool aggregate_input_may_be_empty = true;
 };
 

--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -592,6 +592,14 @@ void CompressedMaterialization::CreateDecompressProjection(unique_ptr<LogicalOpe
 
 		if (statistics[col_idx]) {
 			statistics_map[new_binding] = statistics[col_idx]->ToUnique();
+		} else {
+			// not compressed: transfer the statistics of the old binding (if any) to the new binding,
+			// so that references rebound to the decompress projection keep their statistics
+			auto stats_it = statistics_map.find(old_binding);
+			if (stats_it != statistics_map.end() && stats_it->second) {
+				statistics_map[new_binding] = std::move(stats_it->second);
+				statistics_map.erase(stats_it);
+			}
 		}
 	}
 

--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -593,12 +593,12 @@ void CompressedMaterialization::CreateDecompressProjection(unique_ptr<LogicalOpe
 		if (statistics[col_idx]) {
 			statistics_map[new_binding] = statistics[col_idx]->ToUnique();
 		} else {
-			// not compressed: transfer the statistics of the old binding (if any) to the new binding,
-			// so that references rebound to the decompress projection keep their statistics
+			// not compressed: move the statistics of the old binding (if any) to the new binding
 			auto stats_it = statistics_map.find(old_binding);
 			if (stats_it != statistics_map.end() && stats_it->second) {
-				statistics_map[new_binding] = std::move(stats_it->second);
+				auto old_stats = std::move(stats_it->second);
 				statistics_map.erase(stats_it);
+				statistics_map[new_binding] = std::move(old_stats);
 			}
 		}
 	}

--- a/src/optimizer/statistics/expression/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/expression/propagate_aggregate.cpp
@@ -19,6 +19,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundAggreg
 		return nullptr;
 	}
 	AggregateStatisticsInput input(aggr.BindInfo(), stats, node_stats.get());
+	input.input_may_be_empty = aggregate_input_may_be_empty;
 	return aggr.Function().GetCallbacks().GetStatisticsCallback()(context, aggr, input);
 }
 

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -496,6 +496,16 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggr
 	count_matcher->policy = SetMatcher::Policy::ORDERED;
 	count_matcher->matchers.push_back(make_uniq<ExpressionMatcher>());
 
+	// with a GROUP BY, aggregates only run over non-empty groups; without one (or with an empty
+	// grouping set) they can aggregate zero rows, in which case they produce NULL
+	aggregate_input_may_be_empty = aggr.groups.empty();
+	for (auto &grouping_set : aggr.grouping_sets) {
+		if (grouping_set.empty()) {
+			aggregate_input_may_be_empty = true;
+			break;
+		}
+	}
+
 	// propagate statistics in the aggregates
 	for (idx_t aggregate_idx = 0; aggregate_idx < aggr.expressions.size(); aggregate_idx++) {
 		auto &expr = aggr.expressions[aggregate_idx];
@@ -517,6 +527,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggr
 		ColumnBinding aggregate_binding(aggr.aggregate_index, ProjectionIndex(aggregate_idx));
 		statistics_map[aggregate_binding] = std::move(stats);
 	}
+	aggregate_input_may_be_empty = true;
 
 	// check whether all inputs to the aggregate functions are valid
 	TupleDataValidityType distinct_validity = TupleDataValidityType::CANNOT_HAVE_NULL_VALUES;

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -496,8 +496,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggr
 	count_matcher->policy = SetMatcher::Policy::ORDERED;
 	count_matcher->matchers.push_back(make_uniq<ExpressionMatcher>());
 
-	// with a GROUP BY, aggregates only run over non-empty groups; without one (or with an empty
-	// grouping set) they can aggregate zero rows, in which case they produce NULL
+	// grouped aggregates only run over non-empty groups; ungrouped ones (or empty grouping sets) can see zero rows
 	aggregate_input_may_be_empty = aggr.groups.empty();
 	for (auto &grouping_set : aggr.grouping_sets) {
 		if (grouping_set.empty()) {

--- a/test/sql/optimizer/aggregate_stats_propagation.test
+++ b/test/sql/optimizer/aggregate_stats_propagation.test
@@ -21,13 +21,13 @@ CREATE TABLE t AS SELECT range::INTEGER AS x, (range % 16)::INTEGER AS g FROM ra
 query II
 EXPLAIN SELECT g, min(x) AS m FROM t GROUP BY g HAVING m > 20000;
 ----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
+physical_plan	<REGEX>:.*Empty Result.*
 
 # an always-true HAVING is removed instead
 query II
 EXPLAIN SELECT g, min(x) AS m FROM t GROUP BY g HAVING m >= 0;
 ----
-physical_plan	<!REGEX>:.*FILTER.*
+physical_plan	<!REGEX>:.*Filter.*
 
 query I
 SELECT count(*) FROM (SELECT g, min(x) AS m FROM t GROUP BY g HAVING m > 20000) sub;
@@ -42,7 +42,7 @@ SELECT count(*) FROM (SELECT g, min(x) AS m FROM t GROUP BY g HAVING m >= 0) sub
 query II
 EXPLAIN SELECT g, max(x) AS m FROM t GROUP BY g HAVING m < 0;
 ----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
+physical_plan	<REGEX>:.*Empty Result.*
 
 query I
 SELECT count(*) FROM (SELECT g, max(x) AS m FROM t GROUP BY g HAVING m < 0) sub;
@@ -52,66 +52,52 @@ SELECT count(*) FROM (SELECT g, max(x) AS m FROM t GROUP BY g HAVING m < 0) sub;
 query II
 EXPLAIN SELECT g, first(x) AS m FROM t GROUP BY g HAVING m > 20000;
 ----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
+physical_plan	<REGEX>:.*Empty Result.*
 
 query II
 EXPLAIN SELECT g, last(x) AS m FROM t GROUP BY g HAVING m < 0;
 ----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
+physical_plan	<REGEX>:.*Empty Result.*
 
 query II
 EXPLAIN SELECT g, any_value(x) AS m FROM t GROUP BY g HAVING m > 20000;
 ----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
+physical_plan	<REGEX>:.*Empty Result.*
 
 query II
 EXPLAIN SELECT g, arg_min(x, g) AS m FROM t GROUP BY g HAVING m > 20000;
 ----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
+physical_plan	<REGEX>:.*Empty Result.*
 
 query II
 EXPLAIN SELECT g, arg_max(x, g) AS m FROM t GROUP BY g HAVING m < 0;
 ----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
+physical_plan	<REGEX>:.*Empty Result.*
 
 query II
 EXPLAIN SELECT g, mode(x) AS m FROM t GROUP BY g HAVING m > 20000;
 ----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
+physical_plan	<REGEX>:.*Empty Result.*
 
 # ---------------------------------------------------------------------------
-# result lies within the input's range: avg / median / quantile_cont / quantile_disc
+# result lies within the input's range: median / quantile_cont / quantile_disc
+# (avg is not tested here: it is decomposed into sum/count before statistics propagation runs)
 # ---------------------------------------------------------------------------
-
-query II
-EXPLAIN SELECT g, avg(x) AS a FROM t GROUP BY g HAVING a > 10239.5;
-----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
-
-query II
-EXPLAIN SELECT g, avg(x) AS a FROM t GROUP BY g HAVING a < 0;
-----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
-
-query I
-SELECT count(*) FROM (SELECT g, avg(x) AS a FROM t GROUP BY g HAVING a > 10239.5) sub;
-----
-0
 
 query II
 EXPLAIN SELECT g, median(x) AS m FROM t GROUP BY g HAVING m > 20000;
 ----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
+physical_plan	<REGEX>:.*Empty Result.*
 
 query II
 EXPLAIN SELECT g, quantile_cont(x, 0.75) AS q FROM t GROUP BY g HAVING q > 20000;
 ----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
+physical_plan	<REGEX>:.*Empty Result.*
 
 query II
 EXPLAIN SELECT g, quantile_disc(x, 0.75) AS q FROM t GROUP BY g HAVING q < 0;
 ----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
+physical_plan	<REGEX>:.*Empty Result.*
 
 # ---------------------------------------------------------------------------
 # the fold also applies to a filter above a subquery, not just HAVING
@@ -120,7 +106,7 @@ physical_plan	<REGEX>:.*EMPTY_RESULT.*
 query II
 EXPLAIN SELECT * FROM (SELECT g, min(x) AS m FROM t GROUP BY g) sub WHERE m > 20000;
 ----
-physical_plan	<REGEX>:.*EMPTY_RESULT.*
+physical_plan	<REGEX>:.*Empty Result.*
 
 # ---------------------------------------------------------------------------
 # correctness guard with NULLs: min/max skip NULLs, bounds still hold, and the

--- a/test/sql/optimizer/aggregate_stats_propagation.test
+++ b/test/sql/optimizer/aggregate_stats_propagation.test
@@ -1,0 +1,154 @@
+# name: test/sql/optimizer/aggregate_stats_propagation.test
+# description: Aggregates whose result is bounded by their input's range propagate output statistics
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/aggregate_stats_prune.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 10240 rows -> 5 row groups of 2048 rows; x in [0, 10239], 16 groups
+statement ok
+CREATE TABLE t AS SELECT range::INTEGER AS x, (range % 16)::INTEGER AS g FROM range(10240);
+
+# ---------------------------------------------------------------------------
+# result is one of the input values: min / max / first / last / any_value /
+# arg_min / arg_max / mode -> output stats inherit the input column's min/max
+# ---------------------------------------------------------------------------
+
+# min(x) is bounded by [0, 10239]: a HAVING outside that range folds to an empty result
+query II
+EXPLAIN SELECT g, min(x) AS m FROM t GROUP BY g HAVING m > 20000;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+# an always-true HAVING is removed instead
+query II
+EXPLAIN SELECT g, min(x) AS m FROM t GROUP BY g HAVING m >= 0;
+----
+physical_plan	<!REGEX>:.*FILTER.*
+
+query I
+SELECT count(*) FROM (SELECT g, min(x) AS m FROM t GROUP BY g HAVING m > 20000) sub;
+----
+0
+
+query I
+SELECT count(*) FROM (SELECT g, min(x) AS m FROM t GROUP BY g HAVING m >= 0) sub;
+----
+16
+
+query II
+EXPLAIN SELECT g, max(x) AS m FROM t GROUP BY g HAVING m < 0;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query I
+SELECT count(*) FROM (SELECT g, max(x) AS m FROM t GROUP BY g HAVING m < 0) sub;
+----
+0
+
+query II
+EXPLAIN SELECT g, first(x) AS m FROM t GROUP BY g HAVING m > 20000;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT g, last(x) AS m FROM t GROUP BY g HAVING m < 0;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT g, any_value(x) AS m FROM t GROUP BY g HAVING m > 20000;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT g, arg_min(x, g) AS m FROM t GROUP BY g HAVING m > 20000;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT g, arg_max(x, g) AS m FROM t GROUP BY g HAVING m < 0;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT g, mode(x) AS m FROM t GROUP BY g HAVING m > 20000;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+# ---------------------------------------------------------------------------
+# result lies within the input's range: avg / median / quantile_cont / quantile_disc
+# ---------------------------------------------------------------------------
+
+query II
+EXPLAIN SELECT g, avg(x) AS a FROM t GROUP BY g HAVING a > 10239.5;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT g, avg(x) AS a FROM t GROUP BY g HAVING a < 0;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query I
+SELECT count(*) FROM (SELECT g, avg(x) AS a FROM t GROUP BY g HAVING a > 10239.5) sub;
+----
+0
+
+query II
+EXPLAIN SELECT g, median(x) AS m FROM t GROUP BY g HAVING m > 20000;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT g, quantile_cont(x, 0.75) AS q FROM t GROUP BY g HAVING q > 20000;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT g, quantile_disc(x, 0.75) AS q FROM t GROUP BY g HAVING q < 0;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+# ---------------------------------------------------------------------------
+# the fold also applies to a filter above a subquery, not just HAVING
+# ---------------------------------------------------------------------------
+
+query II
+EXPLAIN SELECT * FROM (SELECT g, min(x) AS m FROM t GROUP BY g) sub WHERE m > 20000;
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+# ---------------------------------------------------------------------------
+# correctness guard with NULLs: min/max skip NULLs, bounds still hold, and the
+# fold must never drop non-empty results
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE tn AS
+SELECT CASE WHEN range % 7 = 0 THEN NULL ELSE range END::INTEGER AS x, (range % 16)::INTEGER AS g
+FROM range(10240);
+
+query I
+SELECT count(*) FROM (SELECT g, min(x) AS m FROM tn GROUP BY g HAVING m > 20000) sub;
+----
+0
+
+query I
+SELECT count(*) FROM (SELECT g, min(x) AS m FROM tn GROUP BY g HAVING m <= 20000) sub;
+----
+16
+
+# every value of one group is NULL: the aggregate result is NULL and must survive
+statement ok
+CREATE TABLE tg AS
+SELECT CASE WHEN range % 16 = 3 THEN NULL ELSE range END::INTEGER AS x, (range % 16)::INTEGER AS g
+FROM range(10240);
+
+query I
+SELECT count(*) FROM (SELECT g, min(x) AS m FROM tg GROUP BY g HAVING m IS NULL) sub;
+----
+1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes optimizer statistics and plan folding for many aggregates; incorrect bounds or nullability could prune valid results, though new tests cover key NULL and grouping cases.
> 
> **Overview**
> Adds **statistics propagation** for aggregates whose results stay within the range of their primary input (min, max, first, last, mode, arg_min/arg_max, median, quantile_cont/disc). A shared **`PropagateInputValueStats`** callback copies (or cast-propagates) the first argument’s column stats to the aggregate output, marks nullability when inputs can be empty, filtered, or nullable, and skips state-export aggregates.
> 
> The propagator now tracks **`input_may_be_empty`** for grouped vs ungrouped (and empty grouping-set) aggregates so grouped `min(x)` is not incorrectly treated as nullable-only from emptiness. **Compressed materialization** preserves statistics on decompress when a column was not compressed, by moving stats from the old column binding to the new one.
> 
> New optimizer tests confirm impossible **HAVING** and **WHERE** predicates on these aggregates fold to **Empty Result**, while valid predicates and NULL-heavy groups still return correct row counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dae95b1db889d187f2aade5ed2fd2efb4f607d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->