### PR TITLE
[NEED REVIEW] Hjiang/prune count

### DIFF
--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -275,6 +275,19 @@ AggregateStateLayout GetCountStateType(AggregateLayoutInput &input) {
 	return AggregateStateLayout(LogicalType::BIGINT, AlignValue(function.GetStateSizeCallback()(state_input)));
 }
 
+unique_ptr<BaseStatistics> MakeCountStats(const LogicalType &type, optional_ptr<NodeStatistics> node_stats) {
+	int64_t max_val = NumericLimits<int64_t>::Maximum();
+	if (node_stats && node_stats->has_max_cardinality &&
+	    node_stats->max_cardinality <= NumericCast<idx_t>(NumericLimits<int64_t>::Maximum())) {
+		max_val = NumericCast<int64_t>(node_stats->max_cardinality);
+	}
+	auto result = NumericStats::CreateEmpty(type).ToUnique();
+	NumericStats::SetMin(*result, Value::BIGINT(0));
+	NumericStats::SetMax(*result, Value::BIGINT(max_val));
+	result->Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
+	return result;
+}
+
 unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggregateExpression &expr,
                                                AggregateStatisticsInput &input) {
 	if (!expr.IsDistinct() && !input.child_stats[0].CanHaveNull()) {
@@ -283,7 +296,12 @@ unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggr
 		expr.FunctionMutable().SetName("count_star");
 		expr.GetChildrenMutable().clear();
 	}
-	return nullptr;
+	return MakeCountStats(expr.GetReturnType(), input.node_stats);
+}
+
+unique_ptr<BaseStatistics> CountStarPropagateStats(ClientContext &context, BoundAggregateExpression &expr,
+                                                   AggregateStatisticsInput &input) {
+	return MakeCountStats(expr.GetReturnType(), input.node_stats);
 }
 
 } // namespace
