### PR TITLE
[IMPORTANT] Hjiang/drop col before pk

### DIFF
--- a/src/catalog/catalog_entry/duck_index_entry.cpp
+++ b/src/catalog/catalog_entry/duck_index_entry.cpp
@@ -34,6 +34,15 @@ DuckIndexEntry::DuckIndexEntry(Catalog &catalog, SchemaCatalogEntry &schema, Cre
     : IndexCatalogEntry(catalog, schema, create_info), info(std::move(storage_info)), initial_index_size(0) {
 }
 
+unique_ptr<CreateInfo> DuckIndexEntry::GetInfo() const {
+	auto result = IndexCatalogEntry::GetInfo();
+	vector<column_t> column_ids;
+	if (GetDataTableInfo().GetIndexes().TryGetIndexColumnIds(name, column_ids)) {
+		result->Cast<CreateIndexInfo>().column_ids = std::move(column_ids);
+	}
+	return result;
+}
+
 unique_ptr<CatalogEntry> DuckIndexEntry::Copy(ClientContext &context) const {
 	auto info_copy = GetInfo();
 	auto &cast_info = info_copy->Cast<CreateIndexInfo>();

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -744,6 +744,11 @@ void DuckTableEntry::UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_i
                                                    const RemoveColumnInfo &info, CreateTableInfo &create_info,
                                                    const vector<unique_ptr<BoundConstraint>> &bound_constraints,
                                                    bool is_generated) {
+	optional_idx removed_physical_index;
+	if (!columns.GetColumn(removed_index).Generated()) {
+		removed_physical_index = columns.LogicalToPhysical(removed_index).index;
+	}
+
 	// handle constraints for the new table
 	D_ASSERT(constraints.size() == bound_constraints.size());
 	for (idx_t constr_idx = 0; constr_idx < constraints.size(); constr_idx++) {
@@ -828,6 +833,21 @@ void DuckTableEntry::UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_i
 					throw CatalogException(
 					    "Cannot drop column %s because there is a FOREIGN KEY constraint that depends on it",
 					    info.removed_column);
+				}
+			}
+			if (removed_physical_index.IsValid()) {
+				auto remap_keys = [&](vector<PhysicalIndex> &keys) {
+					for (auto &key : keys) {
+						if (key.index > removed_physical_index.GetIndex()) {
+							key.index--;
+						}
+					}
+				};
+				if (fk.info.type != ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+					remap_keys(fk.info.pk_keys);
+				}
+				if (fk.info.type != ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE) {
+					remap_keys(fk.info.fk_keys);
 				}
 			}
 			create_info.constraints.push_back(std::move(copy));
@@ -1361,6 +1381,17 @@ void DuckTableEntry::Rollback(CatalogEntry &prev_entry) {
 	auto &prev_table = prev_entry.Cast<DuckTableEntry>();
 	auto &prev_info = prev_table.GetStorage().GetDataTableInfo();
 	auto &prev_indexes = prev_info->GetIndexes();
+
+	const auto &columns = table.GetStorage().Columns();
+	const auto &prev_columns = prev_table.GetStorage().Columns();
+	if (columns.size() + 1 == prev_columns.size()) {
+		idx_t removed_column = 0;
+		while (removed_column < columns.size() &&
+		       columns[removed_column].Name() == prev_columns[removed_column].Name()) {
+			removed_column++;
+		}
+		prev_indexes.RemapColumnIdsForDrop(removed_column, true);
+	}
 
 	// Find all index-based constraints that exist in rollback_table, but not in table.
 	// Then, remove them.

--- a/src/execution/index/bound_index.cpp
+++ b/src/execution/index/bound_index.cpp
@@ -176,6 +176,28 @@ bool BoundIndex::IndexIsUpdated(const vector<PhysicalIndex> &column_ids_p) const
 	return false;
 }
 
+void BoundIndex::RemapColumnIdsForDrop(const column_t removed_column, const bool undo) {
+	for (auto &column_id : column_ids) {
+		D_ASSERT(undo || column_id != removed_column);
+		if (undo ? column_id >= removed_column : column_id > removed_column) {
+			column_id = undo ? column_id + 1 : column_id - 1;
+		}
+	}
+	column_id_set.clear();
+	column_id_set.insert(column_ids.begin(), column_ids.end());
+
+	for (auto &expression : bound_expressions) {
+		ExpressionIterator::VisitExpressionMutable<BoundReferenceExpression>(
+		    expression, [&](BoundReferenceExpression &bound_ref, unique_ptr<Expression> &) {
+			    auto &index = bound_ref.IndexMutable();
+			    D_ASSERT(undo || index != removed_column);
+			    if (undo ? index >= removed_column : index > removed_column) {
+				    index = undo ? index + 1 : index - 1;
+			    }
+		    });
+	}
+}
+
 bool BoundIndex::SupportsDeltaIndexes() const {
 	return false;
 }

--- a/src/include/duckdb/catalog/catalog_entry/duck_index_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_index_entry.hpp
@@ -33,6 +33,7 @@ public:
 	DuckIndexEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateIndexInfo &create_info,
 	               shared_ptr<IndexDataTableInfo> storage_info);
 
