### PR TITLE
Hjiang/cross column stats

### DIFF
--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1170,6 +1170,145 @@ void BinaryScalarFunctionIgnoreZero(DataChunk &input, ExpressionState &state, Ve
 	BinaryExecutor::Execute<TA, TB, TC, OP, ZWRAPPER>(input.data[0], input.data[1], result);
 }
 
+struct IntegerDivideTryOperator {
+	template <class T>
+	static bool Operation(T left, T right, T &result) {
+		T zero = 0;
+		if (right == zero) {
+			return false;
+		}
+		if (NumericLimits<T>::IsSigned() && left == NumericLimits<T>::Minimum()) {
+			T minus_one = static_cast<T>(zero - static_cast<T>(1));
+			if (right == minus_one) {
+				// MIN / -1 overflows
+				return false;
+			}
+		}
+		result = DivideOperator::Operation<T, T, T>(left, right);
+		return true;
+	}
+};
+
+struct DividePropagateStatistics {
+	template <class T, class OP>
+	static bool Operation(const LogicalType &type, BaseStatistics &lstats, BaseStatistics &rstats, Value &new_min,
+	                      Value &new_max) {
+		T zero = 0;
+		T rmin = NumericStats::GetMin<T>(rstats);
+		T rmax = NumericStats::GetMax<T>(rstats);
+		// a divisor range that contains zero produces NULL (or +/- infinity for IEEE floats): no bounds
+		if (rmin <= zero && rmax >= zero) {
+			return true;
+		}
+		// for a divisor range that excludes zero, division is monotone in both arguments:
+		// the extremes are at the corners of the input ranges
+		T lvals[] {NumericStats::GetMin<T>(lstats), NumericStats::GetMax<T>(lstats)};
+		T rvals[] {rmin, rmax};
+		T min = NumericLimits<T>::Maximum();
+		T max = NumericLimits<T>::Minimum();
+		for (idx_t l = 0; l < 2; l++) {
+			for (idx_t r = 0; r < 2; r++) {
+				T result;
+				if (!OP::Operation(lvals[l], rvals[r], result)) {
+					return true;
+				}
+				if (result < min) {
+					min = result;
+				}
+				if (result > max) {
+					max = result;
+				}
+			}
+		}
+		new_min = NumericStatsValue(type, min);
+		new_max = NumericStatsValue(type, max);
+		return false;
+	}
+};
+
+struct ModuloPropagateStatistics {
+	template <class T, class OP>
+	static bool Operation(const LogicalType &type, BaseStatistics &lstats, BaseStatistics &rstats, Value &new_min,
+	                      Value &new_max) {
+		T zero = 0;
+		T rmin = NumericStats::GetMin<T>(rstats);
+		T rmax = NumericStats::GetMax<T>(rstats);
+		// only strictly positive divisors: zero divisors produce NULL, and negative divisor
+		// bounds would require an overflow-prone abs()
+		if (rmin <= zero) {
+			return true;
+		}
+		// |l % r| < rmax and the result has the sign of l (truncated division semantics)
+		T bound = static_cast<T>(rmax - static_cast<T>(1));
+		T lmin = NumericStats::GetMin<T>(lstats);
+		T lmax = NumericStats::GetMax<T>(lstats);
+		T min = zero;
+		T max = zero;
+		if (lmin < zero) {
+			min = static_cast<T>(zero - bound);
+			if (lmin > min) {
+				min = lmin;
+			}
+		}
+		if (lmax > zero) {
+			max = bound;
+			if (lmax < max) {
+				max = lmax;
+			}
+		}
+		new_min = NumericStatsValue(type, min);
+		new_max = NumericStatsValue(type, max);
+		return false;
+	}
+};
+
+template <class PROPAGATE>
+unique_ptr<BaseStatistics> PropagateIntegerDivModStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	D_ASSERT(child_stats.size() == 2);
+	auto &lstats = child_stats[0];
+	auto &rstats = child_stats[1];
+	if (!NumericStats::HasMinMax(lstats) || !NumericStats::HasMinMax(rstats)) {
+		return nullptr;
+	}
+	auto &return_type = expr.GetReturnType();
+	Value new_min, new_max;
+	bool failed;
+	switch (return_type.InternalType()) {
+	case PhysicalType::INT8:
+		failed = PROPAGATE::template Operation<int8_t, IntegerDivideTryOperator>(return_type, lstats, rstats, new_min,
+		                                                                         new_max);
+		break;
+	case PhysicalType::INT16:
+		failed = PROPAGATE::template Operation<int16_t, IntegerDivideTryOperator>(return_type, lstats, rstats, new_min,
+		                                                                          new_max);
+		break;
+	case PhysicalType::INT32:
+		failed = PROPAGATE::template Operation<int32_t, IntegerDivideTryOperator>(return_type, lstats, rstats, new_min,
+		                                                                          new_max);
+		break;
+	case PhysicalType::INT64:
+		failed = PROPAGATE::template Operation<int64_t, IntegerDivideTryOperator>(return_type, lstats, rstats, new_min,
+		                                                                          new_max);
+		break;
+	case PhysicalType::INT128:
+		failed = PROPAGATE::template Operation<hugeint_t, IntegerDivideTryOperator>(return_type, lstats, rstats,
+		                                                                            new_min, new_max);
+		break;
+	default:
+		return nullptr;
+	}
+	if (failed) {
+		return nullptr;
+	}
+	auto result = NumericStats::CreateEmpty(return_type);
+	NumericStats::SetMin(result, new_min);
+	NumericStats::SetMax(result, new_max);
+	result.CombineValidity(lstats, rstats);
+	return result.ToUnique();
+}
+
 template <class OP>
 scalar_function_t GetBinaryFunctionIgnoreZero(PhysicalType type) {
 	switch (type) {
@@ -1220,9 +1359,11 @@ unique_ptr<FunctionData> BindBinaryFloatingPoint(BindScalarFunctionInput &input)
 ScalarFunctionSet OperatorFloatDivideFun::GetFunctions() {
 	ScalarFunctionSet fp_divide("/");
 	fp_divide.AddFunction(ScalarFunction({LogicalType::FLOAT, LogicalType::FLOAT}, LogicalType::FLOAT, nullptr,
-	                                     BindBinaryFloatingPoint<DivideOperator>));
+	                                     BindBinaryFloatingPoint<DivideOperator>,
+	                                     PropagateFloatingStats<DividePropagateStatistics, DivideOperator>));
 	fp_divide.AddFunction(ScalarFunction({LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr,
-	                                     BindBinaryFloatingPoint<DivideOperator>));
+	                                     BindBinaryFloatingPoint<DivideOperator>,
+	                                     PropagateFloatingStats<DividePropagateStatistics, DivideOperator>));
 	fp_divide.AddFunction(
 	    ScalarFunction({LogicalType::INTERVAL, LogicalType::DOUBLE}, LogicalType::INTERVAL,
 	                   BinaryScalarFunctionIgnoreZero<interval_t, double, interval_t, DivideOperator>));
