### PR TITLE
index buffer pin

### DIFF
--- a/benchmark/micro/index/point/repeated_fk_lookup_with_art.benchmark
+++ b/benchmark/micro/index/point/repeated_fk_lookup_with_art.benchmark
@@ -1,0 +1,24 @@
+# name: benchmark/micro/index/point/repeated_fk_lookup_with_art.benchmark
+# description: Repeated foreign-key checks against an in-memory primary-key ART
+# group: [point]
+
+name Repeated FK Lookup (ART)
+group art
+
+load
+CREATE TABLE integers (id BIGINT PRIMARY KEY);
+INSERT INTO integers
+SELECT id
+FROM (SELECT i * 1000003 % 1000000 AS id FROM range(1000000) t(i))
+ORDER BY id % 7919;
+CREATE TABLE probes AS
+SELECT i * 999983 % 1000000 AS id FROM range(1000000) t(i);
+CREATE TABLE children (id BIGINT REFERENCES integers(id));
+BEGIN TRANSACTION;
+
+run
+INSERT INTO children SELECT id FROM probes;
+
+cleanup
+ROLLBACK;
+BEGIN TRANSACTION;

--- a/src/execution/index/fixed_size_buffer.cpp
+++ b/src/execution/index/fixed_size_buffer.cpp
@@ -37,7 +37,7 @@ constexpr uint8_t FixedSizeBuffer::SHIFT[];
 
 FixedSizeBuffer::FixedSizeBuffer(BlockManager &block_manager, MemoryTag memory_tag)
     : block_manager(block_manager), readers(0), segment_count(0), allocation_size(0), dirty(false), vacuum(false),
