### PR TITLE
Avoid busy polling for exclusive storage lock acquisition

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -17,6 +17,7 @@
 #include "duckdb/common/enums/prepared_statement_mode.hpp"
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/common/pair.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/winapi.hpp"
 #include "duckdb/main/client_config.hpp"
@@ -29,6 +30,8 @@
 #include "duckdb/transaction/transaction_context.hpp"
 #include "duckdb/common/query_context.hpp"
 #include "duckdb/common/query_parameters.hpp"
+
+#include <functional>
 
 namespace duckdb {
 class Logger;
@@ -49,6 +52,7 @@ class Relation;
 class BufferedFileWriter;
 class QueryProfiler;
 class ClientContextLock;
+class ClientContextInterruptCallback;
 struct CreateScalarFunctionInfo;
 class ScalarFunctionCatalogEntry;
 struct ActiveQueryContext;
@@ -58,6 +62,7 @@ class BufferedData;
 struct ClientData;
 class ClientContextState;
 class RegisteredStateManager;
+struct StorageLockInternals;
 
 struct PendingQueryParameters {
 	//! Prepared statement parameters (if any)
@@ -338,8 +343,22 @@ private:
 	bool ErrorInvalidatesTransaction(ExceptionType type);
 
 private:
+	friend class ClientContextInterruptCallback;
+	friend struct StorageLockInternals;
+
+	unique_ptr<ClientContextInterruptCallback> RegisterInterruptCallback(std::function<void()> callback);
+	void RemoveInterruptCallback(idx_t callback_id);
+	void InterruptCheck(bool force_timeout_check) const;
+	optional_idx GetQueryDeadline() const {
+		return query_deadline;
+	}
+
 	//! Lock on using the ClientContext in parallel
 	mutex context_lock;
+	//! Callbacks used to wake operations blocked during query execution
+	mutex interrupt_callbacks_lock;
+	unordered_map<idx_t, std::function<void()>> interrupt_callbacks;
+	idx_t next_interrupt_callback_id = 0;
 	//! The currently active query context
 	unique_ptr<ActiveQueryContext> active_query;
 	//! The current query progress
@@ -351,6 +370,16 @@ private:
 	//! `Catalog::RemoteExecute(string)` and wraps the returned TableRef into a SelectStatement.
 	weak_ptr<AttachedDatabase> connected_to_database;
 	bool is_connected = false;
+};
+
+class ClientContextInterruptCallback {
+public:
+	ClientContextInterruptCallback(ClientContext &context, idx_t callback_id);
+	~ClientContextInterruptCallback();
+
+private:
+	ClientContext &context;
+	idx_t callback_id;
 };
 
 class ClientContextLock {

--- a/src/include/duckdb/storage/storage_lock.hpp
+++ b/src/include/duckdb/storage/storage_lock.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/shared_ptr.hpp"
 
 namespace duckdb {
+class ClientContext;
 struct StorageLockInternals;
 
 enum class StorageLockType { SHARED = 0, EXCLUSIVE = 1 };
@@ -37,6 +38,8 @@ public:
 
 	//! Get an exclusive lock
 	unique_ptr<StorageLockKey> GetExclusiveLock();
+	//! Wait for and get an exclusive lock without blocking new readers while waiting
+	unique_ptr<StorageLockKey> GetExclusiveLock(ClientContext &context);
 	//! Get a shared lock
 	unique_ptr<StorageLockKey> GetSharedLock();
 	//! Try to get an exclusive lock - if we cannot get it immediately we return `nullptr`

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1321,7 +1321,13 @@ unique_ptr<QueryResult> ClientContext::ExecutePendingQueryInternal(ClientContext
 
 void ClientContext::Interrupt() {
 	ClientInterruptState expected = ClientInterruptState::NOT_INTERRUPTED;
-	interrupt_state.compare_exchange_strong(expected, ClientInterruptState::INTERRUPTED);
+	if (!interrupt_state.compare_exchange_strong(expected, ClientInterruptState::INTERRUPTED)) {
+		return;
+	}
+	lock_guard<mutex> guard(interrupt_callbacks_lock);
+	for (auto &entry : interrupt_callbacks) {
+		entry.second();
+	}
 }
 
 bool ClientContext::IsInterrupted() const {
@@ -1332,11 +1338,41 @@ void ClientContext::ClearInterrupt() {
 	interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
 }
 
+unique_ptr<ClientContextInterruptCallback> ClientContext::RegisterInterruptCallback(std::function<void()> callback) {
+	idx_t callback_id;
+	{
+		lock_guard<mutex> guard(interrupt_callbacks_lock);
+		callback_id = next_interrupt_callback_id++;
+		auto entry = interrupt_callbacks.emplace(callback_id, std::move(callback));
+		if (IsInterrupted()) {
+			entry.first->second();
+		}
+	}
+	return make_uniq<ClientContextInterruptCallback>(*this, callback_id);
+}
+
+void ClientContext::RemoveInterruptCallback(idx_t callback_id) {
+	lock_guard<mutex> guard(interrupt_callbacks_lock);
+	interrupt_callbacks.erase(callback_id);
+}
+
+ClientContextInterruptCallback::ClientContextInterruptCallback(ClientContext &context_p, idx_t callback_id_p)
+    : context(context_p), callback_id(callback_id_p) {
+}
+
+ClientContextInterruptCallback::~ClientContextInterruptCallback() {
+	context.RemoveInterruptCallback(callback_id);
+}
+
 void ClientContext::SuppressInterrupts() {
 	interrupt_state = ClientInterruptState::INTERRUPTS_SUPPRESSED;
 }
 
 void ClientContext::InterruptCheck() const {
+	InterruptCheck(false);
+}
+
+void ClientContext::InterruptCheck(bool force_timeout_check) const {
 	// Counter for throttling timeout checks - only check every N iterations
 	static constexpr uint32_t TIMEOUT_CHECK_INTERVAL = 256;
 	thread_local uint32_t timeout_check_counter = 0;
@@ -1345,7 +1381,7 @@ void ClientContext::InterruptCheck() const {
 		throw InterruptException();
 	}
 	// Only check timeout every N calls to avoid expensive steady_clock::now() syscall
-	if (query_deadline.IsValid() && ++timeout_check_counter % TIMEOUT_CHECK_INTERVAL == 0) {
+	if (query_deadline.IsValid() && (force_timeout_check || ++timeout_check_counter % TIMEOUT_CHECK_INTERVAL == 0)) {
 		auto now = NumericCast<idx_t>(duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count());
 		if (now >= query_deadline.GetIndex()) {
 			throw InterruptException("Query exceeded maximum execution time");

--- a/src/storage/storage_lock.cpp
+++ b/src/storage/storage_lock.cpp
@@ -3,7 +3,9 @@
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/assert.hpp"
+#include "duckdb/common/chrono.hpp"
 #include "duckdb/common/thread_annotation/thread_annotation.hpp"
+#include "duckdb/main/client_context.hpp"
 
 #include <condition_variable>
 
@@ -33,6 +35,32 @@ public:
 		state_cv.wait(guard, [&]() { return !writer_active && read_count == 0; });
 		writer_active = true;
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
+	}
+
+	unique_ptr<StorageLockKey> GetExclusiveLock(ClientContext &context) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+		auto interrupt_callback =
+		    context.RegisterInterruptCallback([internals = shared_from_this()]() { internals->NotifyWaiters(); });
+		auto deadline = context.GetQueryDeadline();
+		context.InterruptCheck(true);
+		unique_lock<mutex> guard(state_lock);
+		auto can_wake = [&]() {
+			return context.IsInterrupted() || (!writer_active && read_count == 0);
+		};
+		if (deadline.IsValid()) {
+			auto deadline_time = steady_clock::time_point(milliseconds(deadline.GetIndex()));
+			state_cv.wait_until(guard, deadline_time, can_wake);
+		} else {
+			state_cv.wait(guard, can_wake);
+		}
+		context.InterruptCheck(true);
+		writer_tickets++;
+		writer_active = true;
+		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
+	}
+
+	void NotifyWaiters() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+		lock_guard<mutex> guard(state_lock);
+		state_cv.notify_all();
 	}
 
 	unique_ptr<StorageLockKey> GetSharedLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
@@ -112,6 +140,10 @@ StorageLock::~StorageLock() {
 
 unique_ptr<StorageLockKey> StorageLock::GetExclusiveLock() {
 	return internals->GetExclusiveLock();
+}
+
+unique_ptr<StorageLockKey> StorageLock::GetExclusiveLock(ClientContext &context) {
+	return internals->GetExclusiveLock(context);
 }
 
 unique_ptr<StorageLockKey> StorageLock::TryGetExclusiveLock() {

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -240,10 +240,7 @@ void DuckTransactionManager::Checkpoint(ClientContext &context, bool force) {
 		// grab the start_transaction_lock to prevent new transactions from starting
 		lock_guard<mutex> start_lock(start_transaction_lock);
 		// wait until any active transactions are finished
-		while (!lock) {
-			context.InterruptCheck();
-			lock = checkpoint_lock.TryGetExclusiveLock();
-		}
+		lock = checkpoint_lock.GetExclusiveLock(context);
 	}
 	CheckpointOptions options;
 	if (GetLastCommit() >= LowestVisibilityBound()) {

--- a/test/api/test_threads.cpp
+++ b/test/api/test_threads.cpp
@@ -4,8 +4,10 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/main/materialized_query_result.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
+#include "duckdb/common/chrono.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/storage/storage_info.hpp"
 
 #include <thread>
@@ -135,6 +137,31 @@ TEST_CASE("Test async threads", "[api]") {
 
 	con.Query("SET async_threads=2");
 	REQUIRE(scheduler.NumberOfAsyncThreads() == 2);
+}
+
+TEST_CASE("Interruptible checkpoint lock waits can be cancelled", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	StorageLock storage_lock;
+	auto shared_lock = storage_lock.GetSharedLock();
+	atomic<bool> interrupted {false};
+
+	std::thread writer([&]() {
+		try {
+			auto exclusive_lock = storage_lock.GetExclusiveLock(*con.context);
+		} catch (InterruptException &) {
+			interrupted = true;
+		}
+	});
+	std::this_thread::sleep_for(milliseconds(10));
+	con.Interrupt();
+	writer.join();
+
+	REQUIRE(interrupted);
+	con.context->ClearInterrupt();
+	shared_lock.reset();
+	auto next_reader = storage_lock.GetSharedLock();
+	REQUIRE(next_reader != nullptr);
 }
 
 static idx_t ColumnDataScanMaxThreads(Connection &con, MaterializedQueryResult &result,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes checkpoint lock acquisition and interrupt handling on core storage/transaction paths; behavior should improve but timing and cancellation semantics around FORCE CHECKPOINT need careful review.
> 
> **Overview**
> Replaces **busy-polling** when waiting for an exclusive **storage lock** with **condition-variable sleeps** that respect **query interrupt** and **max execution time**.
> 
> `ClientContext` gains **interrupt callbacks** (registered via RAII `ClientContextInterruptCallback`) so `Interrupt()` can wake threads blocked in `StorageLock::GetExclusiveLock(ClientContext &)`. That overload waits until the lock is free or the context is interrupted/timed out, then runs `InterruptCheck(true)` so deadlines are enforced immediately after waking. **FORCE CHECKPOINT** now uses this path instead of spinning on `TryGetExclusiveLock` + `InterruptCheck`.
> 
> A new API test verifies an exclusive lock wait can be cancelled via `Connection::Interrupt()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54ec189c2c2e8198177ad98f7a316bc673378466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->