### PR TITLE
[IMPORTANT] Hjiang/default value struct

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -585,6 +585,32 @@ unique_ptr<ParsedExpression> PackExpression(unique_ptr<ParsedExpression> expr, I
 	return make_uniq<FunctionExpression>("struct_pack", std::move(children));
 }
 
+static unique_ptr<ParsedExpression> MergeNestedDefaults(unique_ptr<ParsedExpression> existing,
+                                                        unique_ptr<ParsedExpression> added) {
+	if (!existing) {
+		return added;
+	}
+	auto &existing_function = existing->Cast<FunctionExpression>();
+	auto &added_function = added->Cast<FunctionExpression>();
+	D_ASSERT(existing_function.FunctionName() == "struct_pack");
+	D_ASSERT(added_function.FunctionName() == "struct_pack");
+
+	auto &existing_arguments = existing_function.GetArgumentsMutable();
+	for (auto &added_argument : added_function.GetArgumentsMutable()) {
+		auto existing_entry =
+		    std::find_if(existing_arguments.begin(), existing_arguments.end(), [&](const FunctionArgument &argument) {
+			    return argument.GetName() == added_argument.GetName();
+		    });
+		if (existing_entry == existing_arguments.end()) {
+			existing_arguments.emplace_back(added_argument.GetName(), std::move(added_argument.GetExpressionMutable()));
+			continue;
+		}
+		existing_entry->GetExpressionMutable() = MergeNestedDefaults(std::move(existing_entry->GetExpressionMutable()),
+		                                                             std::move(added_argument.GetExpressionMutable()));
+	}
+	return existing;
+}
+
 static child_list_t<LogicalType> GetChildList(const LogicalType &type) {
 	child_list_t<LogicalType> child_types;
 	switch (type.id()) {
@@ -605,6 +631,48 @@ static child_list_t<LogicalType> GetChildList(const LogicalType &type) {
 		throw BinderException("Can't ConstructMapping for type '%s'", type.ToString());
 	}
 	return child_types;
+}
+
+static bool TransformNestedDefaults(ParsedExpression &defaults, const LogicalType &type,
+                                    const vector<Identifier> &column_path, idx_t depth,
+                                    optional_ptr<const Identifier> new_name) {
+	auto &function = defaults.Cast<FunctionExpression>();
+	D_ASSERT(function.FunctionName() == "struct_pack");
+	auto child_types = GetChildList(type);
+	auto path_name = column_path[depth];
+	if (type.id() == LogicalTypeId::LIST && path_name == "element") {
+		path_name = "list";
+	}
+
+	optional_ptr<const LogicalType> child_type;
+	for (auto &entry : child_types) {
+		if (entry.first == path_name) {
+			child_type = entry.second;
+			break;
+		}
+	}
+	D_ASSERT(child_type);
+
+	vector<FunctionArgument> transformed;
+	for (auto &argument : function.GetArgumentsMutable()) {
+		auto argument_name = argument.GetName();
+		auto argument_expression = std::move(argument.GetExpressionMutable());
+		if (argument_name != path_name) {
+			transformed.emplace_back(std::move(argument_name), std::move(argument_expression));
+			continue;
+		}
+		if (depth + 1 == column_path.size()) {
+			if (new_name) {
+				transformed.emplace_back(*new_name, std::move(argument_expression));
+			}
+			continue;
+		}
+		if (!TransformNestedDefaults(*argument_expression, *child_type, column_path, depth + 1, new_name)) {
+			transformed.emplace_back(std::move(argument_name), std::move(argument_expression));
+		}
+	}
+	function.GetArgumentsMutable() = std::move(transformed);
+	return function.GetArguments().empty();
 }
 
 static LogicalType ConstructNewType(const LogicalType &original_type, child_list_t<LogicalType> new_child_types) {
@@ -730,13 +798,17 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddField(ClientContext &context, AddFie
 	children.push_back(make_uniq<ConstantExpression>(Value(res.new_type)));
 	children.push_back(make_uniq<ConstantExpression>(ConstructMapping(col.Name(), col.Type())));
 	D_ASSERT(res.default_value);
+	auto nested_defaults = info.new_field.HasDefaultValue() ? res.default_value->Copy() : nullptr;
 	children.push_back(std::move(res.default_value));
 
 	auto function = make_uniq<FunctionExpression>("remap_struct", std::move(children));
 
 	ChangeColumnTypeInfo change_column_type(info.GetAlterEntryData(), info.column_path[0], std::move(res.new_type),
 	                                        std::move(function));
-	return ChangeColumnType(context, change_column_type, AlterTableType::ADD_FIELD);
+	return ChangeColumnType(context, change_column_type, AlterTableType::ADD_FIELD, [&](ColumnDefinition &column) {
+		auto defaults = column.HasNestedDefaults() ? column.NestedDefaults().Copy() : nullptr;
+		column.SetNestedDefaults(MergeNestedDefaults(std::move(defaults), std::move(nested_defaults)));
+	});
 }
 
 void DuckTableEntry::UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_index,
@@ -988,9 +1060,19 @@ unique_ptr<CatalogEntry> DuckTableEntry::RemoveField(ClientContext &context, Rem
 
 	auto function = make_uniq<FunctionExpression>("remap_struct", std::move(children));
 
+	auto old_type = col.Type();
 	ChangeColumnTypeInfo change_column_type(info.GetAlterEntryData(), info.column_path[0], std::move(res.new_type),
 	                                        std::move(function));
-	return ChangeColumnType(context, change_column_type, AlterTableType::REMOVE_FIELD);
+	return ChangeColumnType(context, change_column_type, AlterTableType::REMOVE_FIELD, [&](ColumnDefinition &column) {
+		if (!column.HasNestedDefaults()) {
+			return;
+		}
+		auto defaults = column.NestedDefaults().Copy();
+		if (TransformNestedDefaults(*defaults, old_type, info.column_path, 1, nullptr)) {
+			defaults.reset();
+		}
+		column.SetNestedDefaults(std::move(defaults));
+	});
 }
 
 DroppedFieldMapping RenameFieldFromStruct(const LogicalType &type, const vector<Identifier> &column_path,
@@ -1082,9 +1164,17 @@ unique_ptr<CatalogEntry> DuckTableEntry::RenameField(ClientContext &context, Ren
 	children.push_back(make_uniq<ConstantExpression>(Value()));
 
 	auto function = make_uniq<FunctionExpression>("remap_struct", std::move(children));
+	auto old_type = col.Type();
 	ChangeColumnTypeInfo change_column_type(info.GetAlterEntryData(), info.column_path[0], std::move(res.new_type),
 	                                        std::move(function));
-	return ChangeColumnType(context, change_column_type, AlterTableType::RENAME_FIELD);
+	return ChangeColumnType(context, change_column_type, AlterTableType::RENAME_FIELD, [&](ColumnDefinition &column) {
+		if (!column.HasNestedDefaults()) {
+			return;
+		}
+		auto defaults = column.NestedDefaults().Copy();
+		TransformNestedDefaults(*defaults, old_type, info.column_path, 1, info.new_name);
+		column.SetNestedDefaults(std::move(defaults));
+	});
 }
 
 unique_ptr<CatalogEntry> DuckTableEntry::SetDefault(ClientContext &context, SetDefaultInfo &info) {
@@ -1173,7 +1263,8 @@ unique_ptr<CatalogEntry> DuckTableEntry::DropNotNull(ClientContext &context, Dro
 }
 
 unique_ptr<CatalogEntry> DuckTableEntry::ChangeColumnType(ClientContext &context, ChangeColumnTypeInfo &info,
-                                                          AlterTableType alter_table_type) {
+                                                          AlterTableType alter_table_type,
+                                                          const std::function<void(ColumnDefinition &)> &callback) {
 	// Bind type
 	auto type_binder = Binder::CreateBinder(context);
 	type_binder->SetSearchPath(catalog, schema.name);
@@ -1212,6 +1303,9 @@ unique_ptr<CatalogEntry> DuckTableEntry::ChangeColumnType(ClientContext &context
 			if (alter_table_type == AlterTableType::RENAME_FIELD && copy.HasDefaultValue()) {
 				copy.SetDefaultValue(
 				    RemapStructDefault(copy.DefaultValue().Copy(), info.target_type, GetRemapStructMapping(info)));
+			}
+			if (callback) {
+				callback(copy);
 			}
 		}
 		// TODO: check if the generated_expression breaks, only delete it if it does

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -9,13 +9,17 @@
 #include "duckdb/main/settings.hpp"
 #include "duckdb/parser/constraints/list.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/constraints/bound_check_constraint.hpp"
+#include "duckdb/planner/expression_binder/constant_binder.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_update.hpp"
+#include "duckdb/function/scalar/struct_functions.hpp"
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/planner/column_binding.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
@@ -355,18 +359,135 @@ bool TableCatalogEntry::HasPrimaryKey() const {
 }
 
 LogicalType TableCatalogEntry::GetExpectedTypeForInsert(const ColumnDefinition &column) const {
+	if (column.HasNestedDefaults()) {
+		return LogicalType::INVALID;
+	}
 	return column.Type();
+}
+
+static child_list_t<LogicalType> GetRemappableChildren(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::STRUCT:
+		return StructType::GetChildTypes(type);
+	case LogicalTypeId::LIST:
+		return {{"list", ListType::GetChildType(type)}};
+	case LogicalTypeId::MAP:
+		return {{"key", MapType::KeyType(type)}, {"value", MapType::ValueType(type)}};
+	default:
+		throw InternalException("Cannot get nested defaults for type %s", type);
+	}
+}
+
+static optional_ptr<const ParsedExpression> FindNestedDefault(const ParsedExpression &defaults,
+                                                              const Identifier &name) {
+	if (defaults.GetExpressionClass() != ExpressionClass::FUNCTION) {
+		throw InternalException("Nested defaults must be stored as a struct_pack expression");
+	}
+	auto &function = defaults.Cast<FunctionExpression>();
+	if (function.FunctionName() != "struct_pack") {
+		throw InternalException("Nested defaults must be stored as a struct_pack expression");
+	}
+	for (auto &argument : function.GetArguments()) {
+		if (argument.GetName() == name) {
+			return argument.GetExpression();
+		}
+	}
+	return nullptr;
+}
+
+static unique_ptr<ParsedExpression> BuildNestedDefaults(const LogicalType &source_type, const LogicalType &target_type,
+                                                        optional_ptr<const ParsedExpression> stored_defaults) {
+	auto source_children = GetRemappableChildren(source_type);
+	auto target_children = GetRemappableChildren(target_type);
+	identifier_map_t<LogicalType> source_map;
+	for (auto &child : source_children) {
+		source_map.emplace(child.first, child.second);
+	}
+
+	vector<FunctionArgument> defaults;
+	for (auto &target_child : target_children) {
+		auto source_entry = source_map.find(target_child.first);
+		auto stored_default = stored_defaults ? FindNestedDefault(*stored_defaults, target_child.first)
+		                                      : optional_ptr<const ParsedExpression>();
+		if (source_entry == source_map.end()) {
+			auto default_value =
+			    stored_default ? stored_default->Copy() : make_uniq<ConstantExpression>(Value(target_child.second));
+			defaults.emplace_back(target_child.first, std::move(default_value));
+			continue;
+		}
+		if (source_entry->second == target_child.second || !source_entry->second.IsNested() ||
+		    !target_child.second.IsNested() || source_entry->second.id() != target_child.second.id()) {
+			continue;
+		}
+		auto child_defaults = BuildNestedDefaults(source_entry->second, target_child.second, stored_default);
+		if (child_defaults) {
+			defaults.emplace_back(target_child.first, std::move(child_defaults));
+		}
+	}
+	if (defaults.empty()) {
+		return nullptr;
+	}
+	return make_uniq<FunctionExpression>("struct_pack", std::move(defaults));
+}
+
+static Value ConstructRemapMapping(const LogicalType &source_type, const LogicalType &target_type) {
+	auto source_children = GetRemappableChildren(source_type);
+	auto target_children = GetRemappableChildren(target_type);
+	identifier_map_t<LogicalType> target_map;
+	for (auto &child : target_children) {
+		target_map.emplace(child.first, child.second);
+	}
+
+	child_list_t<Value> mapping;
+	for (auto &source_child : source_children) {
+		auto target_entry = target_map.find(source_child.first);
+		if (target_entry == target_map.end()) {
+			continue;
+		}
+		Value mapping_value(source_child.first);
+		if (source_child.second.IsNested() && target_entry->second.IsNested() &&
+		    source_child.second.id() == target_entry->second.id()) {
+			vector<Value> nested_mapping;
+			nested_mapping.emplace_back(source_child.first);
+			nested_mapping.push_back(ConstructRemapMapping(source_child.second, target_entry->second));
+			mapping_value = Value::TUPLE(std::move(nested_mapping));
+		}
+		mapping.emplace_back(source_child.first, std::move(mapping_value));
+	}
+	return Value::STRUCT(std::move(mapping));
 }
 
 unique_ptr<Expression> TableCatalogEntry::GetDefaultExpressionForColumn(ClientContext &context,
                                                                         const LogicalType &input_type,
-                                                                        const LogicalType &result_type,
+                                                                        const ColumnDefinition &column,
                                                                         ColumnBinding binding,
                                                                         const Expression &constant_value) const {
-	(void)context;
 	(void)constant_value;
-	return BoundCastExpression::AddCastToType(context, make_uniq<BoundColumnRefExpression>(input_type, binding),
-	                                          result_type);
+	return ApplyNestedDefaults(context, make_uniq<BoundColumnRefExpression>(input_type, binding), column);
+}
+
+unique_ptr<Expression> TableCatalogEntry::ApplyNestedDefaults(ClientContext &context, unique_ptr<Expression> input,
+                                                              const ColumnDefinition &column) {
+	auto &input_type = input->GetReturnType();
+	if (!column.HasNestedDefaults() || input_type == column.Type() || !input_type.IsNested() ||
+	    input_type.id() != column.Type().id()) {
+		return BoundCastExpression::AddCastToType(context, std::move(input), column.Type());
+	}
+
+	auto defaults = BuildNestedDefaults(input_type, column.Type(), column.NestedDefaults());
+	if (!defaults) {
+		return BoundCastExpression::AddCastToType(context, std::move(input), column.Type());
+	}
+	auto binder = Binder::CreateBinder(context);
+	ConstantBinder default_binder(*binder, context, "nested DEFAULT value");
+	auto bound_defaults = default_binder.Bind(defaults);
+
+	vector<unique_ptr<Expression>> children;
+	children.push_back(std::move(input));
+	children.push_back(make_uniq<BoundConstantExpression>(Value(column.Type())));
+	children.push_back(make_uniq<BoundConstantExpression>(ConstructRemapMapping(input_type, column.Type())));
+	children.push_back(std::move(bound_defaults));
+	return RemapStructFun::GetFunction().Bind(context, std::move(children));
 }
 
 virtual_column_map_t TableCatalogEntry::GetVirtualColumns() const {

--- a/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
@@ -87,7 +87,8 @@ private:
 	unique_ptr<CatalogEntry> RemoveField(ClientContext &context, RemoveFieldInfo &info);
 	unique_ptr<CatalogEntry> SetDefault(ClientContext &context, SetDefaultInfo &info);
 	unique_ptr<CatalogEntry> ChangeColumnType(ClientContext &context, ChangeColumnTypeInfo &info,
-	                                          AlterTableType alter_table_type);
+	                                          AlterTableType alter_table_type,
+	                                          const std::function<void(ColumnDefinition &)> &callback = nullptr);
 	unique_ptr<CatalogEntry> SetNotNull(ClientContext &context, SetNotNullInfo &info);
 	unique_ptr<CatalogEntry> DropNotNull(ClientContext &context, DropNotNullInfo &info);
 	unique_ptr<CatalogEntry> AddForeignKeyConstraint(AlterForeignKeyInfo &info);

--- a/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
@@ -141,8 +141,10 @@ public:
 
 	virtual LogicalType GetExpectedTypeForInsert(const ColumnDefinition &column) const;
 	virtual unique_ptr<Expression> GetDefaultExpressionForColumn(ClientContext &context, const LogicalType &input_type,
-	                                                             const LogicalType &result_type, ColumnBinding binding,
+	                                                             const ColumnDefinition &column, ColumnBinding binding,
 	                                                             const Expression &constant_value) const;
+	static unique_ptr<Expression> ApplyNestedDefaults(ClientContext &context, unique_ptr<Expression> input,
+	                                                  const ColumnDefinition &column);
 
 	//! Returns the virtual columns for this table
 	virtual virtual_column_map_t GetVirtualColumns() const;

--- a/src/include/duckdb/parser/column_definition.hpp
+++ b/src/include/duckdb/parser/column_definition.hpp
@@ -34,6 +34,11 @@ public:
 	bool HasDefaultValue() const;
 	void SetDefaultValue(unique_ptr<ParsedExpression> default_value);
 
+	//! defaults for fields added to nested column types
+	const ParsedExpression &NestedDefaults() const;
+	bool HasNestedDefaults() const;
+	void SetNestedDefaults(unique_ptr<ParsedExpression> nested_defaults);
+
 	//! type
 	DUCKDB_API const LogicalType &Type() const;
 	LogicalType &TypeMutable();
@@ -107,6 +112,8 @@ private:
 	//! The default value of the column (for non-generated columns)
 	//! The generated column expression (for generated columns)
 	unique_ptr<ParsedExpression> expression;
+	//! Defaults for fields added to nested column types
+	unique_ptr<ParsedExpression> nested_defaults;
 	//! Comment on this column
 	Value comment;
 	//! Tags on this column

--- a/src/include/duckdb/parser/tableref/expressionlistref.hpp
+++ b/src/include/duckdb/parser/tableref/expressionlistref.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/parser/tableref.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
+#include "duckdb/parser/column_definition.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/vector.hpp"
 
@@ -31,6 +32,8 @@ public:
 	vector<LogicalType> expected_types;
 	//! Expected table names.
 	vector<Identifier> expected_names;
+	//! Expected table columns, when binding an INSERT.
+	vector<ColumnDefinition> expected_columns;
 
 public:
 	string ToString() const override;

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -515,6 +515,11 @@
         "name": "tags",
         "type": "InsertionOrderPreservingMap<string>",
         "default": "InsertionOrderPreservingMap<string>()"
+      },
+      {
+        "id": 107,
+        "name": "nested_defaults",
+        "type": "ParsedExpression*"
       }
     ],
     "constructor": [

--- a/src/include/duckdb/storage/serialization/tableref.json
+++ b/src/include/duckdb/storage/serialization/tableref.json
@@ -245,6 +245,11 @@
         "id": 202,
         "name": "values",
         "type": "vector<vector<ParsedExpression*>>"
+      },
+      {
+        "id": 203,
+        "name": "expected_columns",
+        "type": "vector<ColumnDefinition>"
       }
     ]
   },

