### PR TITLE
[NEED CHECK] Hjiang/optimize dict fsst

### DIFF
--- a/benchmark/micro/compression/fsst/dict_fsst_fetch_row.benchmark
+++ b/benchmark/micro/compression/fsst/dict_fsst_fetch_row.benchmark
@@ -1,0 +1,20 @@
+# name: benchmark/micro/compression/fsst/dict_fsst_fetch_row.benchmark
+# description: Fetching rows one-by-one from a DICT_FSST compressed string column (fetch-row path)
+# group: [fsst]
+
+name dict_fsst fetch-row scan
+group fsst
+storage persistent latest
+
+load
+DROP TABLE IF EXISTS test;
+PRAGMA force_compression='dict_fsst';
+CREATE TABLE test AS SELECT i AS id, 'prefix_' || (i%100000)::VARCHAR AS s FROM range(0, 2000000) tbl(i);
+checkpoint;
+SET debug_force_fetch_row=true;
+
+run
+SELECT sum(length(s))::BIGINT FROM test;
+
+result I
+23777800

--- a/benchmark/micro/compression/fsst/dict_fsst_index_scan.benchmark
+++ b/benchmark/micro/compression/fsst/dict_fsst_index_scan.benchmark
@@ -1,0 +1,21 @@
+# name: benchmark/micro/compression/fsst/dict_fsst_index_scan.benchmark
+# description: ART index scan fetching rows from a DICT_FSST compressed string column
+# group: [fsst]
+
+name dict_fsst index scan
+group fsst
+storage persistent latest
+
+load
+DROP TABLE IF EXISTS test;
+PRAGMA force_compression='dict_fsst';
+CREATE TABLE test AS SELECT i AS id, 'prefix_' || (i%100000)::VARCHAR AS s FROM range(0, 2000000) tbl(i);
+CREATE INDEX idx ON test(id);
+checkpoint;
+SET index_scan_percentage=1.0;
+
+run
+SELECT sum(length(s))::BIGINT FROM test WHERE id >= 1;
+
+result I
+23777792

--- a/src/include/duckdb/storage/compression/dict_fsst/decompression.hpp
+++ b/src/include/duckdb/storage/compression/dict_fsst/decompression.hpp
@@ -47,11 +47,9 @@ public:
 	buffer_ptr<SelectionVector> sel_vec;
 	idx_t sel_vec_size = 0;
 
-	// decompress offset/position - used for scanning without a dictionary
-	uint32_t decompress_offset = 0;
-	idx_t decompress_position = 0;
-
 	vector<uint32_t> string_lengths;
