### PR TITLE
[wip] Optimize conflict manager insertion

### DIFF
--- a/benchmark/micro/index/point/repeated_fk_lookup_with_art.benchmark
+++ b/benchmark/micro/index/point/repeated_fk_lookup_with_art.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/index/point/repeated_fk_lookup_with_art.benchmark
+# description: Insert repeated foreign keys that hit the same hot ART leaf
+# group: [point]
+
+name Repeated FK Lookup With ART
+group art
+
+load
+PRAGMA threads=1;
+CREATE TABLE parent (id BIGINT PRIMARY KEY);
+INSERT INTO parent VALUES (42);
+CREATE TABLE input AS SELECT 42::BIGINT AS id FROM range(10000000);
+CREATE TABLE child (id BIGINT REFERENCES parent(id));
+
+run
+INSERT INTO child SELECT id FROM input;
+
+cleanup
+DELETE FROM child;

--- a/src/common/types/conflict_manager.cpp
+++ b/src/common/types/conflict_manager.cpp
@@ -43,7 +43,23 @@ bool ConflictManager::IsConflict(LookupResultType type) {
 	}
 }
 
-bool ConflictManager::AddHit(const idx_t index_in_chunk, const std::function<void()> &callback) {
+void ConflictManager::AddRowId(const idx_t index_in_chunk, const row_t row_id) {
+	// Only ON CONFLICT DO NOTHING can have multiple conflict targets,
+	// which can cause multiple row IDs per index_in_chunk.
+	// We ignore later row IDs, as we don't need them.
+	auto &data = GetConflictData(FIRST);
+	if (!data.validity.RowIsValid(index_in_chunk)) {
+		data.Insert(index_in_chunk, row_id);
+	}
+}
+
+void ConflictManager::AddSecondRowId(const idx_t index_in_chunk, const row_t row_id) {
+	D_ASSERT(HasConflicts());
+	D_ASSERT(conflict_data[FIRST].validity.RowIsValid(index_in_chunk));
+	GetConflictData(SECOND).Insert(index_in_chunk, row_id);
+}
+
+bool ConflictManager::AddHitInternal(const idx_t index_in_chunk, const row_t row_id, const bool second) {
 	D_ASSERT(index_in_chunk < chunk_size);
 	if (ShouldThrow(index_in_chunk)) {
 		return true;
@@ -63,16 +79,20 @@ bool ConflictManager::AddHit(const idx_t index_in_chunk, const std::function<voi
 	if (finished) {
 		return false;
 	}
-	callback();
+	if (second) {
+		AddSecondRowId(index_in_chunk, row_id);
+	} else {
+		AddRowId(index_in_chunk, row_id);
+	}
 	return false;
 }
 
 bool ConflictManager::AddHit(const idx_t index_in_chunk, const row_t row_id) {
-	return AddHit(index_in_chunk, [&]() { AddRowId(index_in_chunk, row_id); });
+	return AddHitInternal(index_in_chunk, row_id, false);
 }
 
 bool ConflictManager::AddSecondHit(const idx_t index_in_chunk, const row_t row_id) {
-	return AddHit(index_in_chunk, [&]() { AddSecondRowId(index_in_chunk, row_id); });
+	return AddHitInternal(index_in_chunk, row_id, true);
 }
 
 bool ConflictManager::AddNull(const idx_t index_in_chunk) {
@@ -130,7 +150,7 @@ bool ConflictManager::ShouldThrow(const idx_t index_in_chunk) const {
 
 	// If we have already seen a conflict for this index, then we don't throw.
 	D_ASSERT(mode == ConflictManagerMode::THROW);
-	return conflict_rows.find(index_in_chunk) == conflict_rows.end();
+	return !HasConflicts() || !conflict_data[FIRST].validity.RowIsValid(index_in_chunk);
 }
 
 bool ConflictManager::IgnoreNulls() const {

--- a/src/include/duckdb/common/types/conflict_manager.hpp
+++ b/src/include/duckdb/common/types/conflict_manager.hpp
@@ -142,8 +142,6 @@ private:
 	//! All matching indexes by their name (unique identifier).
 	identifier_set_t index_names;
 
-	//! Registers all conflicting rows in a data chunk.
-	unordered_set<idx_t> conflict_rows;
 	//! True, if we can skip recording any further conflicts.
 	bool finished = false;
 
@@ -201,7 +199,7 @@ private:
 	//! Returns true, if we register a conflict for the lookup type.
 	bool IsConflict(LookupResultType type);
 	//! Adds a hit to the conflicts.
-	bool AddHit(const idx_t index_in_chunk, const std::function<void()> &callback);
+	bool AddHitInternal(const idx_t index_in_chunk, const row_t row_id, const bool second);
 	//! Determine visible row ID for each index with two possible row IDs.
 	void Finalize(const std::function<bool(const row_t row_id)> &callback);
 	//! Returns true, if the conflict manager should throw an exception, else false.
@@ -224,23 +222,10 @@ private:
 	}
 
 	//! Adds a row ID to the primary conflict data.
-	void AddRowId(const idx_t index_in_chunk, const row_t row_id) {
-		// Only ON CONFLICT DO NOTHING can have multiple conflict targets,
-		// which can cause multiple row IDs per index_in_chunk.
-		// We let them overwrite each other, as we don't need the row IDs later.
-		auto elem = conflict_rows.find(index_in_chunk);
-		if (elem == conflict_rows.end()) {
-			// We have not yet seen this conflict: insert.
-			conflict_rows.insert(index_in_chunk);
-			GetConflictData(FIRST).Insert(index_in_chunk, row_id);
-		}
-	}
+	void AddRowId(const idx_t index_in_chunk, const row_t row_id);
 
 	//! Adds a row ID to the secondary conflict data.
-	void AddSecondRowId(const idx_t index_in_chunk, const row_t row_id) {
-		D_ASSERT(conflict_rows.find(index_in_chunk) != conflict_rows.end());
-		GetConflictData(SECOND).Insert(index_in_chunk, row_id);
-	}
+	void AddSecondRowId(const idx_t index_in_chunk, const row_t row_id);
 };
 
 } // namespace duckdb


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the hot path for FK and unique constraint conflict recording; behavior is intended to be equivalent but mistakes could affect INSERT, ON CONFLICT, or FK enforcement.
> 
> **Overview**
> **Optimizes how `ConflictManager` records constraint/FK lookup hits** by dropping the per-chunk `unordered_set` of conflicting row indexes and using the existing `ConflictData` validity bitmap instead. `AddHit` no longer goes through a `std::function` callback; row IDs are written via `AddHitInternal` / moved `AddRowId` and `AddSecondRowId` implementations, and `ShouldThrow` keys off that same validity state.
> 
> Adds a micro-benchmark (`repeated_fk_lookup_with_art`) that bulk-inserts 10M rows with the same foreign key to stress repeated ART leaf lookups during FK verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c592178e56950c310c8149ca4b3a7c5f570d343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->