### PR TITLE
Hjiang/issue 25164

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -1466,14 +1466,14 @@ void StringValueScanner::ProcessOverBufferValue() {
 						} else {
 							result.AddRow(result, previous_buffer_handle->actual_size);
 						}
-						state_machine->Transition(states, buffer_handle_ptr[iterator.pos.buffer_pos++]);
-						while (iterator.pos.buffer_pos < cur_buffer_handle->actual_size &&
-						       (buffer_handle_ptr[iterator.pos.buffer_pos] == '\r' ||
-						        buffer_handle_ptr[iterator.pos.buffer_pos] == '\n')) {
-							state_machine->Transition(states, buffer_handle_ptr[iterator.pos.buffer_pos++]);
-						}
-						return;
 					}
+					state_machine->Transition(states, buffer_handle_ptr[iterator.pos.buffer_pos++]);
+					while (iterator.pos.buffer_pos < cur_buffer_handle->actual_size &&
+					       (buffer_handle_ptr[iterator.pos.buffer_pos] == '\r' ||
+					        buffer_handle_ptr[iterator.pos.buffer_pos] == '\n')) {
+						state_machine->Transition(states, buffer_handle_ptr[iterator.pos.buffer_pos++]);
+					}
+					return;
 				} else {
 					if (iterator.pos.buffer_pos + 1 == cur_buffer_handle->actual_size) {
 						return;

--- a/test/sql/copy/csv/parallel/test_25164.test
+++ b/test/sql/copy/csv/parallel/test_25164.test
@@ -1,0 +1,51 @@
+# name: test/sql/copy/csv/parallel/test_25164.test
+# description: Test parallel CSV scanning with repeated carriage returns
+# group: [parallel]
+
+statement ok
+PRAGMA verify_parallelism
+
+# Place the first row's repeated carriage returns across a 4096-byte buffer boundary.
+statement ok
+COPY (
+	SELECT *
+	FROM (VALUES
+		(0::BIGINT, repeat('x', 4084)),
+		(1, 'y'),
+		(2, 'z')
+	) rows(id, val)
+) TO '{TEST_DIR}/issue_25164.csv' (FORMAT CSV, HEADER, NEW_LINE e'\r\r\n')
+
+query II
+SELECT count(*), count(DISTINCT id)
+FROM read_csv(
+	'{TEST_DIR}/issue_25164.csv',
+	auto_detect = false,
+	header = true,
+	delim = ',',
+	columns = {'id': 'BIGINT', 'val': 'VARCHAR'},
+	strict_mode = false,
+	ignore_errors = true,
+	max_line_size = 4096,
+	buffer_size = 4096,
+	parallel = true
+)
+----
+3	3
+
+query II
+SELECT count(*), count(DISTINCT id)
+FROM read_csv(
+	'{TEST_DIR}/issue_25164.csv',
+	auto_detect = false,
+	header = true,
+	delim = ',',
+	columns = {'id': 'BIGINT', 'val': 'VARCHAR'},
+	strict_mode = false,
+	ignore_errors = true,
+	max_line_size = 4096,
+	buffer_size = 4096,
+	parallel = false
+)
+----
+3	3


### PR DESCRIPTION
https://github.com/duckdb/duckdb/issues/25164

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parallel CSV boundary logic in the hot string scanner path; regression is narrow but incorrect parsing could still affect row boundaries in similar newline/buffer edge cases.
> 
> **Overview**
> Fixes incorrect row counts when **parallel** `read_csv` hits **CARRY_ON** line endings (e.g. `\r\r\n`) with extra carriage returns split across a **buffer boundary**—a case that shows up on long first rows with a small `buffer_size`.
> 
> In `ProcessOverBufferValue`, when finishing an empty over-buffer value at a scan boundary, the scanner now **always** runs the state-machine transition and skips trailing `\r`/`\n` after seeing `\r` in the new buffer, instead of doing that only inside the `last_position` vs previous-buffer-size check. Row/value finalization stays gated on that check; newline consumption no longer depends on it.
> 
> Adds `test_25164.test`: CSV with `NEW_LINE e'\r\r\n'`, 4096-byte buffers, and a first field sized so repeated CRs cross the boundary; asserts 3 rows and 3 distinct ids for both `parallel = true` and `parallel = false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c83c4de11261642181c3a0c21d99c2d450379575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->