--- a/src/parser/column_definition.cpp
+++ b/src/parser/column_definition.cpp
@@ -21,6 +21,7 @@ ColumnDefinition ColumnDefinition::Copy() const {
 	copy.oid = oid;
 	copy.storage_oid = storage_oid;
 	copy.expression = expression ? expression->Copy() : nullptr;
+	copy.nested_defaults = nested_defaults ? nested_defaults->Copy() : nullptr;
 	copy.compression_type = compression_type;
 	copy.category = category;
 	copy.comment = comment;
@@ -50,6 +51,19 @@ void ColumnDefinition::SetDefaultValue(unique_ptr<ParsedExpression> default_valu
 		throw InternalException("Calling SetDefaultValue() on a generated column");
 	}
 	this->expression = std::move(default_value);
+}
+
+const ParsedExpression &ColumnDefinition::NestedDefaults() const {
+	D_ASSERT(HasNestedDefaults());
+	return *nested_defaults;
+}
+
+bool ColumnDefinition::HasNestedDefaults() const {
+	return nested_defaults != nullptr;
+}
+
+void ColumnDefinition::SetNestedDefaults(unique_ptr<ParsedExpression> new_nested_defaults) {
+	nested_defaults = std::move(new_nested_defaults);
 }
 
 const LogicalType &ColumnDefinition::Type() const {

--- a/src/parser/tableref/expressionlistref.cpp
+++ b/src/parser/tableref/expressionlistref.cpp
@@ -57,6 +57,9 @@ unique_ptr<TableRef> ExpressionListRef::Copy() {
 	}
 	result->expected_names = expected_names;
 	result->expected_types = expected_types;
+	for (auto &column : expected_columns) {
+		result->expected_columns.push_back(column.Copy());
+	}
 	CopyProperties(*result);
 	return std::move(result);
 }

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -75,6 +75,8 @@ void Binder::ExpandDefaultInValuesList(InsertQueryNode &node, TableCatalogEntry 
 	auto &expr_list = values_list->Cast<ExpressionListRef>();
 	expr_list.expected_types.resize(expected_columns);
 	expr_list.expected_names.resize(expected_columns);
+	expr_list.expected_columns.clear();
+	expr_list.expected_columns.reserve(expected_columns);
 
 	D_ASSERT(!expr_list.values.empty());
 	CheckInsertColumnCountMismatch(expected_columns, expr_list.values[0].size(), !node.columns.empty(), table.name);
@@ -88,6 +90,7 @@ void Binder::ExpandDefaultInValuesList(InsertQueryNode &node, TableCatalogEntry 
 		auto &column = table.GetColumn(table_col_idx);
 		expr_list.expected_types[col_idx] = table.GetExpectedTypeForInsert(column);
 		expr_list.expected_names[col_idx] = column.Name();
+		expr_list.expected_columns.push_back(column.Copy());
 
 		// now replace any DEFAULT values with the corresponding default expression
 		for (idx_t list_idx = 0; list_idx < expr_list.values.size(); list_idx++) {
@@ -113,7 +116,7 @@ unique_ptr<LogicalOperator> Binder::ResolveInputProjection(LogicalInsert &insert
 		}
 		auto &original_type = source_types[mapped_index];
 		auto source_binding = source_bindings[mapped_index];
-		auto expression = table.GetDefaultExpressionForColumn(context, original_type, col.Type(), source_binding,
+		auto expression = table.GetDefaultExpressionForColumn(context, original_type, col, source_binding,
 		                                                      *insert.bound_defaults[storage_idx]);
 		if (!expression->HasQueryLocation() && root->type == LogicalOperatorType::LOGICAL_PROJECTION) {
 			expression->SetQueryLocation(root->expressions[mapped_index]->GetQueryLocation());

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -146,7 +146,7 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 				result->expressions.push_back(merge_into.bound_defaults[storage_idx]->Copy());
 			} else {
 				result->expressions.push_back(table.GetDefaultExpressionForColumn(
-				    context, insert_types[mapped_index], col.Type(), insert_bindings[mapped_index],
+				    context, insert_types[mapped_index], col, insert_bindings[mapped_index],
 				    *merge_into.bound_defaults[storage_idx]));
 			}
 		}

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -74,7 +74,7 @@ void Binder::BindUpdateSet(TableIndex proj_index, unique_ptr<LogicalOperator> &r
 			auto source_binding = ColumnBinding(proj_index, expr_index);
 
 			update_expressions.push_back(table.GetDefaultExpressionForColumn(
-			    context, bound_type, column.Type(), source_binding, *bound_defaults[column.StorageOid()]));
+			    context, bound_type, column, source_binding, *bound_defaults[column.StorageOid()]));
 		}
 	}
 }