@@ -307,6 +325,7 @@ AggregateFunction CountStarFun::GetFunction() {
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	fun.SetWindowBatchCallback(CountStarFunction::Window<int64_t>);
+	fun.SetStatisticsCallback(CountStarPropagateStats);
 	return fun;
 }
 

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -277,8 +277,7 @@ AggregateStateLayout GetCountStateType(AggregateLayoutInput &input) {
 
 unique_ptr<BaseStatistics> MakeCountStats(const LogicalType &type, optional_ptr<NodeStatistics> node_stats) {
 	int64_t max_val = NumericLimits<int64_t>::Maximum();
-	if (node_stats && node_stats->has_max_cardinality &&
-	    node_stats->max_cardinality <= NumericCast<idx_t>(NumericLimits<int64_t>::Maximum())) {
+	if (node_stats && node_stats->has_max_cardinality) {
 		max_val = NumericCast<int64_t>(node_stats->max_cardinality);
 	}
 	auto result = NumericStats::CreateEmpty(type).ToUnique();

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -285,6 +285,7 @@ unique_ptr<BaseStatistics> MakeCountStats(const LogicalType &type, optional_ptr<
 	NumericStats::SetMin(*result, Value::BIGINT(0));
 	NumericStats::SetMax(*result, Value::BIGINT(max_val));
 	result->Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
+	result->Set(StatsInfo::CAN_HAVE_VALID_VALUES);
 	return result;
 }
 

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -492,6 +492,18 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggr
 		statistics_map[group_binding] = std::move(stats);
 	}
 
+	// a group only exists if at least one row belongs to it -> count_star() >= 1 for grouped
+	// aggregates. Skip when any grouping set is empty (that set collapses over all rows).
+	bool grouped_min_one = !aggr.groups.empty();
+	if (grouped_min_one) {
+		for (auto &gs : aggr.grouping_sets) {
+			if (gs.empty()) {
+				grouped_min_one = false;
+				break;
+			}
+		}
+	}
+
 	// propagate statistics in the aggregates
 	for (idx_t aggregate_idx = 0; aggregate_idx < aggr.expressions.size(); aggregate_idx++) {
 		auto &expr = aggr.expressions[aggregate_idx];
@@ -499,6 +511,11 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggr
 		auto stats = PropagateExpression(expr);
 		if (!stats) {
 			continue;
+		}
+		if (grouped_min_one && expr->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE &&
+		    expr->Cast<BoundAggregateExpression>().Function().GetName() == "count_star" &&
+		    NumericStats::HasMinMax(*stats) && NumericStats::Min(*stats).GetValue<int64_t>() < 1) {
+			NumericStats::SetMin(*stats, Value::BIGINT(1));
 		}
 		ColumnBinding aggregate_binding(aggr.aggregate_index, ProjectionIndex(aggregate_idx));
 		statistics_map[aggregate_binding] = std::move(stats);

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -492,18 +492,6 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggr
 		statistics_map[group_binding] = std::move(stats);
 	}
 
-	// a group only exists if at least one row belongs to it -> count_star() >= 1 for grouped
-	// aggregates. Skip when any grouping set is empty (that set collapses over all rows).
-	bool grouped_min_one = !aggr.groups.empty();
-	if (grouped_min_one) {
-		for (auto &gs : aggr.grouping_sets) {
-			if (gs.empty()) {
-				grouped_min_one = false;
-				break;
-			}
-		}
-	}
-
 	// propagate statistics in the aggregates
 	for (idx_t aggregate_idx = 0; aggregate_idx < aggr.expressions.size(); aggregate_idx++) {
 		auto &expr = aggr.expressions[aggregate_idx];
@@ -511,11 +499,6 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggr
 		auto stats = PropagateExpression(expr);
 		if (!stats) {
 			continue;
-		}
-		if (grouped_min_one && expr->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE &&
-		    expr->Cast<BoundAggregateExpression>().Function().GetName() == "count_star" &&
-		    NumericStats::HasMinMax(*stats) && NumericStats::Min(*stats).GetValue<int64_t>() < 1) {
-			NumericStats::SetMin(*stats, Value::BIGINT(1));
 		}
 		ColumnBinding aggregate_binding(aggr.aggregate_index, ProjectionIndex(aggregate_idx));
 		statistics_map[aggregate_binding] = std::move(stats);

--- a/test/sql/aggregate/aggregates/mode_rewrite.test
+++ b/test/sql/aggregate/aggregates/mode_rewrite.test
@@ -258,7 +258,7 @@ query II
 EXPLAIN (FORMAT JSON)
 SELECT g, mode(v), entropy(v) FROM mode_rewrite GROUP BY g;
 ----
-logical_opt	<REGEX>:.*"Groups":\s*\[[^\]]*"g"[^\]]*"v"[^\]]*\].*"Expressions":\s*"count_star\(\)".*arg_max\(#[0-9]+, #[0-9]+\).*sum\(#[0-9]+\).*sum\(.*log2.*COALESCE.*
+logical_opt	<REGEX>:.*"Groups":\s*\[[^\]]*"g"[^\]]*"v"[^\]]*\].*"Expressions":\s*"count_star\(\)".*arg_max\(#[0-9]+, #[0-9]+\).*sum(_no_overflow)?\(#[0-9]+\).*sum\(.*log2.*COALESCE.*
 
 statement ok
 SET disabled_optimizers='distinct_aggregate_rewrite';

--- a/test/sql/optimizer/count_aggregate_stats_propagation.test
+++ b/test/sql/optimizer/count_aggregate_stats_propagation.test
@@ -1,17 +1,14 @@
 # name: test/sql/optimizer/count_aggregate_stats_propagation.test
-# description: count / count_star always return non-negative BIGINT and never NULL; propagate that
+# description: count / count_star propagate that they are >= 0, never NULL, and >= 1 when grouped
 # group: [optimizer]
 
 statement ok
 CREATE TABLE t(x INTEGER NOT NULL);
 
 statement ok
-INSERT INTO t SELECT range FROM range(0, 1000);
+INSERT INTO t SELECT range FROM range(0, 20);
 
-# ---------------------------------------------------------------------------
-# count(*) is always >= 0, so out-of-range HAVING folds to Empty Result
-# ---------------------------------------------------------------------------
-
+# count(*) >= 0 always
 query II
 EXPLAIN SELECT count(*) FROM t HAVING count(*) < 0;
 ----
@@ -21,31 +18,7 @@ query I
 SELECT count(*) FROM t HAVING count(*) < 0;
 ----
 
-query II
-EXPLAIN SELECT count(*) FROM t HAVING count(*) = -5;
-----
-physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM t HAVING count(*) = -5;
-----
-
-# GROUP BY variant: filter is provably false per group as well
-query II
-EXPLAIN SELECT x, count(*) FROM t GROUP BY x HAVING count(*) < 0;
-----
-physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT x, count(*) FROM t GROUP BY x HAVING count(*) < 0);
-----
-0
-
-# ---------------------------------------------------------------------------
-# count(*) is never NULL, so IS NULL folds to Empty Result and IS NOT NULL to
-# an unconditional pass-through
-# ---------------------------------------------------------------------------
-
+# count(*) is never NULL
 query II
 EXPLAIN SELECT count(*) FROM t HAVING count(*) IS NULL;
 ----