-      loaded(false), block_pointer(), block_handle(nullptr) {
+      loaded(false), block_pointer(), in_memory_ptr(nullptr), block_handle(nullptr) {
 	auto &buffer_manager = block_manager.buffer_manager;
 	buffer_handle = buffer_manager.Allocate(memory_tag, &block_manager, false);
 	block_handle = buffer_handle.GetBlockHandle();
@@ -45,21 +45,24 @@ FixedSizeBuffer::FixedSizeBuffer(BlockManager &block_manager, MemoryTag memory_t
 	// Zero-initialize the buffer as it might get serialized to storage.
 	auto block_size = block_manager.GetBlockSize();
 	memset(buffer_handle.GetDataMutable(), 0, block_size);
+	in_memory_ptr = buffer_handle.GetDataMutable();
 }
 
 FixedSizeBuffer::FixedSizeBuffer(BlockManager &block_manager, const idx_t segment_count, const idx_t allocation_size,
                                  shared_ptr<BlockHandle> block_handle_p)
     : block_manager(block_manager), readers(0), segment_count(segment_count), allocation_size(allocation_size),
-      dirty(false), vacuum(false), loaded(false), block_pointer(), block_handle(std::move(block_handle_p)) {
+      dirty(false), vacuum(false), loaded(false), block_pointer(), in_memory_ptr(nullptr),
+      block_handle(std::move(block_handle_p)) {
 	D_ASSERT(block_handle);
 	buffer_handle = block_manager.buffer_manager.Pin(block_handle);
 	D_ASSERT(buffer_handle.IsValid());
+	in_memory_ptr = buffer_handle.GetDataMutable();
 }
 
 FixedSizeBuffer::FixedSizeBuffer(BlockManager &block_manager, const idx_t segment_count, const idx_t allocation_size,
                                  const BlockPointer &block_pointer)
     : block_manager(block_manager), readers(0), segment_count(segment_count), allocation_size(allocation_size),
-      dirty(false), vacuum(false), loaded(false), block_pointer(block_pointer) {
+      dirty(false), vacuum(false), loaded(false), block_pointer(block_pointer), in_memory_ptr(nullptr) {
 	D_ASSERT(block_pointer.IsValid());
 	block_handle = block_manager.RegisterBlock(block_pointer.block_id);
 	D_ASSERT(block_handle->BlockId() < MAXIMUM_BLOCK);
@@ -72,6 +75,7 @@ FixedSizeBuffer::~FixedSizeBuffer() {
 	if (InMemory()) {
 		// we can have multiple readers on a pinned block, and unpinning the buffer handle
 		// decrements the reader count on the underlying block handle (Destroy() unpins)
+		in_memory_ptr = nullptr;
 		buffer_handle.Destroy();
 	}
 	if (OnDisk()) {
@@ -134,6 +138,7 @@ void FixedSizeBuffer::Serialize(PartialBlockManager &partial_block_manager, cons
 
 	// We are done with this buffer.
 	// To use the fixed-size buffer again, we need to re-load it from disk.
+	in_memory_ptr = nullptr;
 	buffer_handle.Destroy();
 
 	// Register the partial block and the block handle.
@@ -163,6 +168,7 @@ void FixedSizeBuffer::LoadFromDisk() {
 
 	buffer_handle = std::move(new_buffer_handle);
 	block_handle = std::move(new_block_handle);
+	in_memory_ptr = buffer_handle.GetDataMutable();
 }
 
 uint32_t FixedSizeBuffer::GetOffset(const idx_t bitmask_count, const idx_t available_segments) {
@@ -240,6 +246,13 @@ void FixedSizeBuffer::SetAllocationSize(const idx_t available_segments, const id
 }
 
 SegmentHandle::SegmentHandle(FixedSizeBuffer &buffer_p, const idx_t offset) : buffer_ptr(buffer_p) {
+	auto in_memory_ptr = buffer_ptr->in_memory_ptr.load();
+	if (in_memory_ptr) {
+		ptr = in_memory_ptr + offset;
+		buffer_ptr->readers++;
+		return;
+	}
+
 	lock_guard<mutex> l(buffer_ptr->lock);
 
 	if (!buffer_ptr->InMemory() && !buffer_ptr->loaded) {

--- a/src/include/duckdb/execution/index/fixed_size_buffer.hpp
+++ b/src/include/duckdb/execution/index/fixed_size_buffer.hpp
@@ -68,7 +68,7 @@ private:
 
 	//! Returns true, if the buffer is in-memory
 	bool InMemory() const {
-		return buffer_handle.IsValid();
+		return in_memory_ptr.load() != nullptr;
 	}
 
 	//! Returns true, if the block is on-disk
@@ -110,6 +110,8 @@ private:
 	BlockPointer block_pointer;
 	//! The buffer handle of the in-memory buffer
 	BufferHandle buffer_handle;
+	//! Cached pointer for lock-free access to an in-memory buffer
+	atomic<data_ptr_t> in_memory_ptr;
 	//! The block handle of the on-disk buffer
 	shared_ptr<BlockHandle> block_handle;
 	//! The lock for this fixed size buffer handle


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes concurrency and lifetime rules for ART fixed-size buffers (atomic cached pointer and reader counts on a lock-free path), which could expose subtle races if in-memory state transitions overlap with concurrent segment access.
> 
> **Overview**
> Speeds up hot-path index segment access (e.g. repeated FK checks against an in-memory ART) by avoiding mutex acquisition and buffer-manager pinning when data is already resident.
> 
> **`FixedSizeBuffer`** now keeps an **`atomic<data_ptr_t> in_memory_ptr`** mirroring the mutable buffer base. **`InMemory()`** is defined from that atomic instead of **`buffer_handle.IsValid()`**. The pointer is set on allocate/pin/load and cleared on destroy, serialize, and when dropping the in-memory handle.
> 
> **`SegmentHandle`** tries a **lock-free fast path**: if **`in_memory_ptr`** is non-null, it computes **`ptr`** and bumps **`readers`** immediately; otherwise it uses the existing locked load/pin path. A new micro-benchmark **`repeated_fk_lookup_with_art.benchmark`** exercises one million FK-validated inserts against a primary-key ART.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a21f38e17f205079cf509edc1c7ae019c12d7d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->