--- a/src/planner/binder/tableref/bind_expressionlistref.cpp
+++ b/src/planner/binder/tableref/bind_expressionlistref.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/operator/logical_expression_get.hpp"
 #include "duckdb/planner/operator/logical_dummy_scan.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 
 namespace duckdb {
 
@@ -37,6 +38,11 @@ BoundStatement Binder::Bind(ExpressionListRef &expr) {
 				binder.target_type = LogicalType(LogicalTypeId::INVALID);
 			}
 			auto bound_expr = binder.Bind(expression_list[val_idx]);
+			if (!expr.expected_columns.empty()) {
+				D_ASSERT(expr.expected_columns.size() == expression_list.size());
+				bound_expr =
+				    TableCatalogEntry::ApplyNestedDefaults(context, std::move(bound_expr), expr.expected_columns[val_idx]);
+			}
 			list.push_back(std::move(bound_expr));
 		}
 		values.push_back(std::move(list));

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -223,6 +223,7 @@ void ColumnDefinition::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<duckdb::CompressionType>(104, "compression_type", compression_type);
 	serializer.WritePropertyWithDefault<Value>(105, "comment", comment, Value());
 	serializer.WritePropertyWithDefault<InsertionOrderPreservingMap<string>>(106, "tags", tags, InsertionOrderPreservingMap<string>());
