### PR TITLE
[NEED CHECK] Hjiang/eliminate unnecessary order

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4025,7 +4025,8 @@ const StringUtil::EnumStringLiteral *GetOptimizerTypeValues() {
 		{ static_cast<uint32_t>(OptimizerType::TYPE_PUSHDOWN), "TYPE_PUSHDOWN" },
 		{ static_cast<uint32_t>(OptimizerType::SCALAR_FN_PUSHDOWN), "SCALAR_FN_PUSHDOWN" },
 		{ static_cast<uint32_t>(OptimizerType::DISTINCT_AGGREGATE_REWRITE), "DISTINCT_AGGREGATE_REWRITE" },
-		{ static_cast<uint32_t>(OptimizerType::AGGREGATE_REUSE), "AGGREGATE_REUSE" }
+		{ static_cast<uint32_t>(OptimizerType::AGGREGATE_REUSE), "AGGREGATE_REUSE" },
+		{ static_cast<uint32_t>(OptimizerType::REMOVE_UNUSED_ORDER), "REMOVE_UNUSED_ORDER" }
 	};
 	return values;
 }

--- a/src/common/enums/optimizer_type.cpp
+++ b/src/common/enums/optimizer_type.cpp
@@ -57,6 +57,7 @@ static const DefaultOptimizerType internal_optimizer_types[] = {
     {"scalar_fn_pushdown", OptimizerType::SCALAR_FN_PUSHDOWN},
     {"distinct_aggregate_rewrite", OptimizerType::DISTINCT_AGGREGATE_REWRITE},
     {"aggregate_reuse", OptimizerType::AGGREGATE_REUSE},
+    {"remove_unused_order", OptimizerType::REMOVE_UNUSED_ORDER},
     {nullptr, OptimizerType::INVALID}};
 
 string OptimizerTypeToString(OptimizerType type) {

--- a/src/include/duckdb/common/enums/optimizer_type.hpp
+++ b/src/include/duckdb/common/enums/optimizer_type.hpp
@@ -58,7 +58,8 @@ enum class OptimizerType : uint32_t {
 	TYPE_PUSHDOWN = 41,
 	SCALAR_FN_PUSHDOWN = 42,
 	DISTINCT_AGGREGATE_REWRITE = 43,
-	AGGREGATE_REUSE = 44
+	AGGREGATE_REUSE = 44,
+	REMOVE_UNUSED_ORDER = 45
 };
 
 string OptimizerTypeToString(OptimizerType type);

--- a/src/include/duckdb/optimizer/remove_unused_order.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_order.hpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/remove_unused_order.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/planner/logical_operator.hpp"
+
+namespace duckdb {
+
+//! Drops LogicalOrder nodes that sit directly below an order-insensitive parent
+//! (aggregate with all NOT_ORDER_DEPENDENT aggregates, DISTINCT, or set ops).
+class RemoveUnusedOrder {
+public:
+	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op);
+};
+
+} // namespace duckdb

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library_unity(
   regex_range_filter.cpp
   remove_duplicate_groups.cpp
   remove_unused_columns.cpp
+  remove_unused_order.cpp
   row_group_pruner.cpp
   statistics_propagator.cpp
   limit_pushdown.cpp

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -437,11 +437,11 @@ void Optimizer::RunBuiltInOptimizers() {
 		plan = topn.Optimize(std::move(plan));
 	});
 