@@ -55,6 +28,7 @@ query I
 SELECT count(*) FROM t HAVING count(*) IS NULL;
 ----
 
+# always-true HAVING is dropped (exercises the non-null propagation in the opposite direction)
 query II
 EXPLAIN SELECT count(*) FROM t HAVING count(*) IS NOT NULL;
 ----
@@ -63,26 +37,9 @@ physical_plan	<!REGEX>:.*Filter.*IS NOT NULL.*
 query I
 SELECT count(*) FROM t HAVING count(*) IS NOT NULL;
 ----
-1000
+20
 
-# ---------------------------------------------------------------------------
-# Always-true HAVING should have its filter dropped
-# ---------------------------------------------------------------------------
-
-query II
-EXPLAIN SELECT count(*) FROM t HAVING count(*) >= 0;
-----
-physical_plan	<!REGEX>:.*Filter.*count_star.*
-
-query I
-SELECT count(*) FROM t HAVING count(*) >= 0;
-----
-1000
-
-# ---------------------------------------------------------------------------
-# count(col) has identical guarantees: >= 0, never NULL
-# ---------------------------------------------------------------------------
-
+# same guarantees apply to count(col)
 query II
 EXPLAIN SELECT count(x) FROM t HAVING count(x) < 0;
 ----
@@ -92,11 +49,37 @@ query I
 SELECT count(x) FROM t HAVING count(x) < 0;
 ----
 
+# grouped: each group has >= 1 row, so count(*) = 0 folds to Empty Result
 query II
-EXPLAIN SELECT count(x) FROM t HAVING count(x) IS NULL;
+EXPLAIN SELECT x % 4 g, count(*) FROM t GROUP BY g HAVING count(*) = 0;
 ----
 physical_plan	<REGEX>:.*Empty Result.*
 
 query I
-SELECT count(x) FROM t HAVING count(x) IS NULL;
+SELECT count(*) FROM (SELECT x % 4 g, count(*) FROM t GROUP BY g HAVING count(*) = 0);
+----
+0
+
+# grouped: count(*) > 0 is always true, filter is dropped
+query II
+EXPLAIN SELECT x % 4 g, count(*) FROM t GROUP BY g HAVING count(*) > 0;
+----
+physical_plan	<!REGEX>:.*Filter.*count_star.*
+
+query II
+SELECT x % 4 g, count(*) FROM t GROUP BY g HAVING count(*) > 0 ORDER BY g;
+----
+0	5
+1	5
+2	5
+3	5
+
+# guardrail: GROUPING SETS containing () aggregates over all rows, so count = 0 is possible
+query II
+EXPLAIN SELECT x % 4 g, count(*) FROM t GROUP BY GROUPING SETS ((), (g)) HAVING count(*) < 1;
+----
+physical_plan	<!REGEX>:.*Empty Result.*
+
+query II
+SELECT x % 4 g, count(*) FROM t GROUP BY GROUPING SETS ((), (g)) HAVING count(*) < 1 ORDER BY g;
 ----

--- a/test/sql/optimizer/count_aggregate_stats_propagation.test
+++ b/test/sql/optimizer/count_aggregate_stats_propagation.test
@@ -1,5 +1,5 @@
 # name: test/sql/optimizer/count_aggregate_stats_propagation.test
-# description: count / count_star propagate that they are >= 0, never NULL, and >= 1 when grouped
+# description: count / count_star propagate that they are >= 0 and never NULL
 # group: [optimizer]
 
 statement ok
@@ -47,39 +47,4 @@ physical_plan	<REGEX>:.*Empty Result.*
 
 query I
 SELECT count(x) FROM t HAVING count(x) < 0;
-----
-
-# grouped: each group has >= 1 row, so count(*) = 0 folds to Empty Result
-query II
-EXPLAIN SELECT x % 4 g, count(*) FROM t GROUP BY g HAVING count(*) = 0;
-----
-physical_plan	<REGEX>:.*Empty Result.*
-
-query I
-SELECT count(*) FROM (SELECT x % 4 g, count(*) FROM t GROUP BY g HAVING count(*) = 0);
-----
-0
-
-# grouped: count(*) > 0 is always true, filter is dropped
-query II
-EXPLAIN SELECT x % 4 g, count(*) FROM t GROUP BY g HAVING count(*) > 0;
-----
-physical_plan	<!REGEX>:.*Filter.*count_star.*
-
-query II
-SELECT x % 4 g, count(*) FROM t GROUP BY g HAVING count(*) > 0 ORDER BY g;
-----
-0	5
-1	5
-2	5
-3	5
-
-# guardrail: GROUPING SETS containing () aggregates over all rows, so count = 0 is possible
-query II
-EXPLAIN SELECT x % 4 g, count(*) FROM t GROUP BY GROUPING SETS ((), (g)) HAVING count(*) < 1;
-----
-physical_plan	<!REGEX>:.*Empty Result.*
-
-query II
-SELECT x % 4 g, count(*) FROM t GROUP BY GROUPING SETS ((), (g)) HAVING count(*) < 1 ORDER BY g;
 ----

