### PR TITLE
[IMPORTANT] Fix unbounded index leak

### DIFF
--- a/src/execution/index/unbound_index.cpp
+++ b/src/execution/index/unbound_index.cpp
@@ -33,7 +33,17 @@ UnboundIndex::UnboundIndex(unique_ptr<CreateInfo> create_info, IndexStorageInfo 
 	std::sort(mapped_column_ids.begin(), mapped_column_ids.end());
 }
 
+UnboundIndex::~UnboundIndex() {
+	if (!storage_reclaimed) {
+		ResetStorage();
+	}
+}
+
 void UnboundIndex::ResetStorage() {
+	if (storage_reclaimed) {
+		return;
+	}
+	storage_reclaimed = true;
 	auto &block_manager = table_io_manager.GetIndexBlockManager();
 	for (auto &info : storage_info.allocator_infos) {
 		for (auto &block : info.block_pointers) {
@@ -59,6 +69,7 @@ unique_ptr<BoundIndex> UnboundIndex::Bind(IndexBinder &binder, const vector<Logi
 	if (HasBufferedReplays()) {
 		bound_index->ApplyBufferedReplays(physical_column_types, buffered_replays, mapped_column_ids);
 	}
+	storage_reclaimed = true;
 	return bound_index;
 }
 

--- a/src/execution/index/unbound_index.cpp
+++ b/src/execution/index/unbound_index.cpp
@@ -66,10 +66,10 @@ IndexStorageInfo UnboundIndex::CopyStorageInfo() const {
 
 unique_ptr<BoundIndex> UnboundIndex::Bind(IndexBinder &binder, const vector<LogicalType> &physical_column_types) {
 	auto bound_index = binder.BindIndex(*this);
+	storage_reclaimed = true;
 	if (HasBufferedReplays()) {
 		bound_index->ApplyBufferedReplays(physical_column_types, buffered_replays, mapped_column_ids);
 	}
-	storage_reclaimed = true;
 	return bound_index;
 }
 

--- a/src/include/duckdb/execution/index/unbound_index.hpp
+++ b/src/include/duckdb/execution/index/unbound_index.hpp
@@ -75,9 +75,14 @@ private:
 	//! Derived from this index's column IDs at construction, deduplicated and sorted.
 	vector<StorageIndex> mapped_column_ids;
 
+	//! Whether persistent blocks referenced by `storage_info` have been reclaimed
+	//! or handed off to a bound index.
+	bool storage_reclaimed = false;
+
 public:
 	UnboundIndex(unique_ptr<CreateInfo> create_info, IndexStorageInfo storage_info, TableIOManager &table_io_manager,
 	             AttachedDatabase &db);
+	~UnboundIndex() override;
 
 public:
 	void ResetStorage() override;


### PR DESCRIPTION
Hi team, I wrote an [extension](https://github.com/dentiny/duckdb-table-inspector) to check the DuckDB file storage details, for example, how many index blocks do we have, and how many free blocks there are, etc.

## Issue statement
Via the following SQL statements, I found we could have a storage leak for unbounded index.
```sh
[~/Desktop/duckdb (main)] 
haojiang@HaoJiangs-MacBook-Pro$ duckdb /tmp/leak.db
DuckDB v1.5.5 (Variegata)
Enter ".help" for usage hints.
leak D INSTALL table_inspector FROM community;
leak D LOAD table_inspector;
leak D PRAGMA disable_checkpoint_on_shutdown;
leak D PRAGMA wal_autocheckpoint='1TB';
leak D CREATE TABLE t(a INTEGER);
leak D INSERT INTO t SELECT range FROM range(10000);
leak D CHECKPOINT;
leak D SELECT * FROM inspect_block_usage();
┌─────────────┬────────────┬────────────┬─────────────┐
│  component  │ size_bytes │ percentage │ block_count │
│   varchar   │   int64    │  varchar   │    int64    │
├─────────────┼────────────┼────────────┼─────────────┤
│ table_data  │     262144 │ 50.0%      │           1 │
│ index       │          0 │ 0.0%       │           0 │
│ metadata    │     262144 │ 50.0%      │           1 │
│ free_blocks │          0 │ 0.0%       │           0 │
│ total       │     524288 │ 100.0%     │           2 │
└─────────────┴────────────┴────────────┴─────────────┘
leak D SELECT COUNT(*) AS active_indexes FROM duckdb_indexes() WHERE table_name = 't';
┌────────────────┐
│ active_indexes │
│     int64      │
├────────────────┤
│              0 │
└────────────────┘

[~/Desktop/duckdb (main)]
haojiang@HaoJiangs-MacBook-Pro$ duckdb /tmp/leak.db
DuckDB v1.5.5 (Variegata)
Enter ".help" for usage hints.
leak D LOAD table_inspector;
leak D PRAGMA disable_checkpoint_on_shutdown;
leak D PRAGMA wal_autocheckpoint='1TB';
leak D BEGIN;
leak D CREATE INDEX idx_a ON t(a);
leak D DROP INDEX idx_a;
leak D COMMIT;

[~/Desktop/duckdb (main)] 
haojiang@HaoJiangs-MacBook-Pro$ duckdb /tmp/leak.db
DuckDB v1.5.5 (Variegata)
Enter ".help" for usage hints.
leak D LOAD table_inspector;
leak D PRAGMA disable_checkpoint_on_shutdown;
leak D PRAGMA wal_autocheckpoint='1TB';
leak D CHECKPOINT;
leak D SELECT * FROM inspect_block_usage();
┌─────────────┬────────────┬────────────┬─────────────┐
│  component  │ size_bytes │ percentage │ block_count │
│   varchar   │   int64    │  varchar   │    int64    │
├─────────────┼────────────┼────────────┼─────────────┤
│ table_data  │     262144 │ 16.7%      │           1 │
│ index       │    1048576 │ 66.7%      │           4 │
│ metadata    │     262144 │ 16.7%      │           1 │
│ free_blocks │          0 │ 0.0%       │           0 │
│ total       │    1572864 │ 100.0%     │           6 │
└─────────────┴────────────┴────────────┴─────────────┘
leak D SELECT COUNT(*) AS active_indexes FROM duckdb_indexes() WHERE table_name = 't';
┌────────────────┐
│ active_indexes │
│     int64      │
├────────────────┤
│              0 │
└────────────────┘
```
As you can tell the as we iterate on the "create and drop index", the index block number keeps growing, but free blocks count doesn't change, which indicates a storage leak.

## Root cause
During WAL replay, [`ReplayCreateIndex`](https://github.com/duckdb/duckdb/blob/780c7c743fec8d377f047422075dce4ecf4f16b7/src/storage/wal_replay.cpp#L1219-L1249) allocates persistent blocks for the index via `ReplayIndexData`, wraps the on-disk metadata in an `UnboundIndex`, and stages it in `ReplayState::replay_index_infos`:

```cpp
auto unbound_index = make_uniq<UnboundIndex>(std::move(create_info), std::move(index_info), io_manager, db);
...
auto &table_index_list = storage.GetDataTableInfo()->GetIndexes();
state.replay_index_infos.emplace_back(table_index_list, std::move(unbound_index), std::move(table_name));
```

[`ReplayDropIndex`](https://github.com/duckdb/duckdb/blob/780c7c743fec8d377f047422075dce4ecf4f16b7/src/storage/wal_replay.cpp#L1251-L1270) and [`ReplayDropTable`](https://github.com/duckdb/duckdb/blob/780c7c743fec8d377f047422075dce4ecf4f16b7/src/storage/wal_replay.cpp#L843-L870) remove the staged entries via `erase(remove_if(...))`:

```cpp
state.replay_index_infos.erase(std::remove_if(state.replay_index_infos.begin(), state.replay_index_infos.end(),
                                              [&info](const ReplayState::ReplayIndexInfo &replay_info) {
                                                  return replay_info.table_name.WithName(
                                                             replay_info.index->GetIndexName()) ==
                                                         info.GetQualifiedName();
                                              }),
                               state.replay_index_infos.end());
```
The issue is, `erase` destructs unique pointer of `UnboundedIndex`, which doesn't have a destructor -- so the block gets leaked forever.

### Unbounded index lifecycle analysis

There're 4 outcomes for the unbounded index
- Convert into a bound index -- unbounded index is just an index to achieve lazy loading
- Destructs with `DROP INDEX` at runtime (not in WAL replay); `TableIndexList` removes index and [retires index](https://github.com/dentiny/duckdb/blob/6d7abb1090e1079f252b15ba0366310bb87d8582/src/storage/table_index_list.cpp#L191-L193)
-  Destructs with `DROP INDEX` at WAL replay, which is not handled at `main` branch (to fix in this PR)
- Unbounded index has been created, database instance shutdown; in this case `TableIndexList` destructor [resets storage index](https://github.com/dentiny/duckdb/blob/6d7abb1090e1079f252b15ba0366310bb87d8582/src/storage/table_index_list.cpp#L71-L81)

Conclusion: adding a destructor for unbounded index doesn't affect existing functionalities.