+	serializer.WritePropertyWithDefault<unique_ptr<ParsedExpression>>(107, "nested_defaults", nested_defaults);
 }
 
 ColumnDefinition ColumnDefinition::Deserialize(Deserializer &deserializer) {
@@ -234,6 +235,7 @@ ColumnDefinition ColumnDefinition::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadProperty<duckdb::CompressionType>(104, "compression_type", result.compression_type);
 	deserializer.ReadPropertyWithExplicitDefault<Value>(105, "comment", result.comment, Value());
 	deserializer.ReadPropertyWithExplicitDefault<InsertionOrderPreservingMap<string>>(106, "tags", result.tags, InsertionOrderPreservingMap<string>());
+	deserializer.ReadPropertyWithDefault<unique_ptr<ParsedExpression>>(107, "nested_defaults", result.nested_defaults);
 	return result;
 }
 

--- a/src/storage/serialization/serialize_tableref.cpp
+++ b/src/storage/serialization/serialize_tableref.cpp
@@ -131,6 +131,7 @@ void ExpressionListRef::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<Identifier>>(200, "expected_names", expected_names);
 	serializer.WritePropertyWithDefault<vector<LogicalType>>(201, "expected_types", expected_types);
 	serializer.WritePropertyWithDefault<vector<vector<unique_ptr<ParsedExpression>>>>(202, "values", values);
