### PR TITLE
[NEED SEND PR] Hjiang/aggregate prune rowgroup minmax

### DIFF
--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -50,19 +50,7 @@ struct MonotonicEndpointInfo {
 	ColumnBinding binding;
 	LogicalType input_type;
 	LogicalType result_type;
-	StorageIndex storage_index;
 	vector<MonotonicExpressionTransform> transforms;
-	unique_ptr<ValueComparator> comparator;
-};
-
-enum class AggregateStatsPlanType : uint8_t { ROW_COUNT, MONOTONIC_ENDPOINT };
-
-struct AggregateStatsPlan {
-	explicit AggregateStatsPlan(AggregateStatsPlanType type_p) : type(type_p) {
-	}
-
-	AggregateStatsPlanType type;
-	unique_ptr<MonotonicEndpointInfo> endpoint;
 };
 
 template <typename StatsType>
@@ -142,13 +130,13 @@ bool TryGetMonotonicExpressionInfo(const Expression &expr, MonotonicExpressionIn
 		return false;
 	}
 
-	bool found_input = false;
+	bool has_input = false;
 	for (idx_t i = 0; i < func.GetChildren().size(); i++) {
 		const auto &child = *func.GetChildren()[i];
 		if (child.IsFoldable()) {
 			continue;
 		}
-		if (found_input) {
+		if (has_input) {
 			// Multiple varying arguments can have extrema originating from different rows.
 			return false;
 		}
@@ -161,9 +149,9 @@ bool TryGetMonotonicExpressionInfo(const Expression &expr, MonotonicExpressionIn
 			return false;
 		}
 		info = std::move(child_info);
-		found_input = true;
+		has_input = true;
 	}
-	return found_input;
+	return has_input;
 }
 
 bool TryGetMonotonicEndpointInfo(const Expression &expr, MonotonicEndpointInfo &info) {
@@ -175,11 +163,7 @@ bool TryGetMonotonicEndpointInfo(const Expression &expr, MonotonicEndpointInfo &
 	info.input_type = expression_info.input_type;
 	info.result_type = expr.GetReturnType();
 	if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
-		MonotonicExpressionTransform transform;
-		transform.expression = expr.Copy();
-		transform.input_binding = expression_info.binding;
-		transform.input_type = expression_info.input_type;
-		info.transforms.push_back(std::move(transform));
+		info.transforms.push_back({expr.Copy(), expression_info.binding, expression_info.input_type});
 	}
 	return true;
 }
