### PR TITLE
[NEED REVIEW] Hjiang/foreign pk fix

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -687,19 +687,21 @@ void DataTable::VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> stora
 
 	// Global constraint verification.
 	auto &data_table = table_entry.GetStorage();
-	data_table.info->indexes.VerifyForeignKey(storage ? &storage->delete_indexes : nullptr, dst_keys_ptr, dst_chunk,
+	auto &local_storage = LocalStorage::Get(context, db);
+	auto sibling_storage = local_storage.GetStorage(data_table);
+	auto sibling_delete_indexes = sibling_storage ? &sibling_storage->delete_indexes : nullptr;
+
+	data_table.info->indexes.VerifyForeignKey(sibling_delete_indexes, dst_keys_ptr, dst_chunk,
 	                                          global_conflict_manager);
 
 	// Check if we can insert the chunk into the local storage.
-	auto &local_storage = LocalStorage::Get(context, db);
 	bool local_error = false;
-	auto local_verification = local_storage.Find(data_table);
+	auto local_verification = sibling_storage != nullptr;
 
 	// Local constraint verification.
 	if (local_verification) {
 		auto &local_indexes = local_storage.GetIndexes(context, data_table);
-		local_indexes.VerifyForeignKey(storage ? &storage->delete_indexes : nullptr, dst_keys_ptr, dst_chunk,
-		                               local_conflict_manager);
+		local_indexes.VerifyForeignKey(sibling_delete_indexes, dst_keys_ptr, dst_chunk, local_conflict_manager);
 		local_error = IsForeignKeyConstraintError(local_conflict_manager, is_append, count);
 	}
 	// Global constraint verification.

--- a/test/sql/constraints/foreignkey/test_fk_transaction.test
+++ b/test/sql/constraints/foreignkey/test_fk_transaction.test
@@ -61,8 +61,10 @@ BEGIN TRANSACTION
 statement ok
 DELETE FROM pkt WHERE i = 1
 
-statement ok
+statement error
 INSERT INTO fkt VALUES (1)
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
 
 statement ok
 ROLLBACK
@@ -108,8 +110,10 @@ BEGIN TRANSACTION
 statement ok
 DELETE FROM pkt WHERE i = 3
 
-statement ok
+statement error
 INSERT INTO fkt VALUES (3)
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
 
 statement ok
 ROLLBACK

--- a/test/sql/constraints/foreignkey/test_fk_transaction.test
+++ b/test/sql/constraints/foreignkey/test_fk_transaction.test
@@ -147,3 +147,48 @@ DELETE FROM b
 
 statement ok
 DELETE FROM a
+
+statement ok
+COMMIT
+
+# Cross-table check: a parent DELETE followed by a child INSERT in the same
+# transaction must not commit a dangling foreign key reference.
+
+statement ok
+CREATE TABLE cross_fk_parent(id INTEGER PRIMARY KEY)
+
+statement ok
+CREATE TABLE cross_fk_child(pid INTEGER, FOREIGN KEY (pid) REFERENCES cross_fk_parent(id))
+
+statement ok
+INSERT INTO cross_fk_parent VALUES (1)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+DELETE FROM cross_fk_parent WHERE id = 1
+
+statement error
+INSERT INTO cross_fk_child VALUES (1)
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
+
+statement ok
+ROLLBACK
+
+query I
+SELECT count(*) FROM cross_fk_parent
+----
+1
+
+query I
+SELECT count(*) FROM cross_fk_child
+----
+0
+
+statement ok
+DROP TABLE cross_fk_child
+
+statement ok
+DROP TABLE cross_fk_parent


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes transactional foreign key enforcement in core storage code; behavior shifts for same-transaction parent/child updates, though coverage is expanded in FK transaction tests.
> 
> **Overview**
> **Fixes foreign key checks in multi-statement transactions** so inserts into a child table fail when the referenced parent key was deleted earlier in the same transaction (and similar cross-table cases that previously slipped through).
> 
> `VerifyForeignKeyConstraint` now loads **transaction-local storage for the referenced (PK) table** via `LocalStorage::GetStorage(data_table)` and passes that table’s `delete_indexes` into both global and local `VerifyForeignKey` calls. It no longer uses the optional `storage` argument from the table being inserted/deleted, which could point at the wrong table and miss in-flight parent deletes.
> 
> Local FK verification is gated on whether the **referenced** table has txn-local state (`sibling_storage != nullptr`), not whether the FK table appears in local storage.
> 
> Tests are tightened: same-transaction parent `DELETE` then child `INSERT` must raise a constraint error, including a dedicated `cross_fk_parent` / `cross_fk_child` scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec0cf0389cfad0a294524d9681a85024fdbd753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->