+	serializer.WritePropertyWithDefault<vector<ColumnDefinition>>(203, "expected_columns", expected_columns);
 }
 
 unique_ptr<TableRef> ExpressionListRef::Deserialize(Deserializer &deserializer) {
@@ -138,6 +139,7 @@ unique_ptr<TableRef> ExpressionListRef::Deserialize(Deserializer &deserializer) 
 	deserializer.ReadPropertyWithDefault<vector<Identifier>>(200, "expected_names", result->expected_names);
 	deserializer.ReadPropertyWithDefault<vector<LogicalType>>(201, "expected_types", result->expected_types);
 	deserializer.ReadPropertyWithDefault<vector<vector<unique_ptr<ParsedExpression>>>>(202, "values", result->values);
+	deserializer.ReadPropertyWithDefault<vector<ColumnDefinition>>(203, "expected_columns", result->expected_columns);
 	return std::move(result);
 }
 

--- a/test/sql/alter/struct/add_col_struct.test
+++ b/test/sql/alter/struct/add_col_struct.test
@@ -77,3 +77,22 @@ statement error
 ALTER TABLE test ADD COLUMN s.x.a INTEGER
 ----
 does not exist
+
+# defaults on added fields apply to rows inserted after the alter
+statement ok
+CREATE TABLE test_added_field_default(s STRUCT(a INTEGER, b INTEGER))
+
+statement ok
+INSERT INTO test_added_field_default VALUES ({'a': 0, 'b': 0})
+
+statement ok
+ALTER TABLE test_added_field_default ADD COLUMN s.c INTEGER DEFAULT 9
+
+statement ok
+INSERT INTO test_added_field_default VALUES ({'a': 1, 'b': 2})
+
+query II
+SELECT s.a, s.c FROM test_added_field_default ORDER BY s.a
+----
+0	9
+1	9