+	unique_ptr<CreateInfo> GetInfo() const override;
 	unique_ptr<CatalogEntry> Copy(ClientContext &context) const override;
 	void Rollback(CatalogEntry &prev_entry) override;
 

--- a/src/include/duckdb/execution/index/bound_index.hpp
+++ b/src/include/duckdb/execution/index/bound_index.hpp
@@ -191,6 +191,8 @@ public:
 
 	//! Returns true if the index is affected by updates on the specified column IDs, and false otherwise
 	bool IndexIsUpdated(const vector<PhysicalIndex> &column_ids) const;
+	//! Remaps physical column IDs after a column drop, or restores them when the drop is rolled back.
+	void RemapColumnIdsForDrop(column_t removed_column, bool undo);
 
 	//! Serializes index memory to disk and returns the index storage information.
 	virtual IndexStorageInfo SerializeToDisk(QueryContext context, const case_insensitive_map_t<Value> &options);

--- a/src/include/duckdb/storage/table/index_entry.hpp
+++ b/src/include/duckdb/storage/table/index_entry.hpp
@@ -132,6 +132,8 @@ public:
 	Identifier GetName() const;
 	//! Returns the physical index type.
 	string GetIndexType() const;
+	//! Returns the physical table columns referenced by the index.
+	vector<column_t> GetColumnIds() const;
 	//! Destroys the physical index.
 	void Retire();
 	//! Binds the unbound physical index without replacing it.
@@ -148,6 +150,8 @@ public:
 	string GetConstraintViolationMessage(VerifyExistenceType verify_type, idx_t failed_index, DataChunk &input) const;
 	//! Verifies that the physical index is not updated by the given columns.
 	void VerifyUpdate(const vector<PhysicalIndex> &column_ids) const;
+	//! Remaps physical column IDs after a column drop, or restores them when the drop is rolled back.
+	void RemapColumnIdsForDrop(column_t removed_column, bool undo);
 	//! Vacuums the physical index if it is bound.
 	void Vacuum();
 	//! Rebuilds the bound physical index with chunks supplied by the scan callback.

--- a/src/include/duckdb/storage/table/table_index_list.hpp
+++ b/src/include/duckdb/storage/table/table_index_list.hpp
@@ -75,6 +75,8 @@ public:
 	bool Contains(const Identifier &name) const;
 	//! Returns shared ownership of the stable logical index entry matching the name.
 	shared_ptr<IndexEntry> FindEntry(const Identifier &name) const;
+	//! Returns the physical columns of an index, including when the index is unbound.
+	bool TryGetIndexColumnIds(const Identifier &name, vector<column_t> &result) const;
 	//! Binds unbound indexes possibly present after loading an extension.
 	void Bind(ClientContext &context, DataTableInfo &table_info, const optional<string> &index_type = {});
 	//! Returns true, if there are no index entries.
@@ -104,6 +106,8 @@ public:
 	void VerifyBuffers() const;
 	//! Verifies that no index is updated by the given columns.
 	void VerifyUpdate(const vector<PhysicalIndex> &column_ids) const;