--- a/test/sql/optimizer/count_aggregate_stats_propagation.test
+++ b/test/sql/optimizer/count_aggregate_stats_propagation.test
@@ -1,0 +1,102 @@
+# name: test/sql/optimizer/count_aggregate_stats_propagation.test
+# description: count / count_star always return non-negative BIGINT and never NULL; propagate that
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t(x INTEGER NOT NULL);
+
+statement ok
+INSERT INTO t SELECT range FROM range(0, 1000);
+
+# ---------------------------------------------------------------------------
+# count(*) is always >= 0, so out-of-range HAVING folds to Empty Result
+# ---------------------------------------------------------------------------
+
+query II
+EXPLAIN SELECT count(*) FROM t HAVING count(*) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM t HAVING count(*) < 0;
+----
+
+query II
+EXPLAIN SELECT count(*) FROM t HAVING count(*) = -5;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM t HAVING count(*) = -5;
+----
+
+# GROUP BY variant: filter is provably false per group as well
+query II
+EXPLAIN SELECT x, count(*) FROM t GROUP BY x HAVING count(*) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM (SELECT x, count(*) FROM t GROUP BY x HAVING count(*) < 0);
+----
+0
+
+# ---------------------------------------------------------------------------
+# count(*) is never NULL, so IS NULL folds to Empty Result and IS NOT NULL to
+# an unconditional pass-through
+# ---------------------------------------------------------------------------
+
+query II
+EXPLAIN SELECT count(*) FROM t HAVING count(*) IS NULL;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(*) FROM t HAVING count(*) IS NULL;
+----
+
+query II
+EXPLAIN SELECT count(*) FROM t HAVING count(*) IS NOT NULL;
+----
+physical_plan	<!REGEX>:.*Filter.*IS NOT NULL.*
+
+query I
+SELECT count(*) FROM t HAVING count(*) IS NOT NULL;
+----
+1000
+
+# ---------------------------------------------------------------------------
+# Always-true HAVING should have its filter dropped
+# ---------------------------------------------------------------------------
+
+query II
+EXPLAIN SELECT count(*) FROM t HAVING count(*) >= 0;
+----
+physical_plan	<!REGEX>:.*Filter.*count_star.*
+
+query I
+SELECT count(*) FROM t HAVING count(*) >= 0;
+----
+1000
+
+# ---------------------------------------------------------------------------
+# count(col) has identical guarantees: >= 0, never NULL
+# ---------------------------------------------------------------------------
+
+query II
+EXPLAIN SELECT count(x) FROM t HAVING count(x) < 0;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(x) FROM t HAVING count(x) < 0;
+----
+
+query II
+EXPLAIN SELECT count(x) FROM t HAVING count(x) IS NULL;
+----
+physical_plan	<REGEX>:.*Empty Result.*
+
+query I
+SELECT count(x) FROM t HAVING count(x) IS NULL;
+----


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Statistics encode safe invariants for COUNT (non-null, ≥0); incorrect bounds would only affect optimization, and tests lock in expected pruning behavior.
> 
> **Overview**
> **`count` and `count_star` now publish aggregate statistics** instead of returning none from their statistics callbacks. A shared `MakeCountStats` helper marks results as non-null, bounded below by 0, and capped at `node_stats.max_cardinality` when available (otherwise `BIGINT` max).
> 
> `CountPropagateStats` still rewrites non-distinct `count(col)` on NOT NULL inputs to `count_star`, but **now also returns these stats**. **`count_star` gets a new `CountStarPropagateStats` callback** wired in `GetFunction()`.
> 
> The optimizer can **fold impossible predicates** (e.g. `HAVING count(*) < 0` or `IS NULL`) to empty results and **drop redundant `IS NOT NULL` filters** on count outputs. New `count_aggregate_stats_propagation.test` covers this; `mode_rewrite.test` relaxes an EXPLAIN regex to allow `sum_no_overflow` in optimized plans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dddce0974909cd6501dbb5db8cccef782c9e8b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->