+	//! Prefix sum over string_lengths - the dictionary offset of every entry, for O(1) lookups in any order
+	vector<uint32_t> string_offsets;
 
 	//! Start of the block (pointing to the dictionary_header)
 	data_ptr_t baseptr;

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -163,6 +163,8 @@ struct ColumnFetchState {
 	QueryContext context;
 	//! The set of pinned block handles for this set of fetches
 	buffer_handle_set_t handles;
+	//! Cached per-segment scan states, for compression functions with expensive scan state initialization
+	unordered_map<const ColumnSegment *, unique_ptr<SegmentScanState>> scan_states;
 	//! Any child states of the fetch
 	vector<unique_ptr<ColumnFetchState>> child_states;
 	//! The current row group we are fetching from

--- a/src/storage/compression/dict_fsst.cpp
+++ b/src/storage/compression/dict_fsst.cpp
@@ -150,10 +150,15 @@ void DictFSSTCompressionStorage::StringScan(ColumnSegment &segment, ColumnScanSt
 //===--------------------------------------------------------------------===//
 void DictFSSTCompressionStorage::StringFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id,
                                                 Vector &result, idx_t result_idx) {
-	// fetch a single row from the string segment
-	CompressedStringScanState scan_state(segment, state.GetOrInsertHandle(segment));
-	scan_state.Initialize(false);
-	scan_state.ScanToFlatVector(result, result_idx, NumericCast<idx_t>(row_id), 1);
+	// fetch a single row from the string segment - re-use the initialized scan state for the segment
+	auto entry = state.scan_states.find(&segment);
+	if (entry == state.scan_states.end()) {
+		auto scan_state = make_uniq<CompressedStringScanState>(segment, state.GetOrInsertHandle(segment));
+		scan_state->Initialize(false);
+		entry = state.scan_states.emplace(&segment, std::move(scan_state)).first;
+	}
+	entry->second->Cast<CompressedStringScanState>().ScanToFlatVector(result, result_idx, NumericCast<idx_t>(row_id),
+	                                                                  1);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/compression/dict_fsst/decompression.cpp
+++ b/src/storage/compression/dict_fsst/decompression.cpp
@@ -102,6 +102,15 @@ void CompressedStringScanState::Initialize(bool initialize_dictionary) {
 	string_lengths.resize(AlignValue<uint32_t, BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE>(dict_count));
 	BitpackingPrimitives::UnPackBuffer<uint32_t>(data_ptr_cast(string_lengths.data()),
 	                                             data_ptr_cast(string_lengths_ptr), dict_count, string_lengths_width);
+
+	// Build the prefix sums over the string lengths, so any dictionary entry can be located in O(1)
+	string_offsets.resize(dict_count);
+	uint32_t current_offset = 0;
+	for (uint32_t i = 0; i < dict_count; i++) {
+		string_offsets[i] = current_offset;
+		current_offset += string_lengths[i];
+	}
+
 	if (!initialize_dictionary || mode == DictFSSTMode::FSST_ONLY) {
 		// Used by fetch, as fetch will never produce a DictionaryVector
 		return;
@@ -114,12 +123,9 @@ void CompressedStringScanState::Initialize(bool initialize_dictionary) {
 	D_ASSERT(dict_count >= 1);
 	validity.SetInvalid(0);
 
-	uint32_t offset = 0;
 	for (uint32_t i = 0; i < dict_count; i++) {
 		//! We can uncompress during fetching, we need the length of the string inside the dictionary
-		auto string_len = string_lengths[i];
-		dict_child_data[i] = FetchStringFromDict(dict_data, offset, i);
-		offset += string_len;
+		dict_child_data[i] = FetchStringFromDict(dict_data, string_offsets[i], i);
 	}
 }
 
@@ -180,13 +186,7 @@ void CompressedStringScanState::ScanToFlatVector(Vector &result, idx_t result_of
 				result_data.WriteNull();
 				continue;
 			}
-			if (decompress_position > string_number) {
-				throw InternalException("DICT_FSST: not performing a sequential scan?");
-			}
-			for (; decompress_position < string_number; decompress_position++) {
-				decompress_offset += string_lengths[decompress_position];
-			}
-			result_data.WriteStringRef(FetchStringFromDict(result, decompress_offset, string_number));
+			result_data.WriteStringRef(FetchStringFromDict(result, string_offsets[string_number], string_number));
 		}
 	}
 	result.Verify();
@@ -200,13 +200,7 @@ void CompressedStringScanState::Select(Vector &result, idx_t start, const Select
 	for (idx_t i = 0; i < sel_count; i++) {
 		// Lookup dict offset in index buffer
 		auto string_number = start_offset + sel.get_index(i);
-		if (decompress_position > string_number) {
-			throw InternalException("DICT_FSST: not performing a sequential scan?");
-		}
-		for (; decompress_position < string_number; decompress_position++) {
-			decompress_offset += string_lengths[decompress_position];
-		}
-		result_data.WriteValue(FetchStringFromDict(result, decompress_offset, string_number));
+		result_data.WriteValue(FetchStringFromDict(result, string_offsets[string_number], string_number));
 	}
 }
 

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -230,8 +230,8 @@ idx_t ColumnData::ScanVector(ColumnScanState &state, Vector &result, idx_t remai
 		idx_t result_offset = base_result_offset + initial_remaining - remaining;
 		if (scan_count > 0) {
 			if (state.scan_options && state.scan_options->force_fetch_row) {
+				ColumnFetchState fetch_state;
 				for (idx_t i = 0; i < scan_count; i++) {
-					ColumnFetchState fetch_state;
 					current.FetchRow(fetch_state, UnsafeNumericCast<row_t>(state.offset_in_column + i - current_start),
 					                 result, result_offset + i);
 				}
@@ -268,9 +268,9 @@ void ColumnData::SelectVector(ColumnScanState &state, Vector &result, idx_t targ
 		throw InternalException("ColumnData::SelectVector should be able to fetch everything from one segment");
 	}
 	if (state.scan_options && state.scan_options->force_fetch_row) {
+		ColumnFetchState fetch_state;
 		for (idx_t i = 0; i < sel_count; i++) {
 			auto source_idx = sel.get_index(i);
-			ColumnFetchState fetch_state;
 			current.FetchRow(fetch_state, UnsafeNumericCast<row_t>(state.offset_in_column + source_idx), result, i);
 		}
 	} else {
@@ -869,9 +869,9 @@ unique_ptr<ColumnCheckpointState> ColumnData::CreateCheckpointState(const RowGro
 void ColumnData::CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count,
                                 Vector &scan_vector) const {
 	if (state.scan_options && state.scan_options->force_fetch_row) {
+		ColumnFetchState fetch_state;
+		fetch_state.row_group = state.parent->row_group;
 		for (idx_t i = 0; i < count; i++) {
-			ColumnFetchState fetch_state;
-			fetch_state.row_group = state.parent->row_group;
 			segment.FetchRow(fetch_state, UnsafeNumericCast<row_t>(state.offset_in_column + i), scan_vector, i);
 		}
 	} else {

--- a/test/sql/types/enum/test_3479.test
+++ b/test/sql/types/enum/test_3479.test
@@ -24,4 +24,4 @@ insert into m_2 values ('1')
 statement error
 insert into m SELECT * FROM m_2
 ----
-<REGEX>:.*Conversion Error.*out of range for the destination type.*
+Type ENUM('1', '2', '3') with value 1 can't be cast to the destination type ENUM('sad', 'ok', 'happy')

--- a/test/sql/types/enum/test_3641.test
+++ b/test/sql/types/enum/test_3641.test
@@ -43,4 +43,4 @@ SELECT * FROM m WHERE m=m_2
 statement error
 SELECT * FROM m WHERE m::mood_2=m_2
 ----
-<REGEX>:.*Conversion Error.*out of range for the destination type.*
+Type ENUM('sad', 'ok', 'happy') with value sad can't be cast to the destination type ENUM('very sad', 'very ok', 'very happy')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes hot storage read paths for compressed VARCHAR segments and shared fetch state lifetime; behavior should be equivalent but regressions could affect index scans and row fetches.
> 
> **Overview**
> Speeds up **DICT_FSST** string reads on **fetch-row** and **out-of-order** access paths (e.g. index scans), which previously assumed sequential dictionary walks or re-initialized decompression state on every row.
> 
> **Decompression** now builds a **`string_offsets`** prefix sum at init so any dictionary index resolves in O(1), replacing sequential `decompress_offset` / `decompress_position` advancement and the non-sequential scan internal error.
> 
> **Fetch-row** reuses **`CompressedStringScanState`** per segment via a new cache on **`ColumnFetchState`**, and **`ColumnData`** keeps one **`ColumnFetchState`** across loops when **`force_fetch_row`** is enabled (scan, select, checkpoint).
> 
> Adds micro-benchmarks for fetch-row scans and ART index scans on DICT_FSST columns. Enum SQL tests now assert **exact** cast error text instead of regex (orthogonal to compression).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67cdd84756281447f6e9ebeaad05786acb6455d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->