+	//! Remaps physical column IDs after a column drop, or restores them when the drop is rolled back.
+	void RemapColumnIdsForDrop(column_t removed_column, bool undo);
 	//! Returns table storage metadata for all indexes.
 	vector<IndexInfo> GetStorageInfo() const;
 	//! Returns the combined in-memory size of all bound indexes.

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -129,8 +129,6 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t removed_co
 	for (const auto column_id : info->indexes.GetIndexedColumns()) {
 		if (column_id == removed_column) {
 			throw CatalogException("Cannot drop this column: an index depends on it!");
-		} else if (column_id > removed_column) {
-			throw CatalogException("Cannot drop this column: an index depends on a column after it!");
 		}
 	}
 
@@ -153,6 +151,8 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t removed_co
 
 	// scan the original table, and fill the new column with the transformed value
 	local_storage.DropColumn(parent, *this, removed_column);
+
+	info->indexes.RemapColumnIdsForDrop(removed_column, false);
 
 	// this table replaces the previous table, hence the parent is no longer the root DataTable
 	parent.version = DataTableVersion::ALTERED;

--- a/src/storage/index_entry.cpp
+++ b/src/storage/index_entry.cpp
@@ -315,6 +315,11 @@ string IndexEntry::GetIndexType() const {
 	return owned_index->GetIndexType();
 }
 