--- a/test/sql/alter/struct/add_col_struct.test
+++ b/test/sql/alter/struct/add_col_struct.test
@@ -91,8 +91,69 @@ ALTER TABLE test_added_field_default ADD COLUMN s.c INTEGER DEFAULT 9
 statement ok
 INSERT INTO test_added_field_default VALUES ({'a': 1, 'b': 2})
 
-query II
-SELECT s.a, s.c FROM test_added_field_default ORDER BY s.a
+statement ok
+INSERT INTO test_added_field_default VALUES ({'a': 2, 'b': 3, 'c': 7})
+
+statement ok
+INSERT INTO test_added_field_default VALUES ({'a': 3, 'b': 4, 'c': NULL})
+
+statement ok
+INSERT INTO test_added_field_default VALUES ({'a': 4})
+
+query III
+SELECT s.a, s.b, s.c FROM test_added_field_default ORDER BY s.a
 ----
-0	9
-1	9
+0	0	9
+1	2	9
+2	3	7
+3	4	NULL
+4	NULL	9
+
+statement ok
+ALTER TABLE test_added_field_default ADD COLUMN s.d INTEGER DEFAULT 10
+
+statement ok
+INSERT INTO test_added_field_default VALUES ({'a': 5, 'b': 6, 'c': 8})
+
+query IIII
+SELECT s.a, s.b, s.c, s.d FROM test_added_field_default ORDER BY s.a
+----
+0	0	9	10
+1	2	9	10
+2	3	7	10
+3	4	NULL	10
+4	NULL	9	10
+5	6	8	10
+
+statement ok
+INSERT INTO test_added_field_default VALUES
+	({'a': 6, 'b': 7}),
+	({'a': 7, 'b': 8, 'c': 11, 'd': 12})
+
+query IIII
+SELECT s.a, s.b, s.c, s.d FROM test_added_field_default WHERE s.a >= 6 ORDER BY s.a
+----
+6	7	9	10
+7	8	11	12
+
+statement ok
+ALTER TABLE test_added_field_default RENAME s.c TO e
+
+statement ok
+INSERT INTO test_added_field_default VALUES ({'a': 8, 'b': 9})
+
+query III
+SELECT s.a, s.e, s.d FROM test_added_field_default WHERE s.a = 8
+----
+8	9	10
+
+statement ok
+ALTER TABLE test_added_field_default DROP COLUMN s.e
+
+statement ok
+INSERT INTO test_added_field_default VALUES ({'a': 9, 'b': 10})
+
+query III
+SELECT s.a, s.b, s.d FROM test_added_field_default WHERE s.a = 9
+----
+9	10	10