@@ -212,14 +196,13 @@ bool IsUnusableMonotonicValue(const Value &value) {
 	if (value.IsNull()) {
 		return true;
 	}
-	switch (value.type().id()) {
-	case LogicalTypeId::DOUBLE:
+	if (value.type().id() == LogicalTypeId::DOUBLE) {
 		return Value::IsNan(value.GetValue<double>());
-	case LogicalTypeId::FLOAT:
-		return Value::IsNan(value.GetValue<float>());
-	default:
-		return false;
 	}
+	if (value.type().id() == LogicalTypeId::FLOAT) {
+		return Value::IsNan(value.GetValue<float>());
+	}
+	return false;
 }
 
 bool EvaluateMonotonicExpression(ClientContext &context, const MonotonicEndpointInfo &info, Value input,
@@ -292,19 +275,8 @@ bool TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &
 	return true;
 }
 
-bool TryExecuteRowCount(const vector<PartitionStatistics> &partition_stats, Value &result) {
-	idx_t count = 0;
-	for (const auto &stats : partition_stats) {
-		if (stats.count_type == CountType::COUNT_APPROXIMATE) {
-			return false;
-		}
-		count += stats.count;
-	}
-	result = Value::BIGINT(NumericCast<int64_t>(count));
-	return true;
-}
-
 bool TryExecuteMonotonicEndpoint(ClientContext &context, const vector<PartitionStatistics> &partition_stats,
+                                 const StorageIndex &storage_index, const ValueComparator &comparator,
                                  const MonotonicEndpointInfo &info, Value &result) {
 	auto min_comparator = GetComparator(Identifier("min"), info.input_type);
 	auto max_comparator = GetComparator(Identifier("max"), info.input_type);
@@ -313,20 +285,18 @@ bool TryExecuteMonotonicEndpoint(ClientContext &context, const vector<PartitionS
 	}
 
 	auto get_partition_result = [&](const PartitionStatistics &stats, Value &partition_result) {
-		Value input_min;
-		Value input_max;
-		if (!TryGetValueFromStats(stats, info.storage_index, *min_comparator, info.input_type, input_min) ||
-		    !TryGetValueFromStats(stats, info.storage_index, *max_comparator, info.input_type, input_max)) {
+		Value input_min, input_max;
+		if (!TryGetValueFromStats(stats, storage_index, *min_comparator, info.input_type, input_min) ||
+		    !TryGetValueFromStats(stats, storage_index, *max_comparator, info.input_type, input_max)) {
 			return false;
 		}
-		Value output_min;
-		Value output_max;
+		Value output_min, output_max;
 		if (!EvaluateMonotonicExpression(context, info, std::move(input_min), output_min) ||
 		    !EvaluateMonotonicExpression(context, info, std::move(input_max), output_max)) {
 			return false;
 		}
 		partition_result = std::move(output_min);
-		if (!info.comparator->Compare(partition_result, output_max)) {
+		if (!comparator.Compare(partition_result, output_max)) {
 			partition_result = std::move(output_max);
 		}
 		return true;
@@ -340,24 +310,11 @@ bool TryExecuteMonotonicEndpoint(ClientContext &context, const vector<PartitionS
 		if (!get_partition_result(partition_stats[partition_idx], partition_result)) {
 			return false;
 		}
-		if (!info.comparator->Compare(result, partition_result)) {
+		if (!comparator.Compare(result, partition_result)) {
 			result = std::move(partition_result);
 		}
 	}
 	return true;
-}
-
-bool TryExecuteAggregateStatsPlan(ClientContext &context, const vector<PartitionStatistics> &partition_stats,
-                                  const AggregateStatsPlan &plan, Value &result) {
-	switch (plan.type) {
-	case AggregateStatsPlanType::ROW_COUNT:
-		return TryExecuteRowCount(partition_stats, result);
-	case AggregateStatsPlanType::MONOTONIC_ENDPOINT:
-		D_ASSERT(plan.endpoint);
-		return TryExecuteMonotonicEndpoint(context, partition_stats, *plan.endpoint, result);
-	default:
-		throw InternalException("Unsupported aggregate statistics plan");
-	}
 }
 
 bool GroupingSetCanIntroduceNull(const LogicalAggregate &aggr, idx_t group_idx) {
@@ -380,11 +337,13 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		// not possible with groups
 		return;
 	}
-	// Build a statistics execution strategy for every aggregate.
-	vector<AggregateStatsPlan> aggregate_plans;
-	aggregate_plans.reserve(aggr.expressions.size());
+	// check if all aggregates are COUNT(*), MIN or MAX
+	vector<idx_t> count_star_idxs;
+	vector<MonotonicEndpointInfo> endpoints;
+	vector<unique_ptr<ValueComparator>> comparators;
 
-	for (auto &aggr_ref : aggr.expressions) {
+	for (idx_t i = 0; i < aggr.expressions.size(); i++) {
+		auto &aggr_ref = aggr.expressions[i];
 		if (aggr_ref->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
 			// not an aggregate
 			return;
@@ -403,22 +362,21 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 			if (aggr_expr.GetChildren().size() != 1) {
 				return;
 			}
-			auto endpoint = make_uniq<MonotonicEndpointInfo>();
-			if (!TryGetMonotonicEndpointInfo(*aggr_expr.GetChildren()[0], *endpoint)) {
+			MonotonicEndpointInfo endpoint;
+			if (!TryGetMonotonicEndpointInfo(*aggr_expr.GetChildren()[0], endpoint)) {
 				return;
 			}
-			endpoint->comparator = GetComparator(fun_name, endpoint->result_type);
-			if (!endpoint->comparator) {
+			auto comparator = GetComparator(fun_name, endpoint.result_type);
+			if (!comparator) {
 				// Type has no min max statistics
 				return;
 			}
-			AggregateStatsPlan plan(AggregateStatsPlanType::MONOTONIC_ENDPOINT);
-			plan.endpoint = std::move(endpoint);
-			aggregate_plans.push_back(std::move(plan));
+			endpoints.push_back(std::move(endpoint));
+			comparators.push_back(std::move(comparator));
 		} else if (fun_name == "count_star") {
-			aggregate_plans.emplace_back(AggregateStatsPlanType::ROW_COUNT);
+			count_star_idxs.push_back(i);
 		} else {
-			// No statistics execution strategy exists for this aggregate.
+			// aggregate is not count star, min or max - bail
 			return;
 		}
 	}
@@ -426,11 +384,7 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 	// skip any projections
 	reference<LogicalOperator> child_ref = *aggr.children[0];
 	while (child_ref.get().type == LogicalOperatorType::LOGICAL_PROJECTION) {
-		for (auto &plan : aggregate_plans) {
-			if (plan.type != AggregateStatsPlanType::MONOTONIC_ENDPOINT) {
-				continue;
-			}
-			auto &endpoint = *plan.endpoint;
+		for (auto &endpoint : endpoints) {
 			auto &proj = child_ref.get().Cast<LogicalProjection>();
 			auto &expr = proj.GetExpression(endpoint.binding);
 			MonotonicEndpointInfo projection_info;
@@ -471,13 +425,11 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		return;
 	}
 
-	for (auto &plan : aggregate_plans) {
-		if (plan.type != AggregateStatsPlanType::MONOTONIC_ENDPOINT) {
-			continue;
-		}
-		auto &endpoint = *plan.endpoint;
+	vector<StorageIndex> endpoint_storage_indexes(endpoints.size());
+	for (idx_t i = 0; i < endpoints.size(); i++) {
+		auto &endpoint = endpoints[i];
 		auto &column_index = get.GetColumnIndex(endpoint.binding);
-		if (!get.TryGetStorageIndex(column_index, endpoint.storage_index)) {
+		if (!get.TryGetStorageIndex(column_index, endpoint_storage_indexes[i])) {
 			//! Can't get a storage index for this column, so it doesn't have stats we can use
 			//! This happens when we're dealing with a generated column for example
 			return;
@@ -559,13 +511,30 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		return;
 	}
 
-	for (const auto &plan : aggregate_plans) {
+	for (idx_t i = 0; i < endpoints.size(); i++) {
 		Value result;
-		if (!TryExecuteAggregateStatsPlan(context, partition_stats, plan, result)) {
+		if (!TryExecuteMonotonicEndpoint(context, partition_stats, endpoint_storage_indexes[i], *comparators[i],
+		                                 endpoints[i], result)) {
 			return;
 		}
 		types.push_back(result.type());
 		agg_results.push_back(make_uniq<BoundConstantExpression>(std::move(result)));
+	}
+	if (!count_star_idxs.empty()) {
+		// Execute count_star aggregates on partition statistics
+		idx_t count = 0;
+		for (const auto &stats : partition_stats) {
+			if (stats.count_type == CountType::COUNT_APPROXIMATE) {
+				// we cannot get an exact count
+				return;
+			}
+			count += stats.count;
+		}
+		for (const auto count_star_idx : count_star_idxs) {
+			auto count_result = make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(count)));
+			agg_results.emplace(agg_results.begin() + NumericCast<int64_t>(count_star_idx), std::move(count_result));
+			types.insert(types.begin() + NumericCast<int64_t>(count_star_idx), LogicalType::BIGINT);
+		}
 	}
 
 	if (need_to_scan) {

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -7,10 +7,13 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/arg_properties.hpp"
 #include "duckdb/function/partition_stats.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/optimizer/column_binding_replacer.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
@@ -31,16 +34,35 @@ namespace duckdb {
 
 namespace {
 
-struct MinMaxColumnInfo {
-	ColumnBinding binding;
+struct MonotonicExpressionTransform {
+	unique_ptr<Expression> expression;
+	ColumnBinding input_binding;
 	LogicalType input_type;
-	LogicalType result_type;
 };
 
 struct ValueComparator {
 	virtual ~ValueComparator() = default;
 	virtual bool Compare(Value &lhs, Value &rhs) const = 0;
 	virtual Value GetVal(BaseStatistics &stats) const = 0;
+};
+
+struct MonotonicEndpointInfo {
+	ColumnBinding binding;
+	LogicalType input_type;
+	LogicalType result_type;
+	StorageIndex storage_index;
+	vector<MonotonicExpressionTransform> transforms;
+	unique_ptr<ValueComparator> comparator;
+};
+
+enum class AggregateStatsPlanType : uint8_t { ROW_COUNT, MONOTONIC_ENDPOINT };
+
+struct AggregateStatsPlan {
+	explicit AggregateStatsPlan(AggregateStatsPlanType type_p) : type(type_p) {
+	}
+
+	AggregateStatsPlanType type;
+	unique_ptr<MonotonicEndpointInfo> endpoint;
 };
 
 template <typename StatsType>
@@ -92,29 +114,141 @@ bool IsSafeMinMaxCast(const LogicalType &source, const LogicalType &target) {
 	return LogicalType::DefaultTryGetMaxLogicalTypeUnchecked(source, target, max_type) && max_type == target;
 }
 
-bool TryGetMinMaxColumnInfo(const Expression &expr, MinMaxColumnInfo &info) {
+struct MonotonicExpressionInfo {
+	ColumnBinding binding;
+	LogicalType input_type;
+};
+
+bool TryGetMonotonicExpressionInfo(const Expression &expr, MonotonicExpressionInfo &info) {
 	if (expr.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
 		const auto &col_ref = expr.Cast<BoundColumnRefExpression>();
 		info.binding = col_ref.Binding();
 		info.input_type = col_ref.GetReturnType();
-		info.result_type = col_ref.GetReturnType();
 		return true;
 	}
-	if (!BoundCastExpression::IsCast(expr)) {
+	if (BoundCastExpression::IsCast(expr)) {
+		const auto &cast = expr.Cast<BoundFunctionExpression>();
+		const auto &cast_child = BoundCastExpression::Child(cast);
+		if (!IsSafeMinMaxCast(cast_child.GetReturnType(), BoundCastExpression::TargetType(cast))) {
+			return false;
+		}
+		return TryGetMonotonicExpressionInfo(cast_child, info);
+	}
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
 		return false;
 	}
-	const auto &cast = expr.Cast<BoundFunctionExpression>();
-	const auto &cast_child = BoundCastExpression::Child(cast);
-	if (cast_child.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+	const auto &func = expr.Cast<BoundFunctionExpression>();
+	if (!func.Function().HasArgProperties() || func.Function().GetStability() != FunctionStability::CONSISTENT) {
 		return false;
 	}
-	const auto &col_ref = cast_child.Cast<BoundColumnRefExpression>();
-	if (!IsSafeMinMaxCast(col_ref.GetReturnType(), BoundCastExpression::TargetType(cast))) {
+
+	bool found_input = false;
+	for (idx_t i = 0; i < func.GetChildren().size(); i++) {
+		const auto &child = *func.GetChildren()[i];
+		if (child.IsFoldable()) {
+			continue;
+		}
+		if (found_input) {
+			// Multiple varying arguments can have extrema originating from different rows.
+			return false;
+		}
+		MonotonicExpressionInfo child_info;
+		if (!TryGetMonotonicExpressionInfo(child, child_info)) {
+			return false;
+		}
+		const auto monotonicity = func.Function().GetArgProperties(i).monotonicity;
+		if (!IsMonotonicIncreasing(monotonicity) && !IsMonotonicDecreasing(monotonicity)) {
+			return false;
+		}
+		info = std::move(child_info);
+		found_input = true;
+	}
+	return found_input;
+}
+
+bool TryGetMonotonicEndpointInfo(const Expression &expr, MonotonicEndpointInfo &info) {
+	MonotonicExpressionInfo expression_info;
+	if (!TryGetMonotonicExpressionInfo(expr, expression_info)) {
 		return false;
 	}
-	info.binding = col_ref.Binding();
-	info.input_type = col_ref.GetReturnType();
-	info.result_type = BoundCastExpression::TargetType(cast);
+	info.binding = expression_info.binding;
+	info.input_type = expression_info.input_type;
+	info.result_type = expr.GetReturnType();
+	if (expr.GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		MonotonicExpressionTransform transform;
+		transform.expression = expr.Copy();
+		transform.input_binding = expression_info.binding;
+		transform.input_type = expression_info.input_type;
+		info.transforms.push_back(std::move(transform));
+	}
+	return true;
+}
+
+bool ReplaceInputWithConstant(unique_ptr<Expression> &expr, const ColumnBinding &binding, const Value &value) {
+	if (expr->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+		const auto &col_ref = expr->Cast<BoundColumnRefExpression>();
+		if (col_ref.Binding() != binding) {
+			return false;
+		}
+		expr = make_uniq<BoundConstantExpression>(value);
+		return true;
+	}
+	bool success = true;
+	bool found_input = false;
+	ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {
+		if (!success || child->IsFoldable()) {
+			return;
+		}
+		if (!ReplaceInputWithConstant(child, binding, value)) {
+			success = false;
+			return;
+		}
+		found_input = true;
+	});
+	return success && found_input;
+}
+
+bool IsUnusableMonotonicValue(const Value &value) {
+	if (value.IsNull()) {
+		return true;
+	}
+	switch (value.type().id()) {
+	case LogicalTypeId::DOUBLE:
+		return Value::IsNan(value.GetValue<double>());
+	case LogicalTypeId::FLOAT:
+		return Value::IsNan(value.GetValue<float>());
+	default:
+		return false;
+	}
+}
+
+bool EvaluateMonotonicExpression(ClientContext &context, const MonotonicEndpointInfo &info, Value input,
+                                 Value &result) {
+	for (auto transform = info.transforms.rbegin(); transform != info.transforms.rend(); ++transform) {
+		if (input.type() != transform->input_type) {
+			auto cast = input.DefaultTryCastAs(transform->input_type);
+			if (!cast) {
+				return false;
+			}
+			input = std::move(*cast);
+		}
+		auto expression = transform->expression->Copy();
+		if (!ReplaceInputWithConstant(expression, transform->input_binding, input) ||
+		    !ExpressionExecutor::TryEvaluateScalar(context, *expression, input) || IsUnusableMonotonicValue(input)) {
+			return false;
+		}
+	}
+	if (input.type() != info.result_type) {
+		auto cast = input.DefaultTryCastAs(info.result_type);
+		if (!cast) {
+			return false;
+		}
+		input = std::move(*cast);
+	}
+	if (!info.transforms.empty() && IsUnusableMonotonicValue(input)) {
+		return false;
+	}
+	result = std::move(input);
 	return true;
 }
 
@@ -158,6 +292,74 @@ bool TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &
 	return true;
 }
 
+bool TryExecuteRowCount(const vector<PartitionStatistics> &partition_stats, Value &result) {
+	idx_t count = 0;
+	for (const auto &stats : partition_stats) {
+		if (stats.count_type == CountType::COUNT_APPROXIMATE) {
+			return false;
+		}
+		count += stats.count;
+	}
+	result = Value::BIGINT(NumericCast<int64_t>(count));
+	return true;
+}
+
+bool TryExecuteMonotonicEndpoint(ClientContext &context, const vector<PartitionStatistics> &partition_stats,
+                                 const MonotonicEndpointInfo &info, Value &result) {
+	auto min_comparator = GetComparator(Identifier("min"), info.input_type);
+	auto max_comparator = GetComparator(Identifier("max"), info.input_type);
+	if (!min_comparator || !max_comparator) {
+		return false;
+	}
+
+	auto get_partition_result = [&](const PartitionStatistics &stats, Value &partition_result) {
+		Value input_min;
+		Value input_max;
+		if (!TryGetValueFromStats(stats, info.storage_index, *min_comparator, info.input_type, input_min) ||
+		    !TryGetValueFromStats(stats, info.storage_index, *max_comparator, info.input_type, input_max)) {
+			return false;
+		}
+		Value output_min;
+		Value output_max;
+		if (!EvaluateMonotonicExpression(context, info, std::move(input_min), output_min) ||
+		    !EvaluateMonotonicExpression(context, info, std::move(input_max), output_max)) {
+			return false;
+		}
+		partition_result = std::move(output_min);
+		if (!info.comparator->Compare(partition_result, output_max)) {
+			partition_result = std::move(output_max);
+		}
+		return true;
+	};
+
+	if (!get_partition_result(partition_stats[0], result)) {
+		return false;
+	}
+	for (idx_t partition_idx = 1; partition_idx < partition_stats.size(); partition_idx++) {
+		Value partition_result;
+		if (!get_partition_result(partition_stats[partition_idx], partition_result)) {
+			return false;
+		}
+		if (!info.comparator->Compare(result, partition_result)) {
+			result = std::move(partition_result);
+		}
+	}
+	return true;
+}
+
+bool TryExecuteAggregateStatsPlan(ClientContext &context, const vector<PartitionStatistics> &partition_stats,
+                                  const AggregateStatsPlan &plan, Value &result) {
+	switch (plan.type) {
+	case AggregateStatsPlanType::ROW_COUNT:
+		return TryExecuteRowCount(partition_stats, result);
+	case AggregateStatsPlanType::MONOTONIC_ENDPOINT:
+		D_ASSERT(plan.endpoint);
+		return TryExecuteMonotonicEndpoint(context, partition_stats, *plan.endpoint, result);
+	default:
+		throw InternalException("Unsupported aggregate statistics plan");
+	}
+}
+
 bool GroupingSetCanIntroduceNull(const LogicalAggregate &aggr, idx_t group_idx) {
 	if (aggr.grouping_sets.empty()) {
 		return false;
@@ -178,13 +380,11 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		// not possible with groups
 		return;
 	}
-	// check if all aggregates are COUNT(*), MIN or MAX
-	vector<idx_t> count_star_idxs;
-	vector<MinMaxColumnInfo> min_max_columns;
-	vector<unique_ptr<ValueComparator>> comparators;
+	// Build a statistics execution strategy for every aggregate.
+	vector<AggregateStatsPlan> aggregate_plans;
+	aggregate_plans.reserve(aggr.expressions.size());
 
-	for (idx_t i = 0; i < aggr.expressions.size(); i++) {
-		auto &aggr_ref = aggr.expressions[i];
+	for (auto &aggr_ref : aggr.expressions) {
 		if (aggr_ref->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
 			// not an aggregate
 			return;
@@ -203,21 +403,22 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 			if (aggr_expr.GetChildren().size() != 1) {
 				return;
 			}
-			MinMaxColumnInfo column_info;
-			if (!TryGetMinMaxColumnInfo(*aggr_expr.GetChildren()[0], column_info)) {
+			auto endpoint = make_uniq<MonotonicEndpointInfo>();
+			if (!TryGetMonotonicEndpointInfo(*aggr_expr.GetChildren()[0], *endpoint)) {
 				return;
 			}
-			min_max_columns.push_back(column_info);
-			auto comparator = GetComparator(fun_name, column_info.input_type);
-			if (!comparator) {
+			endpoint->comparator = GetComparator(fun_name, endpoint->result_type);
+			if (!endpoint->comparator) {
 				// Type has no min max statistics
 				return;
 			}
-			comparators.push_back(std::move(comparator));
+			AggregateStatsPlan plan(AggregateStatsPlanType::MONOTONIC_ENDPOINT);
+			plan.endpoint = std::move(endpoint);
+			aggregate_plans.push_back(std::move(plan));
 		} else if (fun_name == "count_star") {
-			count_star_idxs.push_back(i);
+			aggregate_plans.emplace_back(AggregateStatsPlanType::ROW_COUNT);
 		} else {
-			// aggregate is not count star, min or max - bail
+			// No statistics execution strategy exists for this aggregate.
 			return;
 		}
 	}
@@ -225,18 +426,25 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 	// skip any projections
 	reference<LogicalOperator> child_ref = *aggr.children[0];
 	while (child_ref.get().type == LogicalOperatorType::LOGICAL_PROJECTION) {
-		for (auto &column_info : min_max_columns) {
+		for (auto &plan : aggregate_plans) {
+			if (plan.type != AggregateStatsPlanType::MONOTONIC_ENDPOINT) {
+				continue;
+			}
+			auto &endpoint = *plan.endpoint;
 			auto &proj = child_ref.get().Cast<LogicalProjection>();
-			auto &expr = proj.GetExpression(column_info.binding);
-			MinMaxColumnInfo projection_info;
-			if (!TryGetMinMaxColumnInfo(expr, projection_info)) {
+			auto &expr = proj.GetExpression(endpoint.binding);
+			MonotonicEndpointInfo projection_info;
+			if (!TryGetMonotonicEndpointInfo(expr, projection_info)) {
 				return;
 			}
-			if (!IsSafeMinMaxCast(projection_info.result_type, column_info.input_type)) {
+			if (!IsSafeMinMaxCast(projection_info.result_type, endpoint.input_type)) {
 				return;
 			}
-			column_info.binding = projection_info.binding;
-			column_info.input_type = projection_info.input_type;
+			endpoint.binding = projection_info.binding;
+			endpoint.input_type = projection_info.input_type;
+			for (auto &transform : projection_info.transforms) {
+				endpoint.transforms.push_back(std::move(transform));
+			}
 		}
 		child_ref = *child_ref.get().children[0];
 	}
@@ -263,11 +471,13 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		return;
 	}
 
-	vector<StorageIndex> min_max_storage_indexes(min_max_columns.size());
-	for (idx_t i = 0; i < min_max_columns.size(); i++) {
-		auto &binding = min_max_columns[i].binding;
-		auto &column_index = get.GetColumnIndex(binding);
-		if (!get.TryGetStorageIndex(column_index, min_max_storage_indexes[i])) {
+	for (auto &plan : aggregate_plans) {
+		if (plan.type != AggregateStatsPlanType::MONOTONIC_ENDPOINT) {
+			continue;
+		}
+		auto &endpoint = *plan.endpoint;
+		auto &column_index = get.GetColumnIndex(endpoint.binding);
+		if (!get.TryGetStorageIndex(column_index, endpoint.storage_index)) {
 			//! Can't get a storage index for this column, so it doesn't have stats we can use
 			//! This happens when we're dealing with a generated column for example
 			return;
@@ -349,47 +559,13 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		return;
 	}
 
-	if (!min_max_columns.empty()) {
-		// Execute min/max aggregates on partition statistics
-		for (idx_t agg_idx = 0; agg_idx < min_max_storage_indexes.size(); agg_idx++) {
-			const auto &storage_index = min_max_storage_indexes[agg_idx];
-			const auto &result_type = min_max_columns[agg_idx].result_type;
-			auto &comparator = comparators[agg_idx];
-
-			Value agg_result;
-			if (!TryGetValueFromStats(partition_stats[0], storage_index, *comparator, result_type, agg_result)) {
-				return;
-			}
-			for (idx_t partition_idx = 1; partition_idx < partition_stats.size(); partition_idx++) {
-				Value rhs;
-				if (!TryGetValueFromStats(partition_stats[partition_idx], storage_index, *comparator, result_type,
-				                          rhs)) {
-					return;
-				}
-				if (!comparator->Compare(agg_result, rhs)) {
-					agg_result = rhs;
-				}
-			}
-			types.push_back(agg_result.type());
-			auto expr = make_uniq<BoundConstantExpression>(agg_result);
-			agg_results.push_back(std::move(expr));
+	for (const auto &plan : aggregate_plans) {
+		Value result;
+		if (!TryExecuteAggregateStatsPlan(context, partition_stats, plan, result)) {
+			return;
 		}
-	}
-	if (!count_star_idxs.empty()) {
-		// Execute count_star aggregates on partition statistics
-		idx_t count = 0;
-		for (const auto &stats : partition_stats) {
-			if (stats.count_type == CountType::COUNT_APPROXIMATE) {
-				// we cannot get an exact count
-				return;
-			}
-			count += stats.count;
-		}
-		for (const auto count_star_idx : count_star_idxs) {
-			auto count_result = make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(count)));
-			agg_results.emplace(agg_results.begin() + NumericCast<int64_t>(count_star_idx), std::move(count_result));
-			types.insert(types.begin() + NumericCast<int64_t>(count_star_idx), LogicalType::BIGINT);
-		}
+		types.push_back(result.type());
+		agg_results.push_back(make_uniq<BoundConstantExpression>(std::move(result)));
 	}
 
 	if (need_to_scan) {

--- a/test/optimizer/eager_aggregate_execution.test
+++ b/test/optimizer/eager_aggregate_execution.test
@@ -61,6 +61,17 @@ SELECT max(i), count(i), min(i) FROM t
 ----
 8191	8192	0
 
+# MIN/MAX over recursively monotonic expressions can be evaluated from exact row-group statistics.
+query II
+EXPLAIN SELECT min(i + 1), max(i + 1), min(-(i + 1)), max(-(i + 1)) FROM t
+----
+physical_plan	<!REGEX>:.*AGGREGATE.*
+
+query IIII
+SELECT min(i + 1), max(i + 1), min(-(i + 1)), max(-(i + 1)) FROM t
+----
+1	8192	-8192	-1
+
 query II
 explain SELECT count(*),max(i),min(i) FROM t where i >=2048
 ----

--- a/test/optimizer/eager_aggregate_execution.test
+++ b/test/optimizer/eager_aggregate_execution.test
@@ -72,6 +72,12 @@ SELECT min(i + 1), max(i + 1), min(-(i + 1)), max(-(i + 1)) FROM t
 ----
 1	8192	-8192	-1
 
+# Extrema of expressions with multiple varying inputs cannot be reconstructed from independent column statistics.
+query II
+EXPLAIN SELECT min(i + j), max(i + j) FROM t
+----
+physical_plan	<REGEX>:.*AGGREGATE.*
+
 query II
 explain SELECT count(*),max(i),min(i) FROM t where i >=2048
 ----

--- a/test/sql/optimizer/aggregate_stats_propagation.test
+++ b/test/sql/optimizer/aggregate_stats_propagation.test
@@ -15,17 +15,28 @@ CREATE TABLE t AS SELECT range::INTEGER AS x, (range % 16)::INTEGER AS g FROM ra
 statement ok
 CHECKPOINT;
 
-# An exact MAX over a monotonic expression becomes a dynamic filter that prunes every row group.
+# An exact MAX over a monotonic expression becomes a dynamic filter that scans only the final row group.
 query II
-EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x > (SELECT max(x + 1) FROM t);
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x >= (SELECT max(x + 1) - 1000 FROM t);
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 5.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
 
-# An exact MIN over a monotonic expression can likewise prune every row group.
+# The aggregate itself must not scan all row groups before producing the dynamic filter.
 query II
-EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x < (SELECT min(x - 1) FROM t);
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x >= (SELECT max(x + 1) - 1000 FROM t);
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 5.*
+analyzed_plan	<!REGEX>:.*Row Groups Scanned: 5 / 5.*
+
+# An exact MIN over a monotonic expression likewise limits the scan to the first row group.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x <= (SELECT min(x - 1) + 1000 FROM t);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x <= (SELECT min(x - 1) + 1000 FROM t);
+----
+analyzed_plan	<!REGEX>:.*Row Groups Scanned: 5 / 5.*
 
 # ---------------------------------------------------------------------------
 # result is one of the input values: min / max / first / last / any_value /

--- a/test/sql/optimizer/aggregate_stats_propagation.test
+++ b/test/sql/optimizer/aggregate_stats_propagation.test
@@ -21,22 +21,11 @@ EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x >= (SELECT max(x + 1) - 1000 FROM
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
 
-# The aggregate itself must not scan all row groups before producing the dynamic filter.
-query II
-EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x >= (SELECT max(x + 1) - 1000 FROM t);
-----
-analyzed_plan	<!REGEX>:.*Row Groups Scanned: 5 / 5.*
-
 # An exact MIN over a monotonic expression likewise limits the scan to the first row group.
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x <= (SELECT min(x - 1) + 1000 FROM t);
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 5.*
-
-query II
-EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x <= (SELECT min(x - 1) + 1000 FROM t);
-----
-analyzed_plan	<!REGEX>:.*Row Groups Scanned: 5 / 5.*
 
 # ---------------------------------------------------------------------------
 # result is one of the input values: min / max / first / last / any_value /

--- a/test/sql/optimizer/aggregate_stats_propagation.test
+++ b/test/sql/optimizer/aggregate_stats_propagation.test
@@ -12,6 +12,21 @@ USE db;
 statement ok
 CREATE TABLE t AS SELECT range::INTEGER AS x, (range % 16)::INTEGER AS g FROM range(10240);
 
+statement ok
+CHECKPOINT;
+
+# An exact MAX over a monotonic expression becomes a dynamic filter that prunes every row group.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x > (SELECT max(x + 1) FROM t);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 5.*
+
+# An exact MIN over a monotonic expression can likewise prune every row group.
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM t WHERE x < (SELECT min(x - 1) FROM t);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 0 / 5.*
+
 # ---------------------------------------------------------------------------
 # result is one of the input values: min / max / first / last / any_value /
 # arg_min / arg_max / mode -> output stats inherit the input column's min/max


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes optimizer aggregate folding and row-group pruning correctness paths; logic is guarded by monotonicity checks and falls back to scanning when reconstruction fails, but wrong endpoint math would change query results.
> 
> **Overview**
> Extends **ungrouped MIN/MAX eager aggregate** execution so it no longer requires a bare column reference. The optimizer now recognizes **single-input monotonic expressions** (safe integral casts, consistent functions with increasing/decreasing arg properties) and derives aggregate results from **exact partition min/max statistics** on the underlying column.
> 
> For each row group, it applies the expression to the stored column min and max, picks the appropriate endpoint for MIN vs MAX, then merges across partitions—same constant-replacement path as before, but with new helpers (`TryGetMonotonicEndpointInfo`, `EvaluateMonotonicExpression`, `TryExecuteMonotonicEndpoint`). **Expressions with multiple non-constant arguments** (e.g. `i + j`) are explicitly rejected because extrema can come from different rows.
> 
> Tests confirm correct results for `min/max(i±1)` and that subqueries like `max(x+1)` / `min(x-1)` feed **dynamic filters** that scan only one row group out of five.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a70c76fc0e11e02fcb3d0b3430b246db01cca0d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->