### PR TITLE
Hjiang/issue 25166

### DIFF
--- a/extension/core_functions/scalar/string/printf.cpp
+++ b/extension/core_functions/scalar/string/printf.cpp
@@ -6,11 +6,62 @@
 
 namespace duckdb {
 
+struct UTF8Character {
+	explicit UTF8Character(uint8_t value) {
+		data[0] = UnsafeNumericCast<char>(0xC0 | (value >> 6));
+		data[1] = UnsafeNumericCast<char>(0x80 | (value & 0x3F));
+	}
+
+	idx_t size() const {
+		return 2;
+	}
+
+	idx_t width() const {
+		return 1;
+	}
+
+	template <class ITERATOR>
+	void operator()(ITERATOR &&iterator) const {
+		*iterator++ = data[0];
+		*iterator++ = data[1];
+	}
+
+	char data[2];
+};
+
+class UTF8PrintfArgFormatter : public duckdb_fmt::printf_arg_formatter<duckdb_fmt::buffer_range<char>> {
+public:
+	using Base = duckdb_fmt::printf_arg_formatter<duckdb_fmt::buffer_range<char>>;
+	using iterator = typename Base::iterator;
+	using Context = duckdb_fmt::basic_printf_context<iterator, char>;
+	using Base::operator();
+
+	UTF8PrintfArgFormatter(iterator iterator, duckdb_fmt::basic_format_specs<char> &specs, Context &context)
+	    : Base(iterator, specs, context) {
+	}
+
+	iterator operator()(char value) {
+		auto codepoint = static_cast<uint8_t>(value);
+		if (codepoint < 0x80) {
+			return Base::operator()(value);
+		}
+		auto &format_specs = *this->specs();
+		format_specs.sign = duckdb_fmt::sign::none;
+		format_specs.alt = false;
+		format_specs.align = duckdb_fmt::align::right;
+		this->writer().write_padded(format_specs, UTF8Character(codepoint));
+		return this->out();
+	}
+};
+
 struct FMTPrintf {
 	template <class CTX>
 	static string OP(const char *format_str, vector<duckdb_fmt::basic_format_arg<CTX>> &format_args) {
-		return duckdb_fmt::vsprintf(
-		    format_str, duckdb_fmt::basic_format_args<CTX>(format_args.data(), static_cast<int>(format_args.size())));
+		duckdb_fmt::basic_memory_buffer<char> buffer;
+		duckdb_fmt::vprintf<UTF8PrintfArgFormatter>(
+		    buffer, duckdb_fmt::string_view(format_str),
+		    duckdb_fmt::basic_format_args<CTX>(format_args.data(), static_cast<int>(format_args.size())));
+		return duckdb_fmt::to_string(buffer);
 	}
 };
 

--- a/test/sql/function/string/issue_25166.test
+++ b/test/sql/function/string/issue_25166.test
@@ -1,0 +1,13 @@
+# name: test/sql/function/string/issue_25166.test
+# description: Issue #25166: printf %c must return valid UTF-8
+# group: [string]
+
+query TTTTTT
+SELECT hex(printf('%c', 255)),
+       hex(lower(printf('%c', 255))),
+       hex(upper(printf('%c', 255))),
+       hex(rtrim(printf('%c', 255))),
+       hex(trim(printf('%c', 255))),
+       hex(strip_accents(printf('%c', 255)));
+----
+C3BF	C3BF	C5B8	C3BF	C3BF	79

--- a/test/sql/function/string/issue_25166.test
+++ b/test/sql/function/string/issue_25166.test
@@ -11,3 +11,8 @@ SELECT hex(printf('%c', 255)),
        hex(strip_accents(printf('%c', 255)));
 ----
 C3BF	C3BF	C5B8	C3BF	C3BF	79
+
+query TT
+SELECT hex(printf('%c', 128)), hex(printf('%c%c', 195, 191));
+----
+C280	C383C2BF


### PR DESCRIPTION
https://github.com/duckdb/duckdb/issues/25166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `printf` formatting behavior for all `%c` arguments with values ≥ 128, which may alter existing query results but aligns VARCHAR with valid UTF-8.
> 
> **Overview**
> Fixes **issue #25166** where `printf('%c', n)` for `n` in 128–255 produced a single invalid UTF-8 byte, breaking downstream string functions.
> 
> **`printf` / `FMTPrintf`** now routes formatting through a custom `UTF8PrintfArgFormatter` instead of `vsprintf`. For `%c`, ASCII bytes still format as before; values ≥ `0x80` are emitted as **2-byte UTF-8** via a small `UTF8Character` helper (with padding/alignment handled through the fmt writer).
> 
> Adds regression tests in `issue_25166.test` covering `hex(printf('%c', 255))`, string transforms on that output, and `%c` for 128 vs paired bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3782199828a99879e317dfc970aec0a301ee0138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->