--- a/test/sql/alter/struct/add_col_struct_storage.test
+++ b/test/sql/alter/struct/add_col_struct_storage.test
@@ -1,0 +1,28 @@
+# name: test/sql/alter/struct/add_col_struct_storage.test
+# description: Test persistence of defaults on fields added to structs
+# group: [struct]
+
+load {TEST_DIR}/add_col_struct_storage.db
+
+statement ok
+CREATE TABLE test(s STRUCT(a INTEGER, b INTEGER))
+
+statement ok
+INSERT INTO test VALUES ({'a': 0, 'b': 0})
+
+statement ok
+ALTER TABLE test ADD COLUMN s.c INTEGER DEFAULT 9
+
+statement ok
+CHECKPOINT
+
+restart
+
+statement ok
+INSERT INTO test VALUES ({'a': 1, 'b': 2})
+
+query II
+SELECT s.a, s.c FROM test ORDER BY s.a
+----
+0	9
+1	9


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches catalog DDL, column serialization, and insert/update/merge expression binding for nested types; incorrect default merging could change row contents on insert after schema evolution.
> 
> **Overview**
> **Adds catalog metadata and insert-time logic so `DEFAULT` on `ALTER TABLE ... ADD COLUMN s.field` applies to new rows**, without rewriting existing stored values.
> 
> `ColumnDefinition` gains **`nested_defaults`** (a nested `struct_pack` of default expressions), persisted in serialization and maintained when nested fields are **added** (`MergeNestedDefaults`), **dropped**, or **renamed** (`TransformNestedDefaults`) via an optional callback on `ChangeColumnType`.
> 
> On **INSERT/UPDATE/MERGE** and **`VALUES`**, binding now passes full column definitions (`ExpressionListRef.expected_columns`) and **`ApplyNestedDefaults`** uses `remap_struct` to fill missing nested fields when the supplied struct type is narrower than the table column. Columns with nested defaults use **`GetExpectedTypeForInsert` → INVALID** so VALUES binding does not over-constrain partial struct literals.
> 
> Tests cover multi-field defaults, explicit overrides, rename/drop behavior, and **checkpoint/restart** persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27211854e35016f4a3688f4bd220cba77a5b4c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->