+vector<column_t> IndexEntry::GetColumnIds() const {
+	auto entry_lock = lock.GetSharedLock();
+	return owned_index->GetColumnIds();
+}
+
 void IndexEntry::Retire() {
 	auto entry_lock = lock.GetExclusiveLock();
 	deltas.Reset();
@@ -394,6 +399,18 @@ void IndexEntry::VerifyUpdate(const vector<PhysicalIndex> &column_ids) const {
 	const auto &bound_index = owned_index->Cast<BoundIndex>();
 	D_ASSERT(!bound_index.IndexIsUpdated(column_ids));
 #endif
+}
+
+void IndexEntry::RemapColumnIdsForDrop(const column_t removed_column, const bool undo) {
+	auto entry_lock = lock.GetExclusiveLock();
+	D_ASSERT(owned_index->IsBound());
+	owned_index->Cast<BoundIndex>().RemapColumnIdsForDrop(removed_column, undo);
+	for (auto delta_type : {IndexDeltaType::DELETED_ROWS_IN_USE, IndexDeltaType::ADDED_DATA_DURING_CHECKPOINT,
+	                        IndexDeltaType::REMOVED_DATA_DURING_CHECKPOINT}) {
+		if (auto delta = deltas.Find(delta_type)) {
+			delta->RemapColumnIdsForDrop(removed_column, undo);
+		}
+	}
 }
 
 void IndexEntry::Vacuum() {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -44,6 +44,7 @@ LocalTableStorage::LocalTableStorage(ClientContext &context, DataTable &new_data
 	row_groups = std::move(parent.row_groups);
 	row_groups->collection = std::move(new_collection);
 
+	parent.append_indexes.RemapColumnIdsForDrop(drop_column_index, false);
 	append_indexes.Move(parent.append_indexes);
 }
 

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -277,6 +277,13 @@ void TableIndexList::VerifyUpdate(const vector<PhysicalIndex> &column_ids) const
 #endif
 }
 
+void TableIndexList::RemapColumnIdsForDrop(const column_t removed_column, const bool undo) {
+	annotated_lock_guard lock(index_entries_lock);
+	for (const auto &entry : index_entries) {
+		entry->RemapColumnIdsForDrop(removed_column, undo);
+	}
+}
+
 vector<IndexInfo> TableIndexList::GetStorageInfo() const {
 	annotated_lock_guard lock(index_entries_lock);
 	vector<IndexInfo> result;
@@ -350,6 +357,17 @@ shared_ptr<IndexEntry> TableIndexList::FindEntry(const Identifier &name) const {
 		return entry;
 	}
 	return nullptr;
+}
+
+bool TableIndexList::TryGetIndexColumnIds(const Identifier &name, vector<column_t> &result) const {
+	annotated_lock_guard lock(index_entries_lock);
+	for (const auto &entry : index_entries) {
+		if (entry->GetName() == name) {
+			result = entry->GetColumnIds();
+			return true;
+		}
+	}
+	return false;
 }
 
 void TableIndexList::Bind(ClientContext &context, DataTableInfo &table_info, const optional<string> &index_type) {

--- a/test/sql/alter/drop_col/test_drop_col_before_pk.test
+++ b/test/sql/alter/drop_col/test_drop_col_before_pk.test
@@ -9,13 +9,27 @@ statement ok
 INSERT INTO t VALUES (1, 10), (2, 20);
 
 statement ok
+BEGIN TRANSACTION;
+
+statement ok
+INSERT INTO t VALUES (3, 30);
+
+statement ok
 ALTER TABLE t DROP COLUMN a;
+
+statement ok
+INSERT INTO t VALUES (40);
+
+statement ok
+COMMIT;
 
 query I
 SELECT * FROM t ORDER BY b
 ----
 10
 20
+30
+40
 
 statement error
 INSERT INTO t VALUES (10);

--- a/test/sql/alter/drop_col/test_drop_col_before_pk.test
+++ b/test/sql/alter/drop_col/test_drop_col_before_pk.test
@@ -1,0 +1,23 @@
+# name: test/sql/alter/drop_col/test_drop_col_before_pk.test
+# description: DROP COLUMN must succeed for a non-key column that appears before a PRIMARY KEY column
+# group: [drop_col]
+
+statement ok
+CREATE TABLE t(a INTEGER, b INTEGER PRIMARY KEY);
+
+statement ok
+INSERT INTO t VALUES (1, 10), (2, 20);
+
+statement ok
+ALTER TABLE t DROP COLUMN a;
+
+query I
+SELECT * FROM t ORDER BY b
+----
+10
+20
+
+statement error
+INSERT INTO t VALUES (10);
+----
+<REGEX>:Constraint Error.*Duplicate key "b: 10" violates primary key constraint.*

--- a/test/sql/alter/drop_col/test_drop_col_index.test
+++ b/test/sql/alter/drop_col/test_drop_col_index.test
@@ -17,8 +17,20 @@ ALTER TABLE test DROP COLUMN j
 ----
 Catalog Error: Cannot drop this column: an index depends on it
 
-# we also cannot drop the column i (for now) because an index depends on a subsequent column
-statement error
+# dropping a column before an indexed column remaps the index
+statement ok
 ALTER TABLE test DROP COLUMN i
+
+query I
+SELECT * FROM test ORDER BY j
 ----
-Catalog Error: Cannot drop this column: an index depends on a column
+1
+2
+
+statement ok
+INSERT INTO test VALUES (3)
+
+query I
+SELECT j FROM test WHERE j = 3
+----
+3

--- a/test/sql/alter/drop_col/test_drop_col_rollback.test
+++ b/test/sql/alter/drop_col/test_drop_col_rollback.test
@@ -3,7 +3,7 @@
 # group: [drop_col]
 
 statement ok
-CREATE TABLE test(i INTEGER, j INTEGER)
+CREATE TABLE test(i INTEGER, j INTEGER PRIMARY KEY)
 
 statement ok
 INSERT INTO test VALUES (1, 1), (2, 2)
@@ -12,7 +12,7 @@ statement ok
 BEGIN TRANSACTION
 
 statement ok
-ALTER TABLE test DROP COLUMN j
+ALTER TABLE test DROP COLUMN i
 
 query I
 SELECT * FROM test
@@ -30,4 +30,9 @@ SELECT * FROM test
 1
 2
 2
+
+statement error
+INSERT INTO test VALUES (3, 1)
+----
+<REGEX>:Constraint Error.*Duplicate key "j: 1" violates primary key constraint.*
 

--- a/test/sql/function/table/CMakeLists.txt
+++ b/test/sql/function/table/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library_unity(test_table_function OBJECT table_in_out.cpp
-                  table_bind_replace.cpp table_partition_info.cpp)
+                  table_bind_replace.cpp table_function_legacy_cardinality.cpp
+                  table_partition_info.cpp)
 set(UNITTEST_OBJECT_FILES
     ${UNITTEST_OBJECT_FILES} $<TARGET_OBJECTS:test_table_function>
     PARENT_SCOPE)

--- a/test/sql/function/table/table_function_legacy_cardinality.cpp
+++ b/test/sql/function/table/table_function_legacy_cardinality.cpp
@@ -1,0 +1,97 @@
+#include "catch.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector/string_vector.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+struct LegacyCardinalityFunction {
+	struct GlobalState : public GlobalTableFunctionState {
+		bool done = false;
+
+		idx_t MaxThreads() const override {
+			return 1;
+		}
+	};
+
+	struct LocalState : public LocalTableFunctionState {
+		vector<column_t> column_ids;
+	};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &, TableFunctionBindInput &, vector<LogicalType> &return_types,
+	                                     vector<Identifier> &names) {
+		names = {"col_a", "col_b"};
+		return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+		return make_uniq<TableFunctionData>();
+	}
+
+	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &, TableFunctionInitInput &) {
+		return make_uniq<GlobalState>();
+	}
+
+	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *) {
+		auto result = make_uniq<LocalState>();
+		result->column_ids = input.column_ids;
+		return std::move(result);
+	}
+
+	static void Scan(ClientContext &, TableFunctionInput &input, DataChunk &output) {
+		auto &global_state = input.global_state->Cast<GlobalState>();
+		auto &local_state = input.local_state->Cast<LocalState>();
+		if (global_state.done) {
+			return;
+		}
+		global_state.done = true;
+
+		for (idx_t col_idx = 0; col_idx < local_state.column_ids.size(); col_idx++) {
+			auto &vector = output.data[col_idx];
+			if (local_state.column_ids[col_idx] == 0) {
+				auto data = FlatVector::GetDataMutable<string_t>(vector);
+				for (idx_t row_idx = 0; row_idx < 9; row_idx++) {
+					data[row_idx] = StringVector::AddString(vector, "row" + std::to_string(row_idx));
+				}
+			} else {
+				for (idx_t row_idx = 0; row_idx < 9; row_idx++) {
+					FlatVector::SetNull(vector, row_idx, true);
+				}
+			}
+		}
+		// Legacy table functions only set the DataChunk count, leaving the vector sizes at zero.
+		output.SetCardinalityUnsafe(9);
+	}
+
+	static void Register(Connection &con) {
+		con.BeginTransaction();
+		auto &catalog = Catalog::GetSystemCatalog(*con.context);
+		TableFunction function("legacy_cardinality_rows", {}, Scan, Bind, InitGlobal, InitLocal);
+		function.projection_pushdown = true;
+		CreateTableFunctionInfo info(function);
+		catalog.CreateTableFunction(*con.context, info);
+		con.Commit();
+	}
+};
+
+static void CheckCount(Connection &con, const string &filter, int64_t expected) {
+	auto result = con.Query("SELECT count(*) FROM legacy_cardinality_rows() WHERE " + filter);
+	REQUIRE(!result->HasError());
+	REQUIRE(CHECK_COLUMN(result, 0, {expected}));
+}
+
+} // namespace
+
+TEST_CASE("NULL filters support table functions using legacy cardinality", "[tablefunction]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	LegacyCardinalityFunction::Register(con);
+
+	CheckCount(con, "col_b IS NULL", 9);
+	CheckCount(con, "col_b IS NOT NULL", 0);
+	CheckCount(con, "col_a IS NOT NULL", 9);
+	CheckCount(con, "col_a IS NULL", 0);
+	CheckCount(con, "col_a = 'row3'", 1);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes ALTER TABLE DROP COLUMN, index maintenance, FK metadata, and transaction rollback paths—core storage/catalog behavior where mistakes break constraints or corrupt indexes.
> 
> **Overview**
> **DROP COLUMN** can now remove non-key columns that appear **before** a PRIMARY KEY, UNIQUE index, or secondary index. The old behavior rejected any drop when an index referenced a later physical column; only drops that touch an indexed column itself are still blocked.
> 
> After the column is removed from table storage, **`RemapColumnIdsForDrop`** shifts physical column IDs in bound indexes (and bound expression references), index checkpoint deltas, transaction-local append indexes, and foreign-key **`pk_keys`/`fk_keys`**. Catalog rollback of a drop calls the same path with **`undo=true`**. **`DuckIndexEntry::GetInfo`** pulls current **`column_ids`** from storage so copies/WAL metadata stay aligned.
> 
> SQL tests cover drop-before-PK, drop-before-index, and rollback with PK enforcement.
> 
> Separately, a C++ test registers a table function that uses legacy **`SetCardinalityUnsafe`** cardinality so **`IS NULL` / `IS NOT NULL`** filters on projected columns count rows correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5909866181b343b09e7c1f9899669a23fa6a6291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->