@@ -1237,6 +1378,10 @@ ScalarFunctionSet OperatorIntegerDivideFun::GetFunctions() {
 	for (auto &type : LogicalType::Numeric()) {
 		if (type.id() == LogicalTypeId::DECIMAL) {
 			continue;
+		} else if (TypeIsIntegral(type.InternalType())) {
+			full_divide.AddFunction(
+			    ScalarFunction({type, type}, type, GetBinaryFunctionIgnoreZero<DivideOperator>(type.InternalType()),
+			                   nullptr, PropagateIntegerDivModStats<DividePropagateStatistics>));
 		} else {
 			full_divide.AddFunction(
 			    ScalarFunction({type, type}, type, GetBinaryFunctionIgnoreZero<DivideOperator>(type.InternalType())));
@@ -1297,7 +1442,8 @@ ScalarFunctionSet OperatorModuloFun::GetFunctions() {
 			modulo.AddFunction(ScalarFunction({type, type}, type, nullptr, BindDecimalModulo<ModuloOperator>));
 		} else {
 			modulo.AddFunction(
-			    ScalarFunction({type, type}, type, GetBinaryFunctionIgnoreZero<ModuloOperator>(type.InternalType())));
+			    ScalarFunction({type, type}, type, GetBinaryFunctionIgnoreZero<ModuloOperator>(type.InternalType()),
+			                   nullptr, PropagateIntegerDivModStats<ModuloPropagateStatistics>));
 		}
 	}
 	for (auto &func : modulo.functions) {

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_between_expression.hpp"
+#include "duckdb/planner/expression/bound_case_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
@@ -392,6 +393,66 @@ void ReplaceWithBoundReference(unique_ptr<Expression> &root_expr) {
 	    });
 }
 