-	// drop bare ORDER BY nodes whose parent (aggregate / distinct / set op) does not care about row order
-	{
+	// drop bare ORDER BY nodes whose parent (aggregate / distinct) does not care about row order
+	RunOptimizer(OptimizerType::REMOVE_UNUSED_ORDER, [&]() {
 		RemoveUnusedOrder remove_unused_order;
 		plan = remove_unused_order.Optimize(std::move(plan));
-	}
+	});
 
 	// try to use late materialization
 	RunOptimizer(OptimizerType::LATE_MATERIALIZATION, [&]() {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -28,6 +28,7 @@
 #include "duckdb/optimizer/regex_range_filter.hpp"
 #include "duckdb/optimizer/remove_duplicate_groups.hpp"
 #include "duckdb/optimizer/remove_unused_columns.hpp"
+#include "duckdb/optimizer/remove_unused_order.hpp"
 #include "duckdb/optimizer/row_group_pruner.hpp"
 #include "duckdb/optimizer/rule/distinct_aggregate_optimizer.hpp"
 #include "duckdb/optimizer/rule/equal_or_null_simplification.hpp"
@@ -435,6 +436,12 @@ void Optimizer::RunBuiltInOptimizers() {
 		TopN topn(context);
 		plan = topn.Optimize(std::move(plan));
 	});
+
+	// drop bare ORDER BY nodes whose parent (aggregate / distinct / set op) does not care about row order
+	{
+		RemoveUnusedOrder remove_unused_order;
+		plan = remove_unused_order.Optimize(std::move(plan));
+	}
 
 	// try to use late materialization
 	RunOptimizer(OptimizerType::LATE_MATERIALIZATION, [&]() {

--- a/src/optimizer/remove_unused_order.cpp
+++ b/src/optimizer/remove_unused_order.cpp
@@ -3,31 +3,56 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_distinct.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
 
 namespace duckdb {
 
 namespace {
 
+bool AnyExpressionIsVolatile(const vector<unique_ptr<Expression>> &exprs) {
+	for (auto &e : exprs) {
+		if (e->IsVolatile()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 bool CanIgnoreChildOrder(const LogicalOperator &op) {
 	switch (op.type) {
-	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
+		auto &agg = op.Cast<LogicalAggregate>();
+		// volatile group expressions can change group assignment based on input order
+		if (AnyExpressionIsVolatile(agg.groups)) {
+			return false;
+		}
 		for (auto &e : op.expressions) {
 			if (e->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
 				return false;
 			}
 			auto &aggr = e->Cast<BoundAggregateExpression>();
 			if (aggr.Function().GetOrderDependent() != AggregateOrderDependent::NOT_ORDER_DEPENDENT ||
-			    aggr.GetOrderBys()) {
+			    aggr.GetOrderBys() || aggr.IsVolatile()) {
 				return false;
 			}
 		}
 		return true;
+	}
 	case LogicalOperatorType::LOGICAL_DISTINCT:
 		return op.Cast<LogicalDistinct>().distinct_type == DistinctType::DISTINCT;
-	case LogicalOperatorType::LOGICAL_UNION:
-	case LogicalOperatorType::LOGICAL_EXCEPT:
-	case LogicalOperatorType::LOGICAL_INTERSECT:
-		return true;
+	default:
+		return false;
+	}
+}
+
+// True for operators whose row-by-row output preserves input order AND whose
+// per-row work does not depend on input order (i.e. no volatile expressions).
+bool IsOrderTransparent(const LogicalOperator &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+	case LogicalOperatorType::LOGICAL_FILTER:
+		return !AnyExpressionIsVolatile(op.expressions);
 	default:
 		return false;
 	}
@@ -45,9 +70,7 @@ unique_ptr<LogicalOperator> RemoveUnusedOrder::Optimize(unique_ptr<LogicalOperat
 	for (auto &child : op->children) {
 		// walk past order-preserving passthrough operators
 		auto *cur = &child;
-		while (!(*cur)->children.empty() &&
-		       ((*cur)->type == LogicalOperatorType::LOGICAL_PROJECTION ||
-		        (*cur)->type == LogicalOperatorType::LOGICAL_FILTER)) {
+		while (!(*cur)->children.empty() && IsOrderTransparent(**cur)) {
 			cur = &(*cur)->children[0];
 		}
 		if ((*cur)->type == LogicalOperatorType::LOGICAL_ORDER_BY) {

--- a/src/optimizer/remove_unused_order.cpp
+++ b/src/optimizer/remove_unused_order.cpp
@@ -1,0 +1,60 @@
+#include "duckdb/optimizer/remove_unused_order.hpp"
+
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/planner/operator/logical_distinct.hpp"
+
+namespace duckdb {
+
+namespace {
+
+bool CanIgnoreChildOrder(const LogicalOperator &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		for (auto &e : op.expressions) {
+			if (e->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
+				return false;
+			}
+			auto &aggr = e->Cast<BoundAggregateExpression>();
+			if (aggr.Function().GetOrderDependent() != AggregateOrderDependent::NOT_ORDER_DEPENDENT ||
+			    aggr.GetOrderBys()) {
+				return false;
+			}
+		}
+		return true;
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+		return op.Cast<LogicalDistinct>().distinct_type == DistinctType::DISTINCT;
+	case LogicalOperatorType::LOGICAL_UNION:
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+	case LogicalOperatorType::LOGICAL_INTERSECT:
+		return true;
+	default:
+		return false;
+	}
+}
+
+} // namespace
+
+unique_ptr<LogicalOperator> RemoveUnusedOrder::Optimize(unique_ptr<LogicalOperator> op) {
+	for (auto &child : op->children) {
+		child = Optimize(std::move(child));
+	}
+	if (!CanIgnoreChildOrder(*op)) {
+		return op;
+	}
+	for (auto &child : op->children) {
+		// walk past order-preserving passthrough operators
+		auto *cur = &child;
+		while (!(*cur)->children.empty() &&
+		       ((*cur)->type == LogicalOperatorType::LOGICAL_PROJECTION ||
+		        (*cur)->type == LogicalOperatorType::LOGICAL_FILTER)) {
+			cur = &(*cur)->children[0];
+		}
+		if ((*cur)->type == LogicalOperatorType::LOGICAL_ORDER_BY) {
+			*cur = std::move((*cur)->children[0]);
+		}
+	}
+	return op;
+}
+
+} // namespace duckdb

--- a/test/sql/optimizer/eliminate_redundant_order.test
+++ b/test/sql/optimizer/eliminate_redundant_order.test
@@ -1,0 +1,39 @@
+# name: test/sql/optimizer/eliminate_redundant_order.test
+# description: ORDER BY under order-insensitive parents should be dropped
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t(x INT NOT NULL);
+
+statement ok
+INSERT INTO t SELECT range % 100 FROM range(0, 1000);
+
+# aggregate consumer does not care about input order
+query II
+EXPLAIN SELECT sum(x) FROM (SELECT x FROM t ORDER BY x);
+----
+physical_plan	<!REGEX>:.*Order By.*
+
+# DISTINCT does not preserve order
+query II
+EXPLAIN SELECT DISTINCT x FROM (SELECT x FROM t ORDER BY x);
+----
+physical_plan	<!REGEX>:.*Order By.*
+
+# GROUP BY does not care about input order
+query II
+EXPLAIN SELECT x, count(*) FROM (SELECT x FROM t ORDER BY x) GROUP BY x;
+----
+physical_plan	<!REGEX>:.*Order By.*
+
+# order-dependent aggregate (string_agg) must keep the sort
+query II
+EXPLAIN SELECT string_agg(x::VARCHAR, ',') FROM (SELECT x FROM t ORDER BY x);
+----
+physical_plan	<REGEX>:.*Order By.*
+
+# ORDER BY + LIMIT is meaningful (TopN) - must keep
+query II
+EXPLAIN SELECT sum(x) FROM (SELECT x FROM t ORDER BY x LIMIT 10);
+----
+physical_plan	<REGEX>:.*TOP_N.*


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Plan-changing optimizer logic must preserve correctness for volatile expressions and order-dependent aggregates; mistakes could drop required sorts.
> 
> **Overview**
> Adds a **`remove_unused_order`** optimizer pass that strips redundant `LogicalOrder` nodes when the parent does not depend on input row order.
> 
> The pass runs **after TopN** so `ORDER BY … LIMIT` plans are unchanged. It recurses the plan and, for aggregates (only `NOT_ORDER_DEPENDENT` aggregates, no volatile/group-by expressions), and plain `DISTINCT`, removes a child sort—optionally skipping through non-volatile **projection** and **filter** nodes. Order-dependent aggregates (e.g. `string_agg`) and meaningful TopN patterns are left intact.
> 
> Wiring includes a new `OptimizerType::REMOVE_UNUSED_ORDER`, build integration, and SQL tests that assert `EXPLAIN` physical plans omit or retain `Order By` / `TOP_N` as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e638b1e24b5676f2396e405b31871f5bb41ec690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->