+//! Returns true if the zonemap check can potentially derive statistics for this value expression
+static bool CanDeriveExpressionStats(const Expression &expr) {
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::BOUND_COLUMN_REF:
+	case ExpressionClass::BOUND_CONSTANT:
+		return true;
+	case ExpressionClass::BOUND_CASE: {
+		auto &case_expr = expr.Cast<BoundCaseExpression>();
+		for (auto &case_check : case_expr.CaseChecks()) {
+			if (!CanDeriveExpressionStats(*case_check.then_expr)) {
+				return false;
+			}
+		}
+		return CanDeriveExpressionStats(case_expr.Else());
+	}
+	case ExpressionClass::BOUND_FUNCTION: {
+		auto &func = expr.Cast<BoundFunctionExpression>();
+		if (!BoundCastExpression::IsCast(func) && !func.Function().HasStatisticsCallback() &&
+		    !func.Function().HasArgProperties()) {
+			return false;
+		}
+		for (auto &child : func.GetChildren()) {
+			if (!CanDeriveExpressionStats(*child)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	default:
+		return false;
+	}
+}
+
+//! Returns true if the multi-column zonemap check can potentially prune with this filter expression
+static bool CanCheckExpressionStats(const Expression &expr) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
+		auto &conj = expr.Cast<BoundConjunctionExpression>();
+		for (auto &child : conj.GetChildren()) {
+			if (!CanCheckExpressionStats(*child)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	if (expr.GetExpressionType() == ExpressionType::COMPARE_BETWEEN &&
+	    expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		auto &between = expr.Cast<BoundFunctionExpression>();
+		return CanDeriveExpressionStats(BoundBetweenExpression::Input(between)) &&
+		       CanDeriveExpressionStats(BoundBetweenExpression::LowerBound(between)) &&
+		       CanDeriveExpressionStats(BoundBetweenExpression::UpperBound(between));
+	}
+	if (BoundComparisonExpression::IsComparison(expr.GetExpressionType()) &&
+	    expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		auto &comparison = expr.Cast<BoundFunctionExpression>();
+		return CanDeriveExpressionStats(BoundComparisonExpression::Left(comparison)) &&
+		       CanDeriveExpressionStats(BoundComparisonExpression::Right(comparison));
+	}
+	return false;
+}
+
 FilterPushdownResult FilterCombiner::TryPushdownGenericExpression(LogicalGet &get, Expression &expr) {
 	if (!get.function.pushdown_expression) {
 		// the scan does not support pushing down generic expressions
@@ -404,46 +465,46 @@ FilterPushdownResult FilterCombiner::TryPushdownGenericExpression(LogicalGet &ge
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	auto table = get.GetTable();
-	if (bindings.size() == 2 && bindings[0] != bindings[1] && table && table->IsDuckTable() &&
-	    BoundComparisonExpression::IsComparison(expr)) {
-		const auto &comparison = expr.Cast<BoundFunctionExpression>();
-		const auto &left = BoundComparisonExpression::Left(comparison);
-		const auto &right = BoundComparisonExpression::Right(comparison);
-		const auto comparison_type = comparison.GetExpressionType();
-		const bool supported_comparison = comparison_type == ExpressionType::COMPARE_EQUAL ||
-		                                  comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
-		                                  comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO ||
-		                                  comparison_type == ExpressionType::COMPARE_LESSTHAN ||
-		                                  comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
-		if (!supported_comparison || left.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF ||
-		    right.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF || !left.GetReturnType().IsNumeric() ||
-		    !right.GetReturnType().IsNumeric()) {
+	// collect the distinct column bindings referenced by the expression
+	vector<ColumnBinding> distinct_bindings;
+	for (auto &binding : bindings) {
+		if (std::find(distinct_bindings.begin(), distinct_bindings.end(), binding) == distinct_bindings.end()) {
+			distinct_bindings.push_back(binding);
+		}
+	}
+	if (distinct_bindings.size() >= 2) {
+		// expressions over multiple columns are pushed down for zonemap checking only:
+		// the filter itself is still executed by the LogicalFilter on top
+		if (!table || !table->IsDuckTable()) {
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}
-		const auto &left_ref = left.Cast<BoundColumnRefExpression>();
-		const auto &right_ref = right.Cast<BoundColumnRefExpression>();
-		if (left_ref.Binding().table_index != get.table_index || right_ref.Binding().table_index != get.table_index ||
-		    left_ref.Binding().column_index >= get.GetColumnIds().size() ||
-		    right_ref.Binding().column_index >= get.GetColumnIds().size() ||
-		    get.GetColumnIds()[left_ref.Binding().column_index].IsVirtualColumn() ||
-		    get.GetColumnIds()[right_ref.Binding().column_index].IsVirtualColumn()) {
+		for (auto &binding : distinct_bindings) {
+			if (binding.table_index != get.table_index || binding.column_index >= get.GetColumnIds().size() ||
+			    get.GetColumnIds()[binding.column_index].IsVirtualColumn()) {
+				return FilterPushdownResult::NO_PUSHDOWN;
+			}
+		}
+		// only push expressions whose statistics can be derived - anything else can never prune
+		if (!CanCheckExpressionStats(expr)) {
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}
-
-		auto left_bound_ref = make_uniq<BoundReferenceExpression>(left_ref.GetAlias(), left_ref.GetReturnType(), 0);
-		auto right_bound_ref = make_uniq<BoundReferenceExpression>(right_ref.GetAlias(), right_ref.GetReturnType(), 1);
-		auto filter_expr =
-		    BoundComparisonExpression::Create(comparison_type, std::move(left_bound_ref), std::move(right_bound_ref));
-		vector<ProjectionIndex> column_indexes {left_ref.Binding().column_index, right_ref.Binding().column_index};
+		auto filter_expr = expr.Copy();
+		ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
+		    filter_expr, [&](BoundColumnRefExpression &col_ref, unique_ptr<Expression> &owned_expr) {
+			    auto entry = std::find(distinct_bindings.begin(), distinct_bindings.end(), col_ref.Binding());
+			    D_ASSERT(entry != distinct_bindings.end());
+			    auto ref_idx = NumericCast<idx_t>(entry - distinct_bindings.begin());
+			    owned_expr =
+			        make_uniq<BoundReferenceExpression>(col_ref.GetAlias(), col_ref.GetReturnType(), ref_idx);
+		    });
+		vector<ProjectionIndex> column_indexes;
+		column_indexes.reserve(distinct_bindings.size());
+		for (auto &binding : distinct_bindings) {
+			column_indexes.emplace_back(binding.column_index);
+		}
 		get.table_filters.PushMultiColumnFilter(
 		    make_uniq<ExpressionFilter>(std::move(filter_expr), std::move(column_indexes)));
 		return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
-	}
-	// we can only pushdown expressions that refer to exactly one column
-	for (idx_t i = 1; i < bindings.size(); i++) {
-		if (bindings[i] != bindings[0]) {
-			return FilterPushdownResult::NO_PUSHDOWN;
-		}
 	}
 	if (!get.function.pushdown_expression(context, get, expr)) {
 		// the scan does not support pushing down THIS expression

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/expression/bound_between_expression.hpp"
+#include "duckdb/planner/expression/bound_case_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
@@ -205,6 +206,11 @@ static FilterPropagateResult CheckZonemapAgainstConstants(const BaseStatistics &
 	}
 }
 
+static optional_ptr<const BaseStatistics> TryGetCaseExpressionStats(optional_ptr<ClientContext> context_p,
+                                                                    const BoundCaseExpression &case_expr,
+                                                                    array_ptr<const BaseStatistics> input_stats,
+                                                                    vector<unique_ptr<BaseStatistics>> &owned_stats);
+
 static optional_ptr<const BaseStatistics> TryGetExpressionStats(optional_ptr<ClientContext> context_p,
                                                                 const Expression &expr,
                                                                 array_ptr<const BaseStatistics> input_stats,
@@ -296,9 +302,59 @@ static optional_ptr<const BaseStatistics> TryGetExpressionStats(optional_ptr<Cli
 
 		return nullptr;
 	}
+	case ExpressionClass::BOUND_CASE:
+		return TryGetCaseExpressionStats(context_p, expr.Cast<BoundCaseExpression>(), input_stats, owned_stats);
 	default:
 		return nullptr;
 	}
+}
+
+//! The result of a CASE is one of the THEN branches or the ELSE branch: merge the statistics of every
+//! branch that can be taken. Branches whose condition never holds are skipped, and branches after a
+//! condition that always holds (including the ELSE) are unreachable.
+static optional_ptr<const BaseStatistics> TryGetCaseExpressionStats(optional_ptr<ClientContext> context_p,
+                                                                    const BoundCaseExpression &case_expr,
+                                                                    array_ptr<const BaseStatistics> input_stats,
+                                                                    vector<unique_ptr<BaseStatistics>> &owned_stats) {
+	unique_ptr<BaseStatistics> merged;
+	bool else_reachable = true;
+	for (auto &case_check : case_expr.CaseChecks()) {
+		auto cond_result = ExpressionFilter::CheckExpressionStatistics(context_p, *case_check.when_expr, input_stats);
+		if (cond_result == FilterPropagateResult::FILTER_ALWAYS_FALSE ||
+		    cond_result == FilterPropagateResult::FILTER_FALSE_OR_NULL) {
+			// this branch is never taken
+			continue;
+		}
+		auto then_stats = TryGetExpressionStats(context_p, *case_check.then_expr, input_stats, owned_stats);
+		if (!then_stats) {
+			return nullptr;
+		}
+		if (merged) {
+			merged->Merge(*then_stats);
+		} else {
+			merged = then_stats->ToUnique();
+		}
+		if (cond_result == FilterPropagateResult::FILTER_ALWAYS_TRUE) {
+			else_reachable = false;
+			break;
+		}
+	}
+	if (else_reachable) {
+		auto else_stats = TryGetExpressionStats(context_p, case_expr.Else(), input_stats, owned_stats);
+		if (!else_stats) {
+			return nullptr;
+		}
+		if (merged) {
+			merged->Merge(*else_stats);
+		} else {
+			merged = else_stats->ToUnique();
+		}
+	}
+	if (!merged) {
+		return nullptr;
+	}
+	owned_stats.push_back(std::move(merged));
+	return owned_stats.back().get();
 }
 
 static optional_ptr<const BaseStatistics> TryGetFilterStats(optional_ptr<ClientContext> context_p,
@@ -618,6 +674,50 @@ static FilterPropagateResult CheckOperatorStatistics(optional_ptr<ClientContext>
 	}
 }
 
+//! A boolean CASE used as a filter: combine the prune results of every branch that can be taken.
+static FilterPropagateResult CheckCaseStatistics(optional_ptr<ClientContext> context_p,
+                                                 const BoundCaseExpression &case_expr,
+                                                 array_ptr<const BaseStatistics> input_stats) {
+	bool all_true = true;
+	bool all_false = true;
+	bool has_false_or_null = false;
+	auto add_branch_result = [&](FilterPropagateResult branch_result) {
+		if (branch_result != FilterPropagateResult::FILTER_ALWAYS_TRUE) {
+			all_true = false;
+		}
+		if (branch_result == FilterPropagateResult::FILTER_FALSE_OR_NULL) {
+			has_false_or_null = true;
+		} else if (branch_result != FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+			all_false = false;
+		}
+	};
+	bool else_reachable = true;
+	for (auto &case_check : case_expr.CaseChecks()) {
+		auto cond_result = ExpressionFilter::CheckExpressionStatistics(context_p, *case_check.when_expr, input_stats);
+		if (cond_result == FilterPropagateResult::FILTER_ALWAYS_FALSE ||
+		    cond_result == FilterPropagateResult::FILTER_FALSE_OR_NULL) {
+			// this branch is never taken
+			continue;
+		}
+		add_branch_result(ExpressionFilter::CheckExpressionStatistics(context_p, *case_check.then_expr, input_stats));
+		if (cond_result == FilterPropagateResult::FILTER_ALWAYS_TRUE) {
+			else_reachable = false;
+			break;
+		}
+	}
+	if (else_reachable) {
+		add_branch_result(ExpressionFilter::CheckExpressionStatistics(context_p, case_expr.Else(), input_stats));
+	}
+	if (all_false) {
+		return has_false_or_null ? FilterPropagateResult::FILTER_FALSE_OR_NULL
+		                         : FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (all_true) {
+		return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+	}
+	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+}
+
 static FilterPropagateResult CheckConjunctionStatistics(optional_ptr<ClientContext> context_p,
                                                         const BoundConjunctionExpression &conj,
                                                         array_ptr<const BaseStatistics> input_stats) {
@@ -679,6 +779,19 @@ FilterPropagateResult ExpressionFilter::CheckExpressionStatistics(optional_ptr<C
 		return CheckOperatorStatistics(context_p, expr.Cast<BoundOperatorExpression>(), input_stats);
 	case ExpressionClass::BOUND_CONJUNCTION:
 		return CheckConjunctionStatistics(context_p, expr.Cast<BoundConjunctionExpression>(), input_stats);
+	case ExpressionClass::BOUND_CASE:
+		return CheckCaseStatistics(context_p, expr.Cast<BoundCaseExpression>(), input_stats);
+	case ExpressionClass::BOUND_CONSTANT: {
+		auto &value = expr.Cast<BoundConstantExpression>().GetValue();
+		if (value.IsNull()) {
+			return FilterPropagateResult::FILTER_FALSE_OR_NULL;
+		}
+		if (value.type().id() != LogicalTypeId::BOOLEAN) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+		return BooleanValue::Get(value) ? FilterPropagateResult::FILTER_ALWAYS_TRUE
+		                                : FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
 	default:
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}

--- a/test/sql/optimizer/case_expression_zonemap_pruning.test
+++ b/test/sql/optimizer/case_expression_zonemap_pruning.test
@@ -1,0 +1,93 @@
+# name: test/sql/optimizer/case_expression_zonemap_pruning.test
+# description: CASE expressions (and if/nullif, which fold to CASE) prune row groups
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/case_expr_zonemap.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 5 row groups: [0,2047], [2048,4095], [4096,6143], [6144,8191], [8192,10239]
+statement ok
+CREATE TABLE t AS SELECT
+	range::INTEGER AS x,
+	(range % 16)::INTEGER AS y,
+	CASE WHEN range % 2 = 0 THEN NULL ELSE range END::INTEGER AS xn
+FROM range(10240);
+
+# boolean CASE: prune row groups where the WHEN condition is always false
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE CASE WHEN x > 9000 THEN true ELSE false END;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE CASE WHEN x > 9000 THEN true ELSE false END;
+----
+1239
+
+# if() folds to CASE
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE if(x > 9000, true, false);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE if(x > 9000, true, false);
+----
+1239
+
+# nullif(x, c) folds to CASE and preserves the range of x
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE nullif(x, -1) > 9000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE nullif(x, -1) > 9000;
+----
+1239
+
+# value CASE compared against a constant: result range is the union of the branch ranges
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE (CASE WHEN x > 9000 THEN 1 ELSE 0 END) = 1;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE (CASE WHEN x > 9000 THEN 1 ELSE 0 END) = 1;
+----
+1239
+
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE (CASE WHEN y = 3 THEN x ELSE 0 END) > 9000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE (CASE WHEN y = 3 THEN x ELSE 0 END) > 9000;
+----
+77
+
+# multiple WHEN branches: first and last row group can match
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE CASE WHEN x < 100 THEN true WHEN x > 9000 THEN true ELSE false END;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE CASE WHEN x < 100 THEN true WHEN x > 9000 THEN true ELSE false END;
+----
+1339
+
+# NULL condition evaluates the ELSE branch: pruning must remain correct on nullable columns
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE CASE WHEN xn > 9000 THEN true ELSE false END;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE CASE WHEN xn > 9000 THEN true ELSE false END;
+----
+620

--- a/test/sql/optimizer/division_modulo_zonemap_pruning.test
+++ b/test/sql/optimizer/division_modulo_zonemap_pruning.test
@@ -1,0 +1,111 @@
+# name: test/sql/optimizer/division_modulo_zonemap_pruning.test
+# description: division and modulo derive statistics for row group pruning
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/division_modulo_zonemap.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 5 row groups: [0,2047], [2048,4095], [4096,6143], [6144,8191], [8192,10239]
+statement ok
+CREATE TABLE t AS SELECT range::INTEGER AS x FROM range(10240);
+
+# n covers [-5000, 5239]
+statement ok
+CREATE TABLE neg AS SELECT (range - 5000)::INTEGER AS n FROM range(10240);
+
+# integer division by a positive constant is monotone
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE x // 2 > 4500;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE x // 2 > 4500;
+----
+1238
+
+# float division by a positive constant is monotone (x is cast to DOUBLE)
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE x / 2.0 > 4500.0;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE x / 2.0 > 4500.0;
+----
+1239
+
+# division by a negative constant flips the bounds
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE x / -2.0 < -4500.0;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE x / -2.0 < -4500.0;
+----
+1239
+
+# integer division with negative values in the column
+query II
+EXPLAIN ANALYZE SELECT sum(n) FROM neg WHERE n // 4 > 1000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM neg WHERE n // 4 > 1000;
+----
+1236
+
+# x % 2048 is bounded by [0, 2047]: the filter can never be true
+query II
+EXPLAIN SELECT count(*) FROM t WHERE x % 2048 > 9000;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM t WHERE x % 2048 > 9000;
+----
+0
+
+# modulo of negative values yields negative remainders: n % 100 is in (-100, 100)
+query II
+EXPLAIN SELECT count(*) FROM neg WHERE n % 100 > 99;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM neg WHERE n % 100 > 99;
+----
+0
+
+query I
+SELECT count(*) FROM neg WHERE n % 100 >= -99;
+----
+10240
+
+# modulo equality is not prunable in general - correctness only
+query I
+SELECT count(*) FROM t WHERE x % 16 = 3;
+----
+640
+
+# division by zero guards: integer // and % yield NULL, float / yields inf (and nan for 0/0,
+# which DuckDB orders greater than everything) - derived statistics must not prune these
+query I
+SELECT count(*) FROM t WHERE x // 0 > 1;
+----
+0
+
+query I
+SELECT count(*) FROM t WHERE x % 0 = 0;
+----
+0
+
+query I
+SELECT count(*) FROM t WHERE x / 0 > 1;
+----
+10240

--- a/test/sql/optimizer/multi_column_expression_zonemap_pruning.test
+++ b/test/sql/optimizer/multi_column_expression_zonemap_pruning.test
@@ -1,0 +1,70 @@
+# name: test/sql/optimizer/multi_column_expression_zonemap_pruning.test
+# description: expressions over multiple columns prune row groups via zonemaps
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/multi_column_expr_zonemap.duckdb' AS db (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE db;
+
+# 5 row groups: [0,2047], [2048,4095], [4096,6143], [6144,8191], [8192,10239]
+statement ok
+CREATE TABLE t AS SELECT
+	range::INTEGER AS x,
+	(range % 16)::INTEGER AS y,
+	(10239 - range)::INTEGER AS z
+FROM range(10240);
+
+# y is in [0, 15], so greatest(x, y) can only exceed 9000 in the last row group
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE greatest(x, y) > 9000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE greatest(x, y) > 9000;
+----
+1239
+
+# least(x, z) < 100 requires x < 100 or z < 100: first and last row group
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE least(x, z) < 100;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE least(x, z) < 100;
+----
+200
+
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE greatest(x, z) > 10139;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE greatest(x, z) > 10139;
+----
+200
+
+# per row group, max(x) + max(y) bounds x + y
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE x + y > 9015;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE x + y > 9015;
+----
+1232
+
+query II
+EXPLAIN ANALYZE SELECT sum(x) FROM t WHERE x - y > 9000;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query I
+SELECT count(*) FROM t WHERE x - y > 9000;
+----
+1232


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Incorrect statistics or prune logic could skip row groups and return wrong results; the change is heavily tested but touches conservative optimizer paths for division, modulo, and multi-branch CASE.
> 
> **Overview**
> Extends **row-group zonemap pruning** so filters on derived expressions can skip scans more aggressively, without changing filter semantics (multi-column filters remain optional/partial pushdown).
> 
> **Multi-column filters:** `FilterCombiner` now pushes **any** DuckDB-table expression that references two or more columns into multi-column zonemap checks (not only simple numeric `col1 OP col2`), when statistics can be derived for the expression tree (comparisons, `BETWEEN`, conjunctions, `CASE`, casts, and functions with statistics callbacks or monotonic `ArgProperties`).
> 
> **Expression statistics:** `ExpressionFilter` derives stats for **`CASE`** by merging reachable `THEN`/`ELSE` branches (using WHEN prune results to skip unreachable branches) and evaluates boolean **`CASE` filters** by combining branch prune outcomes. Boolean constants in filters are handled explicitly.
> 
> **Arithmetic stats:** Integer `//`, `%`, and float `/` register **statistics propagation** (`DividePropagateStatistics`, `ModuloPropagateStatistics`) with guards for zero divisors, overflow (`MIN / -1`), and ambiguous divisor ranges so pruning stays conservative.
> 
> New optimizer SQL tests cover `CASE`/`if`/`nullif`, division/modulo, and multi-column `greatest`/`least`/`+`/`-`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf82107a2a0ac26f0990d2353d5aa2b677edadd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->